### PR TITLE
Port: playtest fixes, daily mode, and live aim preview

### DIFF
--- a/port/docs/KNOWN_ISSUES.md
+++ b/port/docs/KNOWN_ISSUES.md
@@ -5,25 +5,6 @@ future maintainer (or fresh-context Claude) can pick up where we left off.
 
 ## Bugs (reported by user during playtest)
 
-### 1. Same maps appear more often than chance suggests
-
-**Symptom:** Across multiple games with the same track-type filter, the same
-tracks recur faster than `1/poolSize` would predict.
-
-**Hypothesis:** `TrackManager.getRandomTracks` does a Fisher–Yates shuffle of
-the filtered pool and slices the first N. There's no memory of recently-served
-tracks, so the same tracks can hit several games in a row. Math.random()'s
-distribution is fine — the issue is "no anti-repeat memory."
-
-**Suggested fix:**
-- Maintain a per-server (or per-lobby) `recentTrackIds: ringbuffer` of the last
-  ~50 tracks served. In `getRandomTracks`, prefer tracks NOT in the ring; only
-  fall through to "any" when the filtered pool is exhausted.
-- Or: weight the random pick so a track served recently has a temporarily
-  reduced probability.
-
-**Files:** `port/server/src/tracks.ts` — `getRandomTracks`.
-
 ### 2. User disconnects unexpectedly
 
 **Symptom:** A player's tab gets disconnected mid-game with no obvious cause.
@@ -52,86 +33,24 @@ Likely candidates:
 **Files:** `port/server/src/connection.ts` (idle constants),
 `port/web/src/connection.ts` (keepalive interval).
 
-### 3. Chat formatting is inconsistent
+### 6. `test-fullflow.ts` and `test-handshake.ts` are stale (predate `lobby tagcounts`)
 
-**Symptom:** The way usernames render in chat differs between lobby chat,
-in-game chat, and the local-echo of one's own messages.
+**Symptom:** Both
+`node --experimental-strip-types --no-warnings server/src/test-fullflow.ts` and
+`node --experimental-strip-types --no-warnings server/src/test-handshake.ts`
+fail with: `expected status game to start with "d 7 status\tgame" but got
+"d 7 lobby\ttagcounts\t2062\t..."`. Pre-existing on master; not caused by
+current changes.
 
-**Locations:**
-- `port/web/src/panels/lobby-multi.ts` — `appendChat`. Local echo writes
-  `<you> {text}` for own messages, `<{senderNick}> {text}` for others.
-- `port/web/src/panels/game.ts` — `appendChat`. Local echo writes
-  `<{myNick}> {text}` (the actual nick, not literal "you").
+**Cause:** The lobby join sequence now interleaves a `lobby tagcounts` packet
+between `lobby ownjoin` and the `status game` triggered by `cspt`. The tests'
+strict-positional assertions still expect the old order.
 
-**Fix:** pick one convention and apply everywhere. Suggested: always use
-`<{nick}> {text}` and have `myNick` filled in for the local user. Whisper
-prefix `[whisper from {nick}]` is consistent already.
+**Fix:** rewrite the assertion to drain frames until `status game` arrives
+(the way `test-multi.ts`, `test-forfeit.ts`, `test-daily.ts` already do via
+`awaitFrame`/`waitFor`-style predicates).
 
-### 4. Ball spawn point sometimes wrong (centre instead of marker)
-
-**Symptom:** On certain tracks the ball spawns at the centre of the playfield
-(367.5, 187.5) instead of the marked start position. Suspected to be tracks
-that have multiple coloured spawn points.
-
-**Hypothesis:** `port/web/src/game/map.ts:buildMap` only collects start
-positions from special shape `24` (common start). It does collect colour
-starts (shapes 48–51) into `resetPositions`, but those are NEVER used by the
-client to initial-position a ball — they're used for water-shore reset for
-that colour player.
-
-In the original game, multi-player tracks have one common start (shape 24)
-that all players spawn at. Tracks with ONLY coloured spawns (no shape 24)
-fall through to the centre default in our code.
-
-**Suggested fix in `game/map.ts`:**
-```ts
-// If no common starts, fall back to coloured starts for the spawn pool.
-if (startPositions.length === 0) {
-  for (const p of resetPositions) if (p) startPositions.push(p);
-}
-```
-
-Then on the client (`game.ts:handleStartTrack`), instead of always picking by
-`gameId % startPositions.length`, give each player a consistent start:
-```ts
-const start = parsed.startPositions[i % parsed.startPositions.length] ?? [...];
-```
-where `i` is `myPlayerId` for the local ball. Other players' balls get their
-own `start[playerN % len]`. (This means each player can have a different start
-position on multi-spawn tracks.)
-
-**Files:** `port/web/src/game/map.ts`, `port/web/src/panels/game.ts`
-(handleStartTrack).
-
-### 5. Scoreboard doesn't show finished hole scores
-
-**Symptom:** After a hole completes, the previous holes show `·` instead of
-the player's final stroke count.
-
-**What it shows now:** Current hole strokes, dot for past holes, dash for
-future holes, total in the rightmost column.
-
-**What it should show:** Current hole strokes for the active hole, the FINAL
-stroke count for each finished hole, dash for future, total at the end.
-Matches the original Java scoreboard which kept per-hole tallies.
-
-**Suggested fix:** Add `holeScores: number[]` to `PlayerSlot` (length =
-numTracks; index = track index 0..N-1). On every `endstroke` broadcast for the
-current hole, write the latest stroke count into `holeScores[currentTrackIdx-1]`
-for that player. When `starttrack` arrives for the next track, the per-track
-stroke counter resets but the historical entry stays.
-
-In `renderScoreboard`:
-```ts
-for (let t = 0; t < this.numTracks; t++) {
-  if (t + 1 < this.currentTrackIdx) cells.push(String(p.holeScores[t]));
-  else if (t + 1 === this.currentTrackIdx) cells.push(String(p.strokesThisTrack));
-  else cells.push("—");
-}
-```
-
-**Files:** `port/web/src/panels/game.ts` — `PlayerSlot`,
-`handleEndStrokeBroadcast`, `renderScoreboard`.
+**Files:** `port/server/src/test-fullflow.ts`, `port/server/src/test-handshake.ts`.
 
 ## Gaps from a faithful 1:1 port
 
@@ -166,6 +85,15 @@ Things we deferred for MVP that the original Java game has:
   no UI; ratings aren't persisted (FileSystemStatsManager is read-only).
 - **Reconnect after network blip.** `c crt 250` advertises a 250-second
   reconnect window but we don't implement reconnect flow.
+- **Daily mode: resting-ghost sync for late joiners.** When a player joins the
+  daily room mid-play, they see existing players' balls at the spawn position
+  rather than wherever those balls have actually come to rest. The next stroke
+  by an existing player corrects this (the server's `beginstroke` broadcast
+  carries the authoritative ball coords). To fix: have the server track each
+  player's last-stop position (e.g. by recording `ballCoords` from each
+  `beginstroke`) and send a snapshot to newcomers via a new `game ghoststate`
+  packet inside `DailyGame.joinDaily`. Files: `port/server/src/game.ts`
+  (`DailyGame`), `port/web/src/panels/game.ts` (handler).
 
 ## Architecture notes for future-Claude
 
@@ -193,6 +121,24 @@ A few non-obvious pitfalls when modifying things:
 
 ## Resolved (kept for posterity)
 
+- **Same maps appeared too often.** Added a 50-entry recently-served ringbuffer
+  to `TrackManager` — `getRandomTracks` now prefers tracks not in the ring and
+  only falls through to recents when the filtered pool is too small.
+- **Inconsistent chat formatting between lobby and game.** Lobby chat used
+  `<you>` for self while game used `<{nick}>`. Lobby-multi now captures the
+  assigned nick from `lobby ownjoin` and renders local-echo as `<{myNick}>`
+  to match peers and the in-game format.
+- **Wrong spawn point on multi-spawn-marker tracks.** `handleStartTrack` now
+  resolves each player's spawn the way Java `resetPosition()` does:
+  `resetPositions[playerId]` (shapes 48..51) wins, common shape-24 start is the
+  fallback, centre is the last resort. Each `PlayerSlot` carries its own
+  `startX/startY` so water/acid resets in `handleBeginStroke` use the right
+  per-player spawn.
+- **Scoreboard didn't show finished hole scores.** Added `holeScores: number[]`
+  to `PlayerSlot`, populated on every `endstroke` broadcast (last write before
+  track advance becomes the recorded final). `renderScoreboard` now shows the
+  per-hole tally for past holes and derives the running total from the same
+  array. The `strokesTotal` field was removed (was double-counting risk).
 - Track-type form values were 0–5 instead of 1–6 (sent ALL when "Basic" was
   picked). Fixed in `lobby.ts` / `lobby-multi.ts`.
 - Bouncy blocks (18) returned a flat 0.84; now use the dynamic

--- a/port/docs/PROTOCOL.md
+++ b/port/docs/PROTOCOL.md
@@ -229,6 +229,26 @@ server → d K game<TAB>end[<TAB>{p0Result}<TAB>{p1Result}...]
    (1 = winner, 0 = draw, -1 = loser; results omitted in single-player)
 ```
 
+## Live aim preview (cursor stream — port-specific)
+
+Loss-tolerant 15 Hz cursor broadcast for spectator-flavoured UX: every player
+sees every other player's aim line in real time while they're lining up a
+shot. Not used for physics — purely cosmetic.
+
+```
+client → d N game<TAB>cursor<TAB>{x}<TAB>{y}
+   (sent only while OUR ball is at rest, throttled to ≤15 Hz, suppressed if
+    cursor moved <2 px since the last send)
+server → d K game<TAB>cursor<TAB>{playerId}<TAB>{x}<TAB>{y}
+   (server stamps the sender's playerId and forwards to every OTHER player in
+    the game — sender doesn't get an echo)
+```
+
+`{x}` and `{y}` are integer canvas pixel coordinates (0..735, 0..375). The
+client only renders a peer's cursor as an aim line when the peer's ball is at
+rest and the peer hasn't holed-in / forfeited. Cursor state is cleared on
+`starttrack` so the previous hole's last cursor never leaks into the next.
+
 ## Heartbeat
 
 Server side:

--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -99,9 +99,14 @@ export abstract class Game {
         this.sendGameInfo(player);
         this.sendPlayerNames(player);
         // Broadcast join to existing players (none for single-player on first add).
+        // Wire: `game join <newPlayerOrdinal> <nick> <clan>`. The client treats
+        // the ordinal as 1-based and subtracts 1 to get its slot index. We are
+        // about to push the new player to `this.players`, so playerCount() + 1
+        // is the correct ordinal to send (otherwise the existing players' first
+        // slot is overwritten with the newcomer's nick on every join).
         for (const p of this.players) {
             if (p !== player) {
-                p.connection.sendData("game", "join", this.playerCount(), player.nick, player.clan);
+                p.connection.sendData("game", "join", this.playerCount() + 1, player.nick, player.clan);
             }
         }
         // Self owninfo — Java sends `numberIndex` BEFORE incrementing, so first player sees 0.
@@ -483,6 +488,188 @@ export class GolfGame extends Game {
     }
 }
 
+/**
+ * Daily-challenge game — singleton room held by the server. Plays a single
+ * deterministic track for the day; everyone in the room sees each other's
+ * balls (existing async-MP broadcast already gives "ghost" semantics, since
+ * other players' beginstroke packets are relayed to all and each client sims
+ * each ball with its own seed).
+ *
+ * Differences from MultiGame:
+ *   - Joining is allowed at any time, no fill-to-start.
+ *   - `numTracks = 1`. After all players finish that one track, the room
+ *     stays alive for late joiners.
+ *   - When THIS player finishes (holes-in or forfeits), they get a personal
+ *     `game end` so the share dialog can appear; the room continues for others.
+ *   - On `back`, the player is sent straight to `lobbyselect` (no daily lobby
+ *     panel exists on the client).
+ *   - On a date roll-over, the track is swapped and per-player counters reset
+ *     so today's players see today's track.
+ */
+export class DailyGame extends GolfGame {
+    public dateKey: string;
+    private dailyTrackManager: TrackManager;
+
+    constructor(gameId: number, trackManager: TrackManager, dateKey: string) {
+        super(
+            gameId,
+            LobbyType.DAILY,
+            "Daily Cup",
+            null,
+            false,
+            1,                             // numberOfTracks
+            PERM_EVERYONE,
+            0,                             // tracksType (ALL — daily picks deterministically)
+            0,                             // maxStrokes (unlimited; forfeit always available)
+            STROKETIMEOUT_INFINITE,
+            0,                             // waterEvent
+            COLLISION_NO,
+            SCORING_STROKE,
+            SCORING_WEIGHT_END_NONE,
+            100,                           // numPlayers — effectively unbounded room cap
+            trackManager,
+        );
+        this.dateKey = dateKey;
+        this.dailyTrackManager = trackManager;
+        // Replace the random-pick tracks with today's deterministic one.
+        this.tracks = [trackManager.getDailyTrack(dateKey)];
+        // Initial playStatus for an empty room.
+        this.playStatus = "";
+        this.isPublic = false;
+    }
+
+    /** Swap track for the new UTC day if needed; reset per-player counters. */
+    rotateIfNewDay(currentDateKey: string): void {
+        if (this.dateKey === currentDateKey) return;
+        this.dateKey = currentDateKey;
+        this.tracks = [this.dailyTrackManager.getDailyTrack(currentDateKey)];
+        for (let i = 0; i < this.players.length; i++) {
+            this.playerStrokesThisTrack[i] = 0;
+            this.playerStrokesTotal[i] = 0;
+        }
+        this.strokeSeedCounter = 0;
+        this.playStatus = "f".repeat(this.players.length);
+        // Re-broadcast a fresh starttrack so everyone resets to spawn.
+        this.broadcastStartTrack();
+    }
+
+    /** Late-join entry. Called from the daily-select handler. */
+    joinDaily(player: Player): void {
+        if (this.players.includes(player)) return;
+        // super.addPlayer broadcasts `game join` to existing players, sends
+        // gameInfo/players/owninfo to the newcomer, and pushes the slot.
+        this.addPlayer(player);
+        // Grow per-player arrays to match the new size.
+        while (this.playerStrokesThisTrack.length < this.players.length) {
+            this.playerStrokesThisTrack.push(0);
+            this.playerStrokesTotal.push(0);
+        }
+        if (this.playStatus.length < this.players.length) {
+            this.playStatus = this.playStatus.padEnd(this.players.length, "f");
+        }
+        // Personal starttrack so the newcomer renders the map.
+        const stats = this.dailyTrackManager.getStats(this.tracks[0]);
+        const buff = "f".repeat(this.players.length);
+        player.connection.sendDataRaw(tabularize("game", "start"));
+        player.connection.sendDataRaw(tabularize("game", "resetvoteskip"));
+        player.connection.sendDataRaw(
+            tabularize("game", "starttrack", buff, this.gameId, networkSerialize(stats)),
+        );
+        // Tell the client to render this game in daily mode (ghosts, share
+        // overlay on end, etc.). Sent after starttrack so the panel is ready.
+        player.connection.sendDataRaw(tabularize("game", "dailymode", this.dateKey));
+    }
+
+    /** Re-broadcast starttrack to everyone (used after a day rotation). */
+    private broadcastStartTrack(): void {
+        const stats = this.dailyTrackManager.getStats(this.tracks[0]);
+        const buff = "f".repeat(this.players.length);
+        this.writeAll(tabularize("game", "resetvoteskip"));
+        this.writeAll(
+            tabularize("game", "starttrack", buff, this.gameId, networkSerialize(stats)),
+        );
+    }
+
+    /** Single track only — no auto-advance. */
+    protected override nextTrack(): void {
+        // No-op.
+    }
+
+    /** Standard endStroke logic, then send a personal `game end` to finishers. */
+    protected override endStroke(player: Player, newPlayStatus: string): void {
+        const id = this.getPlayerId(player);
+        const myStatus = newPlayStatus.charAt(id);
+        this.playerStrokesThisTrack[id] = (this.playerStrokesThisTrack[id] ?? 0) + 1;
+        const psArr = this.playStatus.split("");
+        while (psArr.length < this.players.length) psArr.push("f");
+        const resolvedStatus: "t" | "p" | "f" =
+            myStatus === "t" || myStatus === "p" ? myStatus : "f";
+        psArr[id] = resolvedStatus;
+        this.playStatus = psArr.join("");
+        this.writeAll(
+            tabularize("game", "endstroke", id, this.playerStrokesThisTrack[id], resolvedStatus),
+        );
+        if (resolvedStatus === "t" || resolvedStatus === "p") {
+            // Tell only this player their daily run is over (others keep playing).
+            player.connection.sendData("game", "end");
+        }
+    }
+
+    protected override forfeit(player: Player): void {
+        const id = this.getPlayerId(player);
+        if (!this.players[id]) return;
+        const cur = this.playStatus.charAt(id);
+        if (cur === "t" || cur === "p") return;
+        const cap = (this.playerStrokesThisTrack[id] ?? 0) + 1;
+        this.playerStrokesThisTrack[id] = cap;
+        const psArr = this.playStatus.split("");
+        while (psArr.length < this.players.length) psArr.push("f");
+        psArr[id] = "p";
+        this.playStatus = psArr.join("");
+        this.writeAll(tabularize("game", "endstroke", id, cap, "p"));
+        player.connection.sendData("game", "end");
+    }
+
+    override handlePacket(player: Player, fields: string[]): boolean {
+        if (fields.length >= 2 && fields[1] === "back") {
+            this.removePlayer(player);
+            // No daily lobby panel — bounce straight to lobbyselect.
+            player.connection.sendData("status", "lobbyselect", "300");
+            player.game = null;
+            return true;
+        }
+        return super.handlePacket(player, fields);
+    }
+
+    /**
+     * The configured `numPlayers` is a soft cap (100); reporting that to a
+     * newcomer would make their client allocate 100 empty scoreboard rows.
+     * Report `players.length + 1` instead — the realistic room size right
+     * after this player joins. The subsequent `starttrack` (whose `playStatus`
+     * length is authoritative) corrects this further.
+     */
+    override sendGameInfo(player: Player): void {
+        player.connection.sendData("status", "game");
+        player.connection.sendData(
+            "game",
+            "gameinfo",
+            this.name,
+            this.passworded,
+            this.gameId,
+            this.players.length + 1,
+            this.tracks.length,
+            this.tracksType,
+            this.maxStrokes,
+            this.strokeTimeout,
+            this.waterEvent,
+            this.collision,
+            this.trackScoring,
+            this.trackScoringEnd,
+            "f",
+        );
+    }
+}
+
 export class TrainingGame extends GolfGame {
     constructor(
         player: Player,
@@ -593,7 +780,9 @@ export class MultiGame extends GolfGame {
             return false;
         }
         // Broadcast `game join` to existing players BEFORE adding the new one.
-        this.broadcast(tabularize("game", "join", this.playerCount(), player.nick, player.clan));
+        // Ordinal is 1-based (client subtracts 1) — must include the joiner,
+        // so playerCount() + 1. See Game.sendJoinMessages for the matching note.
+        this.broadcast(tabularize("game", "join", this.playerCount() + 1, player.nick, player.clan));
         this.addPlayer(player);
 
         if (lobby && this.players.length > 1) {

--- a/port/server/src/lobby.ts
+++ b/port/server/src/lobby.ts
@@ -7,6 +7,7 @@ export const LobbyType = Object.freeze({
     SINGLE: "1",
     DUAL: "2",
     MULTI: "x",
+    DAILY: "d",
 } as const);
 
 export type LobbyType = (typeof LobbyType)[keyof typeof LobbyType];

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -115,7 +115,7 @@ register({
 
 register({
     type: PacketType.DATA,
-    pattern: /^lobbyselect\t(rnop|select|qmpt)(?:\t([12x])(h)?)?$/,
+    pattern: /^lobbyselect\t(rnop|select|qmpt|daily)(?:\t([12xd])(h)?)?$/,
     handle: (server, conn, match) => {
         const sub = match[1];
         const player = conn.player;
@@ -124,7 +124,10 @@ register({
             const single = server.getLobby(LobbyType.SINGLE).totalPlayerCount();
             const dual = server.getLobby(LobbyType.DUAL).totalPlayerCount();
             const multi = server.getLobby(LobbyType.MULTI).totalPlayerCount();
-            conn.sendData("lobbyselect", "nop", single, dual, multi);
+            const daily = server.getLobby(LobbyType.DAILY).totalPlayerCount();
+            // Existing 4-field reply (single/dual/multi); daily appended as a
+            // 5th, optional field — older clients ignore it.
+            conn.sendData("lobbyselect", "nop", single, dual, multi, daily);
         } else if (sub === "select") {
             const tag = match[2];
             if (!tag) return;
@@ -133,10 +136,21 @@ register({
                 ? (tag as LobbyType)
                 : null;
             if (!lobbyType) return;
+            if (lobbyType === LobbyType.DAILY) {
+                // Sticky-ref the lobby so `back` knows where they came from,
+                // then funnel them straight into the singleton daily game.
+                server.getLobby(LobbyType.DAILY).addPlayer(player, JoinType.NORMAL);
+                server.getDailyGame().joinDaily(player);
+                return;
+            }
             server.getLobby(lobbyType).addPlayer(player, JoinType.NORMAL);
         } else if (sub === "qmpt") {
             player.isChatHidden = match[3] === "h";
             server.getLobby(LobbyType.MULTI).addPlayer(player, JoinType.NORMAL);
+        } else if (sub === "daily") {
+            // Compatibility alias: `lobbyselect daily` does the same as `select d`.
+            server.getLobby(LobbyType.DAILY).addPlayer(player, JoinType.NORMAL);
+            server.getDailyGame().joinDaily(player);
         }
     },
 });
@@ -285,6 +299,29 @@ register({
         } else {
             // 'command' — admin commands; not implemented in MVP.
             console.log(`[chat] unhandled command from ${player.nick}: ${arg3} ${arg4 ?? ""}`);
+        }
+    },
+});
+
+// Live aim-preview cursor stream. Pure pass-through: the client throttles to
+// ~15 Hz while its ball is at rest, the server stamps the sender's playerId
+// and forwards to every other player in the game. Loss-tolerant by design —
+// the next tick just overwrites the previous one. Must come BEFORE the generic
+// `game .+` handler so the routing isn't swallowed.
+//   client → game \t cursor \t <x> \t <y>
+//   server → game \t cursor \t <playerId> \t <x> \t <y>
+register({
+    type: PacketType.DATA,
+    pattern: /^game\tcursor\t(\d+)\t(\d+)$/,
+    handle: (_server, conn, match) => {
+        const player = conn.player;
+        if (!player || !player.game) return;
+        const game = player.game;
+        const playerId = game.getPlayerId(player);
+        const body = tabularize("game", "cursor", playerId, match[1], match[2]);
+        for (const other of game.getPlayers()) {
+            if (other === player) continue;
+            other.connection.sendDataRaw(body);
         }
     },
 });

--- a/port/server/src/server.ts
+++ b/port/server/src/server.ts
@@ -4,13 +4,20 @@ import type { Connection } from "./connection.ts";
 import { Player } from "./player.ts";
 import { Lobby, LobbyType } from "./lobby.ts";
 import type { TrackManager } from "./tracks.ts";
+import { DailyGame } from "./game.ts";
 import { dispatchPacket } from "./packet-handlers.ts";
+
+/** UTC YYYY-MM-DD — single source of truth for "today". */
+export function todayDateKey(): string {
+    return new Date().toISOString().slice(0, 10);
+}
 
 export class GolfServer {
     private players: Map<number, Player> = new Map();
     private lobbies: Map<LobbyType, Lobby> = new Map();
     private nextPlayerIdCounter = 1;
     private nextGameIdCounter = 1;
+    private dailyGame: DailyGame | null = null;
 
     public readonly trackManager: TrackManager;
 
@@ -19,6 +26,24 @@ export class GolfServer {
         this.lobbies.set(LobbyType.SINGLE, new Lobby(LobbyType.SINGLE));
         this.lobbies.set(LobbyType.DUAL, new Lobby(LobbyType.DUAL));
         this.lobbies.set(LobbyType.MULTI, new Lobby(LobbyType.MULTI));
+        this.lobbies.set(LobbyType.DAILY, new Lobby(LobbyType.DAILY));
+    }
+
+    /**
+     * Singleton daily room. Lazily created on first daily-join (so server
+     * boot doesn't require tracks to be loaded yet). Rotates its track when
+     * the UTC date changes.
+     */
+    getDailyGame(): DailyGame {
+        const today = todayDateKey();
+        if (!this.dailyGame) {
+            const id = this.getNextGameId();
+            this.dailyGame = new DailyGame(id, this.trackManager, today);
+            this.getLobby(LobbyType.DAILY).addGame(this.dailyGame);
+        } else {
+            this.dailyGame.rotateIfNewDay(today);
+        }
+        return this.dailyGame;
     }
 
     getNextPlayerId(): number {

--- a/port/server/src/test-daily.ts
+++ b/port/server/src/test-daily.ts
@@ -1,0 +1,192 @@
+// Daily-challenge smoke test.
+//
+// Verifies the server-side daily room: two clients select daily, both end up
+// in the same singleton DailyGame, both see each other's stroke broadcasts,
+// and finishing (hole-in / forfeit) sends a personal `game end` to the
+// finisher only — the room stays alive for the other player.
+//
+// Usage: node --experimental-strip-types --no-warnings src/test-daily.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4248;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+class Client {
+    name: string;
+    ws: WebSocket;
+    outSeq = 0;
+    received: string[] = [];
+
+    constructor(name: string) {
+        this.name = name;
+        this.ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+        this.ws.on("message", (m) => this.received.push(m.toString()));
+    }
+    async open(): Promise<void> {
+        await new Promise<void>((r) => this.ws.once("open", () => r()));
+    }
+    send(line: string): void {
+        this.ws.send(line);
+    }
+    sendData(...fields: (string | number)[]): void {
+        this.send(`d ${this.outSeq++} ${fields.join("\t")}`);
+    }
+    sendCommand(verb: string, ...args: string[]): void {
+        this.send(`c ${[verb, ...args].join(" ")}`);
+    }
+    async waitFor(predicate: (s: string) => boolean, label: string, timeoutMs = 4000): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => {
+                console.log(`[${this.name}] timed out waiting for ${label}; queue:`, this.received);
+                reject(new Error(`[${this.name}] timeout: ${label}`));
+            }, timeoutMs);
+            const tick = (): void => {
+                const idx = this.received.findIndex(predicate);
+                if (idx >= 0) {
+                    clearTimeout(t);
+                    const [s] = this.received.splice(idx, 1);
+                    resolve(s);
+                    return;
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+    /** Like waitFor but resolves false (no error) if the timeout elapses. */
+    async expectAbsent(predicate: (s: string) => boolean, label: string, windowMs = 400): Promise<boolean> {
+        await new Promise((r) => setTimeout(r, windowMs));
+        const found = this.received.findIndex(predicate);
+        if (found >= 0) {
+            console.log(`[${this.name}] unexpectedly found "${label}":`, this.received[found]);
+            return false;
+        }
+        return true;
+    }
+    close(): void {
+        try { this.ws.close(); } catch { /* */ }
+    }
+}
+
+async function login(c: Client): Promise<void> {
+    await c.waitFor((s) => s === "h 1", "h 1");
+    await c.waitFor((s) => s.startsWith("c crt"), "c crt");
+    await c.waitFor((s) => s === "c ctr", "c ctr");
+    c.sendCommand("new");
+    await c.waitFor((s) => s.startsWith("c id "), "c id");
+    c.sendData("version", 35);
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (v)");
+    c.sendData("language", "en");
+    c.sendData("logintype", "nr");
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (lt)");
+    c.sendData("login");
+    await c.waitFor((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+    await c.waitFor((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+}
+
+async function enterDaily(c: Client): Promise<void> {
+    c.sendData("lobbyselect", "select", "d");
+    await c.waitFor((s) => /^d \d+ status\tlobby\td/.test(s), "status lobby d");
+    await c.waitFor((s) => /^d \d+ status\tgame$/.test(s), "status game");
+    await c.waitFor((s) => /^d \d+ game\tgameinfo\t/.test(s), "gameinfo");
+    await c.waitFor((s) => /^d \d+ game\tstart$/.test(s), "game start");
+    await c.waitFor((s) => /^d \d+ game\tstarttrack\t/.test(s), "starttrack");
+    await c.waitFor((s) => /^d \d+ game\tdailymode\t/.test(s), "dailymode");
+}
+
+async function main(): Promise<void> {
+    let server: RunningServer | null = null;
+    try {
+        server = await startServer({ host: HOST, port: PORT, tracksDir: tracksDir(), verbose: false });
+        console.log("[server] up");
+
+        const a = new Client("A");
+        const b = new Client("B");
+        await Promise.all([a.open(), b.open()]);
+
+        await login(a);
+        await login(b);
+        console.log("[OK] both logged in");
+
+        await enterDaily(a);
+        console.log("[OK] A in daily room");
+        await enterDaily(b);
+        console.log("[OK] B in daily room");
+
+        // A should see B's `game join` broadcast (B was added after A) AND
+        // it must carry the new player's 1-based ordinal (=2 for B). The
+        // client treats this as 1-based and subtracts 1 to get the slot
+        // index — sending 1 here would make A's client overwrite slot 0
+        // (its own row) with B's nick.
+        const joinPkt = await a.waitFor((s) => /^d \d+ game\tjoin\t/.test(s), "A sees B join");
+        const joinFields = joinPkt.split("\t");
+        const ordinal = parseInt(joinFields[2] ?? "0", 10);
+        if (ordinal !== 2) {
+            throw new Error(`A saw join with ordinal=${ordinal}; want 2 (B's 1-based slot)`);
+        }
+        console.log(`[OK] join broadcast carries correct 1-based ordinal=${ordinal}`);
+
+        // Both shoot — same async semantics as MultiGame. The strokes happen
+        // in the singleton daily game; both players see each other's strokes.
+        const ball = (200 * 1500 + 200 * 4 + 0).toString(36).padStart(4, "0");
+        const mouseA = (300 * 1500 + 250 * 4 + 0).toString(36).padStart(4, "0");
+        const mouseB = (100 * 1500 + 150 * 4 + 0).toString(36).padStart(4, "0");
+        a.sendData("game", "beginstroke", ball, mouseA);
+        b.sendData("game", "beginstroke", ball, mouseB);
+
+        const aGotA = await a.waitFor((s) => /^d \d+ game\tbeginstroke\t0\t/.test(s), "A sees own stroke");
+        const bGotA = await b.waitFor((s) => /^d \d+ game\tbeginstroke\t0\t/.test(s), "B sees A's stroke");
+        const seedAonA = aGotA.split("\t").pop();
+        const seedAonB = bGotA.split("\t").pop();
+        if (seedAonA !== seedAonB) throw new Error(`stroke seed differs across clients: ${seedAonA} vs ${seedAonB}`);
+        console.log(`[OK] both clients see identical seed=${seedAonA} for A's stroke`);
+
+        await a.waitFor((s) => /^d \d+ game\tbeginstroke\t1\t/.test(s), "A sees B's stroke");
+        await b.waitFor((s) => /^d \d+ game\tbeginstroke\t1\t/.test(s), "B sees own stroke");
+
+        // A holes in. Server should broadcast the endstroke to both AND send
+        // A a personal `game end` (room continues for B).
+        a.sendData("game", "endstroke", 0, "tf");
+        await a.waitFor((s) => /^d \d+ game\tendstroke\t0\t1\tt$/.test(s), "A sees own holed");
+        await b.waitFor((s) => /^d \d+ game\tendstroke\t0\t1\tt$/.test(s), "B sees A holed");
+        await a.waitFor((s) => /^d \d+ game\tend$/.test(s), "A gets personal end");
+
+        // Crucially, B must NOT receive a `game end` — they're still playing.
+        const bNoEnd = await b.expectAbsent((s) => /^d \d+ game\tend$/.test(s), "B's spurious end", 300);
+        if (!bNoEnd) throw new Error("B got `game end` despite still playing");
+        console.log("[OK] only the finisher gets `game end`; room continues for others");
+
+        // B forfeits — also gets a personal `game end`.
+        b.sendData("game", "forfeit");
+        await b.waitFor((s) => /^d \d+ game\tendstroke\t1\t/.test(s), "B sees forfeit endstroke");
+        await b.waitFor((s) => /^d \d+ game\tend$/.test(s), "B gets personal end after forfeit");
+        console.log("[OK] forfeit yields personal end too");
+
+        // A goes back to lobbyselect (not into a daily lobby panel).
+        a.sendData("game", "back");
+        await a.waitFor((s) => /^d \d+ status\tlobbyselect\t/.test(s), "A back to lobbyselect");
+        console.log("[OK] back from daily routes straight to lobbyselect");
+
+        a.close();
+        b.close();
+        console.log("\nALL DAILY-CHALLENGE PHASES PASSED");
+        process.exit(0);
+    } catch (err) {
+        console.error("FAIL:", err);
+        process.exit(1);
+    } finally {
+        if (server) {
+            try { await server.close(); } catch { /* */ }
+        }
+    }
+}
+
+main();

--- a/port/server/src/test-multi.ts
+++ b/port/server/src/test-multi.ts
@@ -174,6 +174,18 @@ async function main(): Promise<void> {
         await b.waitFor((s) => /^d \d+ game\tendstroke\t1\t1\tf$/.test(s), "B sees own endstroke");
         console.log("[OK] async endstrokes processed and broadcast");
 
+        // Cursor relay: A sends a cursor sample, B must receive it stamped with
+        // A's playerId (0). Guards the "cursor handler must come before generic
+        // game handler" ordering invariant in packet-handlers.ts. Self-echo is
+        // intentionally suppressed by the server.
+        a.sendData("game", "cursor", 123, 456);
+        const bGotCursor = await b.waitFor(
+            (s) => /^d \d+ game\tcursor\t0\t123\t456$/.test(s),
+            "B sees A's cursor",
+        );
+        if (!bGotCursor) throw new Error("cursor relay missing");
+        console.log("[OK] cursor relayed to peer with stamped playerId");
+
         // Both holes-in to end the track.
         a.sendData("game", "beginstroke", ball, mouseA);
         b.sendData("game", "beginstroke", ball, mouseB);

--- a/port/server/src/tracks.ts
+++ b/port/server/src/tracks.ts
@@ -101,12 +101,23 @@ export function networkSerialize(stats: TrackStats): string {
     return tabularize("V 1", "A " + t.author, "N " + t.name, "T " + t.map, cLine, iLine, bLine, rLine);
 }
 
+/**
+ * Anti-repeat memory: how many recently-served tracks to remember per server.
+ * When picking random tracks we prefer ones NOT in this ring. Sized roughly
+ * for "a few games' worth so we don't repeat a track from your last session
+ * unless the filtered pool is small enough to force it."
+ */
+const RECENT_RING_SIZE = 50;
+
 export class TrackManager {
     tracks: Track[] = [];
     trackSets: TrackSet[] = [];
     private byName = new Map<string, Track>();
     private byCategory = new Map<TrackCategoryId, Track[]>();
     private loaded = false;
+    /** Names of recently-served tracks (oldest first). Used by getRandomTracks. */
+    private recentTrackNames: string[] = [];
+    private recentTrackSet = new Set<string>();
 
     async load(tracksDir: string): Promise<void> {
         const tracksPath = path.join(tracksDir, "tracks");
@@ -156,19 +167,71 @@ export class TrackManager {
         if (limit < 1) {
             throw new Error("Number of tracks must be at least 1");
         }
-        const pool =
+        const filtered =
             category === TrackCategory.ALL
                 ? this.tracks
                 : this.tracks.filter((t) => t.categories.includes(category as number));
-        if (pool.length === 0) {
-            // Empty category — fall back to ALL so a player isn't stranded.
-            return this.shuffled(this.tracks).slice(0, limit);
+        // Empty category — fall back to ALL so a player isn't stranded.
+        const pool = filtered.length === 0 ? this.tracks : filtered;
+        const picked = this.pickAvoidingRecent(pool, limit);
+        for (const t of picked) this.markRecent(t.name);
+        return picked;
+    }
+
+    /**
+     * Pick `limit` tracks from `pool`, preferring ones not in the recent ring.
+     * If too few non-recent are available we fill the remainder from the recent
+     * pool so the caller always gets `min(limit, pool.length)` tracks.
+     */
+    private pickAvoidingRecent(pool: Track[], limit: number): Track[] {
+        const fresh: Track[] = [];
+        const stale: Track[] = [];
+        for (const t of pool) {
+            if (this.recentTrackSet.has(t.name)) stale.push(t);
+            else fresh.push(t);
         }
-        return this.shuffled(pool).slice(0, limit);
+        const out = this.shuffled(fresh).slice(0, limit);
+        if (out.length < limit) {
+            for (const t of this.shuffled(stale)) {
+                if (out.length >= limit) break;
+                out.push(t);
+            }
+        }
+        return out;
+    }
+
+    private markRecent(name: string): void {
+        if (this.recentTrackSet.has(name)) {
+            // Move to most-recent position by removing then re-pushing.
+            const idx = this.recentTrackNames.indexOf(name);
+            if (idx !== -1) this.recentTrackNames.splice(idx, 1);
+        } else {
+            this.recentTrackSet.add(name);
+        }
+        this.recentTrackNames.push(name);
+        while (this.recentTrackNames.length > RECENT_RING_SIZE) {
+            const evicted = this.recentTrackNames.shift();
+            if (evicted !== undefined) this.recentTrackSet.delete(evicted);
+        }
     }
 
     findByName(name: string): Track | undefined {
         return this.byName.get(name);
+    }
+
+    /**
+     * Deterministic per-day track pick. Same `dateKey` (UTC YYYY-MM-DD) → same
+     * track. Uses a small string hash so the choice isn't trivially predictable
+     * from the date alone. Falls back to the first track if the pool is empty.
+     */
+    getDailyTrack(dateKey: string): Track {
+        if (this.tracks.length === 0) throw new Error("no tracks loaded");
+        let h = 0x811c9dc5 >>> 0;
+        for (let i = 0; i < dateKey.length; i++) {
+            h ^= dateKey.charCodeAt(i);
+            h = Math.imul(h, 0x01000193) >>> 0;
+        }
+        return this.tracks[h % this.tracks.length];
     }
 
     /**

--- a/port/web/src/daily.ts
+++ b/port/web/src/daily.ts
@@ -1,0 +1,102 @@
+/**
+ * Daily Cup — client-side helpers for the once-per-day mode.
+ *
+ * - `todayKey()` matches the server's `todayDateKey()` (UTC YYYY-MM-DD), so a
+ *   localStorage entry survives if and only if the player already finished
+ *   today's run.
+ * - Results are stored in localStorage to gate the "Daily Cup" button on
+ *   the lobby-select panel and to render the share text.
+ *
+ * No backend persistence — the server doesn't know if you've played; the
+ * gate is purely client-side. Refreshing or clearing storage lets you replay,
+ * matching the user's "we can allow that" stance.
+ */
+
+const STORAGE_PREFIX = "daily-played-";
+
+export interface DailyResult {
+    date: string;        // UTC YYYY-MM-DD
+    strokes: number;     // your final stroke count for the hole
+    average: number;     // server-reported track avg (totalStrokes/plays)
+    forfeited: boolean;
+    trackName: string;
+}
+
+export function todayKey(): string {
+    return new Date().toISOString().slice(0, 10);
+}
+
+export function getDailyResult(date: string = todayKey()): DailyResult | null {
+    try {
+        const raw = localStorage.getItem(STORAGE_PREFIX + date);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as DailyResult;
+        if (parsed.date !== date) return null;
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+export function saveDailyResult(r: DailyResult): void {
+    try {
+        localStorage.setItem(STORAGE_PREFIX + r.date, JSON.stringify(r));
+    } catch {
+        // storage quota / disabled — best-effort.
+    }
+}
+
+/**
+ * Score formula. Above 100 = beat the track average; 100 = on average; below
+ * 100 = worse. Hand-tuned for "average ≈ 5 strokes" tracks: each stroke
+ * relative to the average moves the score by ~10 points. Forfeits get a fixed
+ * floor so the share is still postable.
+ */
+export function dailyScore(strokes: number, average: number, forfeited: boolean): number {
+    if (forfeited) return 0;
+    if (!Number.isFinite(average) || average <= 0) return 100;
+    const delta = average - strokes; // positive = better than average
+    return Math.max(0, Math.round(100 + delta * 10));
+}
+
+/**
+ * Best-effort copy. Resolves to true if the modern Clipboard API succeeded.
+ * Returns false if the browser refused (no permission, insecure context,
+ * etc.) so the caller can show a manual-copy fallback.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+    try {
+        if (navigator.clipboard && window.isSecureContext) {
+            await navigator.clipboard.writeText(text);
+            return true;
+        }
+    } catch {
+        // fall through to the document.execCommand path
+    }
+    try {
+        const ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        const ok = document.execCommand("copy");
+        document.body.removeChild(ta);
+        return ok;
+    } catch {
+        return false;
+    }
+}
+
+export function shareText(r: DailyResult): string {
+    const score = dailyScore(r.strokes, r.average, r.forfeited);
+    const avgStr = r.average > 0 ? r.average.toFixed(1) : "?";
+    const lines = [
+        `Playforia Minigolf — Daily Cup ${r.date}`,
+        r.forfeited
+            ? `Forfeited "${r.trackName}" (avg ${avgStr})`
+            : `${r.strokes} stroke${r.strokes === 1 ? "" : "s"} on "${r.trackName}" (avg ${avgStr}) — score ${score}`,
+    ];
+    return lines.join("\n");
+}

--- a/port/web/src/game/render.ts
+++ b/port/web/src/game/render.ts
@@ -25,6 +25,28 @@ export interface AimLine {
   toY: number;
 }
 
+/**
+ * Peer's live aim preview. Drawn thinner and tinted by ball colour so the
+ * local aim line stays the most prominent visual element. Sent via the
+ * `game cursor` packet at ~15 Hz while the peer's ball is at rest.
+ */
+export interface PeerAim {
+  fromX: number;
+  fromY: number;
+  toX: number;
+  toY: number;
+  /** Player index 0..3 — used to pick a ball-colour-matched stroke. */
+  playerIdx: number;
+}
+
+/** Ball-colour-matched stroke style for peer aim previews. Indexed by playerIdx. */
+const PEER_AIM_COLOURS = [
+  "rgba(255, 255, 255, 0.7)", // 0 — white ball
+  "rgba(220, 80, 80, 0.7)",   // 1 — red ball
+  "rgba(80, 130, 255, 0.7)",  // 2 — blue ball
+  "rgba(240, 210, 80, 0.8)",  // 3 — yellow ball
+];
+
 export interface BallSprite {
   x: number;
   y: number;
@@ -34,6 +56,14 @@ export interface BallSprite {
   moving: boolean;
   /** Hide the ball entirely (e.g. holed-in). */
   hidden: boolean;
+  /**
+   * Daily-mode "ghost" — render the ball at half opacity with a name label
+   * floating above. Used to distinguish other players' concurrent balls from
+   * the local player's own ball in the daily room.
+   */
+  ghost?: boolean;
+  /** Optional label drawn above the ball (only shown when `ghost`). */
+  label?: string;
 }
 
 export class TrackRenderer {
@@ -137,8 +167,21 @@ export class TrackRenderer {
     ctx: CanvasRenderingContext2D,
     balls: BallSprite[],
     aim: AimLine | null,
+    peerAims: PeerAim[] = [],
   ): void {
     ctx.drawImage(this.bgCanvas, 0, 0);
+
+    // Peer aims first so the local aim renders on top of any overlap.
+    for (const pa of peerAims) {
+      ctx.strokeStyle = PEER_AIM_COLOURS[pa.playerIdx % PEER_AIM_COLOURS.length];
+      ctx.lineWidth = 1;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath();
+      ctx.moveTo(pa.fromX, pa.fromY);
+      ctx.lineTo(pa.toX, pa.toY);
+      ctx.stroke();
+    }
+    ctx.setLineDash([]);
 
     if (aim) {
       ctx.strokeStyle = "rgba(0, 0, 0, 0.7)";
@@ -149,8 +192,13 @@ export class TrackRenderer {
       ctx.stroke();
     }
 
-    // Draw inactive balls first, then the active (moving) one on top so it's visible.
-    const sorted = [...balls].sort((a, b) => Number(a.moving) - Number(b.moving));
+    // Sort: ghosts first (drawn beneath), self last so it's always visible.
+    const sorted = [...balls].sort((a, b) => {
+      const ga = a.ghost ? 0 : 1;
+      const gb = b.ghost ? 0 : 1;
+      if (ga !== gb) return ga - gb;
+      return Number(a.moving) - Number(b.moving);
+    });
     for (const b of sorted) {
       if (b.hidden) continue;
       // balls.gif: 8 sprites total, 4 per row → playerIdx*2 + (moving?1:0).
@@ -158,7 +206,26 @@ export class TrackRenderer {
       const { sx, sy } = spriteSrc13(idx, 4);
       const dx = Math.round(b.x - 6.5);
       const dy = Math.round(b.y - 6.5);
-      ctx.drawImage(this.atlases.balls, sx, sy, 13, 13, dx, dy, 13, 13);
+      if (b.ghost) {
+        ctx.save();
+        ctx.globalAlpha = 0.5;
+        ctx.drawImage(this.atlases.balls, sx, sy, 13, 13, dx, dy, 13, 13);
+        if (b.label) {
+          // Small white-with-shadow label above the ghost ball.
+          ctx.globalAlpha = 0.85;
+          ctx.font = "10px Verdana, sans-serif";
+          ctx.textAlign = "center";
+          ctx.textBaseline = "alphabetic";
+          ctx.lineWidth = 3;
+          ctx.strokeStyle = "rgba(0,0,0,0.7)";
+          ctx.strokeText(b.label, b.x, dy - 2);
+          ctx.fillStyle = "#fff";
+          ctx.fillText(b.label, b.x, dy - 2);
+        }
+        ctx.restore();
+      } else {
+        ctx.drawImage(this.atlases.balls, sx, sy, 13, 13, dx, dy, 13, 13);
+      }
     }
   }
 }

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -3,7 +3,7 @@ import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
 import { loadAtlases, type Atlases } from "../game/sprites.ts";
 import { buildMap, type ParsedMap } from "../game/map.ts";
-import { TrackRenderer, type AimLine, type BallSprite } from "../game/render.ts";
+import { TrackRenderer, type AimLine, type BallSprite, type PeerAim } from "../game/render.ts";
 import {
   applyStrokeImpulse,
   newBall,
@@ -12,6 +12,7 @@ import {
   type BallState,
   type PhysicsContext,
 } from "../game/physics.ts";
+import { copyToClipboard, dailyScore, saveDailyResult, shareText, todayKey, type DailyResult } from "../daily.ts";
 
 const DEV = Boolean(import.meta.env?.DEV);
 
@@ -83,7 +84,6 @@ interface PlayerSlot {
   nick: string;
   clan: string;
   strokesThisTrack: number;
-  strokesTotal: number;
   ball: BallState;
   /** Per-stroke physics context — replaced on each `beginstroke` broadcast. */
   ctx: PhysicsContext | null;
@@ -95,6 +95,27 @@ interface PlayerSlot {
   holedThisTrack: boolean;
   /** This player gave up on the current track. */
   forfeitedThisTrack: boolean;
+  /**
+   * Spawn for this player on the current track. On multi-spawn tracks each
+   * colour-keyed reset marker (shapes 48..51) yields a per-player spawn; the
+   * common shape-24 marker is the fallback. Used when constructing the per-
+   * stroke physics context so water/acid resets land at this player's start.
+   */
+  startX: number;
+  startY: number;
+  /**
+   * Final stroke counts per finished hole, indexed by hole-1. Filled in on
+   * every `endstroke` broadcast for the current hole — the last write before
+   * the track advances becomes the recorded final.
+   */
+  holeScores: number[];
+  /**
+   * Last cursor position for this peer (from `game cursor` broadcasts), or
+   * null if we haven't received one yet (or it was cleared on track change).
+   * Drives the live aim-preview render for non-self players.
+   */
+  cursorX: number | null;
+  cursorY: number | null;
 }
 
 /**
@@ -154,6 +175,20 @@ export class GamePanel implements Panel {
   private keyHandler: ((ev: KeyboardEvent) => void) | null = null;
   private mouseMoveHandler: ((ev: MouseEvent) => void) | null = null;
   private clickHandler: ((ev: MouseEvent) => void) | null = null;
+
+  /**
+   * Daily-mode state. Set when the server sends `game dailymode <dateKey>`.
+   * Drives ghost rendering for non-self balls and swaps the end overlay
+   * for a copy-to-clipboard share dialog.
+   */
+  private dailyMode = false;
+  private dailyDateKey: string | null = null;
+  /** Track average from the latest starttrack — used in the share text. */
+  private trackAverage = 0;
+  /** Track display name from the latest starttrack — used in the share text. */
+  private trackName = "";
+  /** Set once we have shown the daily share screen, to avoid double-saving. */
+  private dailyResultRecorded = false;
 
   constructor(app: App) {
     this.app = app;
@@ -437,6 +472,20 @@ export class GamePanel implements Panel {
         // wire: game endstroke <playerId> <strokesThisTrack> <inHole(t/f)>
         this.handleEndStrokeBroadcast(f);
         break;
+      case "cursor":
+        // Live aim preview from a peer. wire: game cursor <playerId> <x> <y>
+        // Loss-tolerant: the next tick overwrites — no replay queue needed.
+        {
+          const id = parseInt(f[2] ?? "0", 10) || 0;
+          const cx = parseInt(f[3] ?? "0", 10) || 0;
+          const cy = parseInt(f[4] ?? "0", 10) || 0;
+          const slot = this.players[id];
+          if (slot && id !== this.myPlayerId) {
+            slot.cursorX = cx;
+            slot.cursorY = cy;
+          }
+        }
+        break;
       case "say":
         {
           const id = parseInt(f[2] ?? "0", 10) || 0;
@@ -449,6 +498,12 @@ export class GamePanel implements Panel {
         break;
       case "end":
         this.showEndOverlay(f);
+        break;
+      case "dailymode":
+        // Server tagging this room as the daily challenge. f[2] is the UTC
+        // date key the server picked the track for.
+        this.dailyMode = true;
+        this.dailyDateKey = f[2] ?? null;
         break;
       default:
         break;
@@ -477,26 +532,36 @@ export class GamePanel implements Panel {
       const parsed = buildMap(tLine, this.atlases);
       this.parsedMap = parsed;
       this.renderer = new TrackRenderer(parsed, this.atlases);
-      const startIdx = parsed.startPositions.length > 0
-        ? Number(BigInt(this.gameId) % BigInt(parsed.startPositions.length))
-        : 0;
-      const start = parsed.startPositions[startIdx] ?? [367.5, 187.5];
-      this.startX = start[0];
-      this.startY = start[1];
+      // Pick the common (shape-24) start, deterministic from gameId.
+      const commonStart: [number, number] | null =
+        parsed.startPositions.length > 0
+          ? parsed.startPositions[
+              Number(BigInt(this.gameId) % BigInt(parsed.startPositions.length))
+            ] ?? null
+          : null;
+      // Panel-wide defaults (used by ensurePlayerSlots before we know spawns).
+      const defaultStart = commonStart ?? [367.5, 187.5];
+      this.startX = defaultStart[0];
+      this.startY = defaultStart[1];
 
-      // Move all per-track totals to running totals BEFORE resetting.
-      for (const p of this.players) {
-        p.strokesTotal += p.strokesThisTrack;
-      }
-      // Reset every player to start.
-      for (const p of this.players) {
-        p.ball = newBall(start[0], start[1]);
+      // Per-player spawn — Java resetPosition() rules: per-color (48..51) wins,
+      // common start is the fallback, finally the centre default.
+      for (let i = 0; i < this.players.length; i++) {
+        const p = this.players[i];
+        const colour = i < parsed.resetPositions.length ? parsed.resetPositions[i] : null;
+        const spawn = colour ?? commonStart ?? [367.5, 187.5];
+        p.startX = spawn[0];
+        p.startY = spawn[1];
+        p.ball = newBall(spawn[0], spawn[1]);
         p.active = true;
         p.strokesThisTrack = 0;
         p.simulating = false;
         p.ctx = null;
         p.holedThisTrack = false;
         p.forfeitedThisTrack = false;
+        // Drop stale aim previews — last hole's cursor would point off-map.
+        p.cursorX = null;
+        p.cursorY = null;
       }
       this.currentTrackIdx++;
       this.updateStrokeCount();
@@ -550,12 +615,21 @@ export class GamePanel implements Panel {
       seed: new Seed(BigInt(seedNum)),
       norandom: false,
       waterEvent: this.waterEvent,
-      startX: this.startX,
-      startY: this.startY,
+      // Per-slot start so water (event 0) and acid resets land at THIS player's
+      // spawn, not at player 0's. Determinism-safe: every client computes the
+      // same per-slot spawn from the same map+gameId.
+      startX: slot.startX,
+      startY: slot.startY,
     };
     slot.ctx = ctx;
     applyStrokeImpulse(slot.ball, ctx, mouse.x, mouse.y);
     slot.simulating = true;
+    // Clear the firing peer's aim preview so we don't draw a stale line from
+    // the new resting position to the old click point after their ball stops.
+    // Self never has cursorX/Y populated (we only set it for peers), so this
+    // is a no-op for the shooter.
+    slot.cursorX = null;
+    slot.cursorY = null;
     this.renderScoreboard();
   }
 
@@ -567,6 +641,11 @@ export class GamePanel implements Panel {
     const slot = this.players[id];
     if (!slot) return;
     slot.strokesThisTrack = strokes;
+    // Stamp the per-hole tally on every stroke; the last write before the
+    // server advances to the next track becomes the recorded final score.
+    if (this.currentTrackIdx > 0) {
+      slot.holeScores[this.currentTrackIdx - 1] = strokes;
+    }
     if (status === "t") {
       slot.ball.inHole = true;
       slot.simulating = false;
@@ -585,10 +664,36 @@ export class GamePanel implements Panel {
 
   private physicsAccumMs = 0;
   private lastTickMs = 0;
+  /** Cursor-broadcast throttle: timestamp of last `game cursor` we sent. */
+  private lastCursorSentMs = 0;
+  private lastCursorSentX = -9999;
+  private lastCursorSentY = -9999;
+
+  /**
+   * Stream our cursor to peers at ~15 Hz so they see our aim line live.
+   * Bandwidth-conscious: sends only while OUR ball is at rest, and only when
+   * the cursor has moved by at least 2 px since last send.
+   */
+  private maybeSendCursor(nowMs: number): void {
+    if (!this.app.connection.isOpen) return;
+    const me = this.players[this.myPlayerId];
+    if (!me) return;
+    if (me.simulating || me.ball.inHole || me.holedThisTrack || me.forfeitedThisTrack) return;
+    if (nowMs - this.lastCursorSentMs < 66) return; // 15 Hz cap
+    const cx = this.mouseX | 0;
+    const cy = this.mouseY | 0;
+    if (Math.abs(cx - this.lastCursorSentX) < 2 && Math.abs(cy - this.lastCursorSentY) < 2) return;
+    // Server stamps the playerId before forwarding, so we don't include it.
+    this.app.connection.sendData("game", "cursor", String(cx), String(cy));
+    this.lastCursorSentMs = nowMs;
+    this.lastCursorSentX = cx;
+    this.lastCursorSentY = cy;
+  }
 
   private startLoop(): void {
     const tick = () => {
       this.rafHandle = requestAnimationFrame(tick);
+      this.maybeSendCursor(performance.now());
       this.draw();
 
       // Step every ball that's currently moving. Each ball has its OWN
@@ -668,6 +773,10 @@ export class GamePanel implements Panel {
     if (this.trackProgressEl) {
       this.trackProgressEl.textContent = `Track ${this.currentTrackIdx}/${this.numTracks}`;
     }
+    // Stash for the daily-share text; both fields are blank until the first
+    // starttrack arrives.
+    this.trackName = name;
+    this.trackAverage = info && info.plays > 0 ? info.totalStrokes / info.plays : 0;
     if (this.trackTitleEl) this.trackTitleEl.textContent = name;
     if (this.trackTagsEl) {
       while (this.trackTagsEl.firstChild) {
@@ -724,14 +833,22 @@ export class GamePanel implements Panel {
       name.textContent = p.nick || `Player ${i + 1}`;
       const tracksCol = document.createElement("span");
       const cells: string[] = [];
+      let totalSoFar = 0;
       for (let t = 0; t < this.numTracks; t++) {
-        if (t + 1 < this.currentTrackIdx) cells.push("·");
-        else if (t + 1 === this.currentTrackIdx) cells.push(String(p.strokesThisTrack));
-        else cells.push("—");
+        if (t + 1 < this.currentTrackIdx) {
+          const score = p.holeScores[t] ?? 0;
+          cells.push(String(score));
+          totalSoFar += score;
+        } else if (t + 1 === this.currentTrackIdx) {
+          cells.push(String(p.strokesThisTrack));
+          totalSoFar += p.strokesThisTrack;
+        } else {
+          cells.push("—");
+        }
       }
       tracksCol.textContent = cells.join("  ");
       const total = document.createElement("span");
-      total.textContent = "= " + (p.strokesTotal + p.strokesThisTrack);
+      total.textContent = "= " + totalSoFar;
       const note = document.createElement("span");
       if (p.holedThisTrack) note.textContent = "in hole";
       else if (p.forfeitedThisTrack) note.textContent = "forfeited";
@@ -840,9 +957,14 @@ export class GamePanel implements Panel {
       aim = { fromX: me.ball.x, fromY: me.ball.y, toX: this.mouseX, toY: this.mouseY };
     }
     const sprites: BallSprite[] = [];
+    const peerAims: PeerAim[] = [];
     for (let i = 0; i < this.numPlayers; i++) {
       const p = this.players[i];
       if (!p) continue;
+      const isMine = i === this.myPlayerId;
+      // Daily mode: render every other player as a translucent ghost with a
+      // name label above. Self renders normally.
+      const ghost = this.dailyMode && !isMine;
       sprites.push({
         x: p.ball.x,
         y: p.ball.y,
@@ -852,15 +974,44 @@ export class GamePanel implements Panel {
         // colours mid-shot.
         moving: false,
         hidden: p.ball.inHole,
+        ghost,
+        label: ghost ? (p.nick || `Player ${i + 1}`) : undefined,
       });
+      // Peer aim preview — only for non-self peers whose ball is at rest and
+      // who have a fresh cursor sample. The cursor is cleared on track change
+      // and on each beginstroke so we never show a stale aim. Suppressed in
+      // daily mode: the ghost rendering treats other players as non-interactive
+      // shadows of past plays; live aim lines would clash with that framing.
+      if (
+        !isMine &&
+        !ghost &&
+        !p.ball.inHole &&
+        !p.simulating &&
+        !p.holedThisTrack &&
+        !p.forfeitedThisTrack &&
+        p.cursorX !== null &&
+        p.cursorY !== null
+      ) {
+        peerAims.push({
+          fromX: p.ball.x,
+          fromY: p.ball.y,
+          toX: p.cursorX,
+          toY: p.cursorY,
+          playerIdx: i,
+        });
+      }
     }
-    this.renderer.drawFrame(ctx, sprites, aim);
+    this.renderer.drawFrame(ctx, sprites, aim, peerAims);
   }
 
   // ----- game-end overlay -----------------------------------------------
 
   private showEndOverlay(f: string[]): void {
     if (!this.root) return;
+    if (this.dailyMode) {
+      this.showDailyShareOverlay();
+      return;
+    }
     this.removeOverlay();
     const ov = document.createElement("div");
     ov.className = "game-end-overlay";
@@ -894,6 +1045,127 @@ export class GamePanel implements Panel {
       this.app.connection.sendData("game", "back");
     });
     ov.appendChild(btn);
+
+    this.root.appendChild(ov);
+    this.overlay = ov;
+  }
+
+  /**
+   * Daily-mode end screen. The local player has just finished the daily hole
+   * (holed-in or forfeited); the room continues for others. Persist the
+   * result to localStorage to gate tomorrow's button, render the score
+   * relative to the track average, and offer a copy-to-clipboard share.
+   */
+  private showDailyShareOverlay(): void {
+    if (!this.root) return;
+    const me = this.players[this.myPlayerId];
+    const dateKey = this.dailyDateKey ?? todayKey();
+    const result: DailyResult = {
+      date: dateKey,
+      strokes: me?.strokesThisTrack ?? 0,
+      average: this.trackAverage,
+      forfeited: !!me?.forfeitedThisTrack && !me?.holedThisTrack,
+      trackName: this.trackName,
+    };
+    if (!this.dailyResultRecorded) {
+      saveDailyResult(result);
+      this.dailyResultRecorded = true;
+    }
+
+    this.removeOverlay();
+    const ov = document.createElement("div");
+    ov.className = "game-end-overlay";
+
+    const title = document.createElement("div");
+    title.textContent = `Daily Cup — ${dateKey}`;
+    ov.appendChild(title);
+
+    const lines = document.createElement("div");
+    lines.style.fontSize = "14px";
+    lines.style.fontWeight = "normal";
+    lines.style.fontFamily = '"Dialog", Verdana, sans-serif';
+    lines.style.textAlign = "center";
+    lines.style.padding = "8px 0";
+
+    const score = dailyScore(result.strokes, result.average, result.forfeited);
+    const verdict = result.forfeited
+      ? "Forfeited"
+      : result.average > 0 && result.strokes < result.average
+        ? "Below average — nice!"
+        : result.average > 0 && result.strokes === Math.round(result.average)
+          ? "Right on average."
+          : result.average > 0
+            ? "Above average."
+            : "First play!";
+
+    const row1 = document.createElement("div");
+    row1.textContent = result.forfeited
+      ? `You forfeited "${result.trackName}".`
+      : `You finished "${result.trackName}" in ${result.strokes} stroke${result.strokes === 1 ? "" : "s"}.`;
+    lines.appendChild(row1);
+    if (result.average > 0) {
+      const row2 = document.createElement("div");
+      row2.textContent = `Track average: ${result.average.toFixed(1)} strokes`;
+      lines.appendChild(row2);
+    }
+    const row3 = document.createElement("div");
+    row3.style.fontWeight = "bold";
+    row3.style.marginTop = "4px";
+    row3.textContent = `Score: ${score}  —  ${verdict}`;
+    lines.appendChild(row3);
+    ov.appendChild(lines);
+
+    const btnRow = document.createElement("div");
+    btnRow.style.display = "flex";
+    btnRow.style.gap = "6px";
+    btnRow.style.justifyContent = "center";
+
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.className = "btn-green";
+    copyBtn.textContent = "Copy share text";
+    copyBtn.addEventListener("click", () => {
+      const text = shareText(result);
+      void copyToClipboard(text).then((ok) => {
+        copyBtn.textContent = ok ? "Copied!" : "Copy failed — select & copy manually";
+        if (!ok) {
+          // Fallback: drop the text into a visible textarea so the user can
+          // hand-copy when the Clipboard API is gated (older browsers / iframes).
+          const ta = document.createElement("textarea");
+          ta.value = text;
+          ta.rows = 3;
+          ta.style.width = "320px";
+          ta.style.fontFamily = '"Lucida Console", monospace';
+          ta.style.fontSize = "11px";
+          ta.style.marginTop = "6px";
+          ov.appendChild(ta);
+          ta.select();
+        }
+        window.setTimeout(() => { copyBtn.textContent = "Copy share text"; }, 2000);
+      });
+    });
+    btnRow.appendChild(copyBtn);
+
+    const backBtn = document.createElement("button");
+    backBtn.type = "button";
+    backBtn.className = "btn-blue";
+    backBtn.textContent = "Back to menu";
+    backBtn.addEventListener("click", () => {
+      this.app.connection.sendData("game", "back");
+    });
+    btnRow.appendChild(backBtn);
+
+    ov.appendChild(btnRow);
+
+    // Hint that other players keep playing even after you exit.
+    const hint = document.createElement("div");
+    hint.textContent = "Other players are still on the same track.";
+    hint.style.fontSize = "11px";
+    hint.style.color = "#666";
+    hint.style.marginTop = "4px";
+    hint.style.fontFamily = '"Dialog", Verdana, sans-serif';
+    hint.style.fontWeight = "normal";
+    ov.appendChild(hint);
 
     this.root.appendChild(ov);
     this.overlay = ov;
@@ -936,13 +1208,17 @@ export class GamePanel implements Panel {
         nick: "",
         clan: "",
         strokesThisTrack: 0,
-        strokesTotal: 0,
         ball: newBall(this.startX, this.startY),
         ctx: null,
         active: true,
         simulating: false,
         holedThisTrack: false,
         forfeitedThisTrack: false,
+        startX: this.startX,
+        startY: this.startY,
+        holeScores: [],
+        cursorX: null,
+        cursorY: null,
       });
     }
   }

--- a/port/web/src/panels/lobby-multi.ts
+++ b/port/web/src/panels/lobby-multi.ts
@@ -93,6 +93,8 @@ export class LobbyMultiPanel implements Panel {
   private listeners: Array<() => void> = [];
   private tagCounts: number[] | null = null;
   private trackTypeSel: HTMLSelectElement | null = null;
+  /** Captured from `lobby ownjoin` so local-echo chat shows our nick consistently with peers. */
+  private myNick = "";
 
   constructor(app: App) {
     this.app = app;
@@ -225,6 +227,7 @@ export class LobbyMultiPanel implements Panel {
         case "ownjoin": {
           const p = parsePlayerString(f[2] ?? "");
           this.players.set(p.nick, p);
+          this.myNick = p.nick;
           this.refreshPlayers();
           break;
         }
@@ -663,9 +666,10 @@ export class LobbyMultiPanel implements Panel {
       return;
     }
 
-    // Echo locally — server only forwards to *others*.
+    // Echo locally — server only forwards to *others*. Use our captured nick
+    // so the format matches incoming `<{sender}> ...` lines from peers.
     this.app.connection.sendData("lobby", "say", text);
-    this.appendChat(`<you> ${text}`, "say-self");
+    this.appendChat(`<${this.myNick || "you"}> ${text}`, "say-self");
   }
 
   private appendChat(line: string, kind: "say" | "say-self" | "whisper" | "system"): void {

--- a/port/web/src/panels/lobbyselect.ts
+++ b/port/web/src/panels/lobbyselect.ts
@@ -1,16 +1,21 @@
 import { PacketType, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
+import { todayKey, getDailyResult } from "../daily.ts";
 
 /**
- * Lobby-select panel — visual port of agolf.LobbySelectPanel.
+ * Lobby-select panel — visual port of agolf.LobbySelectPanel, repurposed:
+ * the original "Dual player" column has been replaced by "Daily Cup"
+ * (since DUAL was never implemented in the port and the daily room is the
+ * port's headline new feature).
+ *
  * Layout overlays the bg-lobbyselect.gif background:
- *   - 3 serif titles ("Single player", "Dual player", "Multiplayer") at the
+ *   - 3 serif titles ("Single player", "Daily Cup", "Multiplayer") at the
  *     1/6, 3/6, 5/6 horizontal positions.
  *   - "(N players)" line below each title (refreshed via lobbyselect/rnop).
- *   - 3 columns of buttons at the bottom of each section: a primary "Single
- *     player" button (height-150) and a smaller "Quick start" button
- *     (height-95) underneath.
+ *     Daily count comes from the new 5th field in the rnop reply.
+ *   - 3 columns of buttons. The daily column has one button — disabled (with
+ *     a "done today" label) once the local player has finished today's run.
  *   - Footer row: graphics-quality dropdown, audio dropdown, quit button.
  */
 export class LobbySelectPanel implements Panel {
@@ -18,7 +23,7 @@ export class LobbySelectPanel implements Panel {
   private wrap: HTMLElement | null = null;
   private listeners: Array<() => void> = [];
   private singleCount: HTMLElement | null = null;
-  private dualCount: HTMLElement | null = null;
+  private dailyCount: HTMLElement | null = null;
   private multiCount: HTMLElement | null = null;
   private rnopTimer: number | null = null;
 
@@ -36,7 +41,7 @@ export class LobbySelectPanel implements Panel {
 
     const positions: Array<["1" | "2" | "3", string, string]> = [
       ["1", "Single player", "16.66%"],
-      ["2", "Dual player", "50%"],
+      ["2", "Daily Cup", "50%"],
       ["3", "Multiplayer", "83.33%"],
     ];
     const counts: Record<"1" | "2" | "3", HTMLElement> = {
@@ -56,15 +61,13 @@ export class LobbySelectPanel implements Panel {
       titles.appendChild(c);
     }
     this.singleCount = counts[1];
-    this.dualCount = counts[2];
+    this.dailyCount = counts[2];
     this.multiCount = counts[3];
     wrap.appendChild(titles);
 
-    // Three button columns
+    // Three button columns: Single / Daily / Multi.
     wrap.appendChild(this.makeColumn(1, "Single player", "Quick start", () => this.selectSingle(), () => this.quickSingle()));
-    // Dual is "Coming soon..." in the original — same here.
-    const dualCol = this.makeColumn(2, "Coming soon...", null, null, null);
-    wrap.appendChild(dualCol);
+    wrap.appendChild(this.makeDailyColumn());
     wrap.appendChild(this.makeColumn(3, "Multiplayer", "Quick start", () => this.selectMulti(), () => this.quickMulti()));
 
     // Footer: graphics / audio / quit
@@ -124,7 +127,7 @@ export class LobbySelectPanel implements Panel {
     }
     this.wrap = null;
     this.singleCount = null;
-    this.dualCount = null;
+    this.dailyCount = null;
     this.multiCount = null;
   }
 
@@ -132,20 +135,32 @@ export class LobbySelectPanel implements Panel {
     if (pkt.type !== PacketType.DATA) return;
     const f = pkt.fields;
     if (f[0] === "lobbyselect" && f[1] === "nop") {
-      // d N lobbyselect nop <single> <dual> <multi>
+      // d N lobbyselect nop <single> <dual> <multi> [<daily>]
+      // We show the daily count in the middle column (where DUAL used to live);
+      // ignore the dual count since DUAL isn't surfaced any more.
       this.setCount(this.singleCount, parseInt(f[2] ?? "-1", 10));
-      this.setCount(this.dualCount, parseInt(f[3] ?? "-1", 10));
       this.setCount(this.multiCount, parseInt(f[4] ?? "-1", 10));
+      this.setCount(this.dailyCount, parseInt(f[5] ?? "-1", 10));
       return;
     }
     if (f[0] === "status" && f[1] === "lobby") {
-      // f[2] is the lobby tag: "1", "1h", "x", "xh", etc.
+      // f[2] is the lobby tag: "1", "1h", "x", "xh", "d" (daily — no panel).
       const tag = (f[2] ?? "1").charAt(0);
+      if (tag === "d") {
+        // Daily lobby is invisible; the server follows up with `status game`
+        // immediately. Ignore and stay on lobbyselect until that arrives.
+        return;
+      }
       if (tag === "x") {
         this.app.setPanel("lobby-multi");
       } else {
         this.app.setPanel("lobby");
       }
+    }
+    if (f[0] === "status" && f[1] === "game") {
+      // Daily mode: server sent `status lobby d` (ignored above) then
+      // `status game` to drop us straight into the daily room.
+      this.app.setPanel("game");
     }
   }
 
@@ -203,6 +218,36 @@ export class LobbySelectPanel implements Panel {
     return col;
   }
 
+  /**
+   * Daily-Challenge column. One button — disabled if today's run is already
+   * recorded in localStorage. Tooltip surfaces the previous result so the
+   * "you already played" message has substance.
+   */
+  private makeDailyColumn(): HTMLElement {
+    const col = document.createElement("div");
+    col.className = "col col-2";
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn-yellow";
+    const existing = getDailyResult();
+    if (existing) {
+      btn.disabled = true;
+      btn.textContent = "Already played today";
+      btn.title =
+        `${todayKey()}: ${existing.forfeited ? "forfeited" : `${existing.strokes} strokes`}` +
+        ` (avg ${existing.average.toFixed(1)}). Come back tomorrow.`;
+    } else {
+      btn.textContent = "Daily Cup";
+      btn.title = `${todayKey()} — same track for everyone today.`;
+      const handler = (): void => this.selectDaily();
+      btn.addEventListener("click", handler);
+      this.listeners.push(() => btn.removeEventListener("click", handler));
+    }
+    col.appendChild(btn);
+    return col;
+  }
+
   private requestCounts(): void {
     if (!this.app.connection.isOpen) return;
     this.app.connection.sendData("lobbyselect", "rnop");
@@ -214,6 +259,11 @@ export class LobbySelectPanel implements Panel {
 
   private selectMulti(): void {
     this.app.connection.sendData("lobbyselect", "select", "x");
+  }
+
+  private selectDaily(): void {
+    if (!this.app.connection.isOpen) return;
+    this.app.connection.sendData("lobbyselect", "select", "d");
   }
 
   private quickSingle(): void {


### PR DESCRIPTION
Bug fixes (from playtest):
- TrackManager: 50-entry recently-served ringbuffer so getRandomTracks prefers tracks not in the ring; falls back to recents only when the filtered pool is too small.
- Lobby chat: capture myNick from `lobby ownjoin` so local-echo renders as <nick> matching what peers see (was <you>).
- Multi-spawn-marker tracks: each PlayerSlot resolves its spawn the way Java resetPosition() does — per-color (shapes 48..51) wins, common shape-24 start is the fallback, centre is last resort. Per-slot startX/Y flow into the per-stroke physics context so water/acid resets land at THIS player's spawn.
- Scoreboard: per-hole final scores tracked via holeScores[] on PlayerSlot, populated on every endstroke broadcast (last write before track advance is the recorded final). renderScoreboard derives the running total from the same array; strokesTotal field removed.

Daily mode:
- New DailyGame singleton: deterministic per-day track, lazily created on first join, rotates when UTC date changes. Players in the daily room see each other's balls as translucent ghosts with name labels (existing async-MP relay gives concurrent semantics).
- DAILY lobby type, lobbyselect button, share-result overlay with copy-to-clipboard, local-storage persistence of the day's result.
- test-daily.ts smoke test: covers join, ordinal correctness, seed agreement, per-player end (room continues for others), forfeit, back-to-lobbyselect routing.
- Fix off-by-one in `game join` ordinal: was sending playerCount() (count BEFORE the push), now sends playerCount() + 1 so the newcomer doesn't overwrite the first existing player's slot.

Live aim preview (port-specific):
- New `game cursor <x> <y>` packet: client throttles to ~15 Hz, sends only while ball at rest, suppresses if cursor moved <2 px since last send.
- Server stamps the sender's playerId and forwards to peers (handler registered before the generic `game .+` catch-all so it isn't swallowed). Sender doesn't get an echo.
- Renderer accepts peerAims: PeerAim[]; each peer line is dashed and tinted by ball colour so the local solid-black aim stays prominent.
- Cursor cleared on starttrack and on each peer's beginstroke so no stale aim line draws from a peer's new resting position to their previous click point.
- Suppressed in daily mode where the ghost framing makes live aim lines feel out of place.
- test-multi.ts asserts the relay (A→server→B with stamped playerId) so the handler-ordering invariant has a guard.
- Documented in PROTOCOL.md.

Tests: 45 shared + multi/forfeit/filter/daily smoke pass. test-handshake/test-fullflow remain stale on master (lobby tagcounts interleave) — documented in KNOWN_ISSUES #6.