### PR TITLE
port: drain interleaved frames in smoke tests

### DIFF
--- a/port/server/src/test-fullflow.ts
+++ b/port/server/src/test-fullflow.ts
@@ -89,7 +89,8 @@ await awaitFrame((s) => /^d \d+ game\towninfo\t/.test(s), "game owninfo");
 await awaitFrame((s) => /^d \d+ game\tstart$/.test(s), "game start");
 await awaitFrame((s) => /^d \d+ game\tresetvoteskip/.test(s), "resetvoteskip");
 const startTrackFrame = await awaitFrame((s) => /^d \d+ game\tstarttrack\t/.test(s), "starttrack", 8000);
-await awaitFrame((s) => /^d \d+ game\tstartturn\t0/.test(s), "startturn 0");
+// Async-mode play: no `startturn` follows starttrack. Clients shoot whenever
+// their own ball is at rest. (See server/src/game.ts startGame.)
 
 // Confirm we received a real track payload (must contain 'V 1' and a 'T ' field)
 const trackPayload = startTrackFrame.split("\t").slice(2).join("\t");
@@ -107,14 +108,14 @@ const v = x * 1500 + y * 4 + mode;
 const encoded = v.toString(36).padStart(4, "0");
 sendData("game", "beginstroke", encoded);
 
-// Server broadcasts beginstroke to other players (none here, single player) — no reply expected.
+// Server writeAll's the beginstroke to all players (incl. shooter): `game beginstroke <id> <ball> <mouse> <seed>`.
 // Sleep a moment then send endstroke (didn't make it in hole)
 await new Promise((r) => setTimeout(r, 200));
 sendData("game", "endstroke", 0, "f");
 
-// Server should reply with startturn (next turn for same player)
-await awaitFrame((s) => /^d \d+ game\tstartturn/.test(s), "startturn after endstroke", 4000);
-console.log("[OK] turn cycled correctly");
+// Async mode: server broadcasts `game endstroke <id> <strokes> <status>` (no startturn).
+await awaitFrame((s) => /^d \d+ game\tendstroke\t0\t1\tf$/.test(s), "endstroke broadcast", 4000);
+console.log("[OK] stroke recorded (1 stroke, still on track)");
 
 // Phase 9: simulate hole-in
 sendData("game", "beginstroke", encoded);

--- a/port/server/src/test-handshake.ts
+++ b/port/server/src/test-handshake.ts
@@ -75,6 +75,29 @@ function assertStartsWith(actual: string, prefix: string, label: string): void {
     console.log(`  ok: ${label}: ${describe(actual)}`);
 }
 
+/**
+ * Pull frames off the queue, discarding any that don't match, until one does.
+ * Used in phases where the server may interleave port-extension packets
+ * (e.g. `lobby tagcounts`) whose exact position we don't want to assert.
+ */
+async function awaitMatch(
+    queue: FrameQueue,
+    predicate: (s: string) => boolean,
+    label: string,
+    timeoutMs = 5000,
+): Promise<string> {
+    const start = Date.now();
+    for (;;) {
+        const remaining = timeoutMs - (Date.now() - start);
+        if (remaining <= 0) throw new Error(`timeout waiting for ${label}`);
+        const frame = await queue.next(remaining);
+        if (predicate(frame)) {
+            console.log(`  ok: ${label}: ${describe(frame)}`);
+            return frame;
+        }
+    }
+}
+
 async function run(): Promise<void> {
     const running: RunningServer = await startServer({
         host: HOST,
@@ -139,16 +162,17 @@ async function run(): Promise<void> {
         // Per Java's LobbyCreateSinglePlayerHandler comment, the client sends "lobby\tcspt..."
         // when already in the lobby, "lobbyselect\tcspt..." when jumping straight from lobbyselect.
         ws.send("d 5 lobby\tcspt\t1\t0\t0");
-        // Lobby part for STARTED_SP is broadcast to remaining lobby players (none here),
-        // so the next frames the client sees are the game-related ones from sendJoinMessages.
-        assertStartsWith(await queue.next(), "d 7 status\tgame", "status game");
-        assertStartsWith(await queue.next(), "d 8 game\tgameinfo\t", "game gameinfo");
-        assertStartsWith(await queue.next(), "d 9 game\tplayers", "game players");
-        assertStartsWith(await queue.next(), "d 10 game\towninfo\t0\t", "game owninfo");
-        assertStartsWith(await queue.next(), "d 11 game\tstart", "game start");
-        assertStartsWith(await queue.next(), "d 12 game\tresetvoteskip", "game resetvoteskip");
-        assertStartsWith(await queue.next(), "d 13 game\tstarttrack\t", "game starttrack");
-        assertStartsWith(await queue.next(), "d 14 game\tstartturn\t0", "game startturn");
+        // The server interleaves a port-extension `lobby tagcounts` packet on lobby join
+        // (see lobby.ts addPlayer), so d-seq numbers in this phase aren't stable. Match on
+        // content instead, draining any extra frames the server emits.
+        // Async-mode play: no `startturn` follows starttrack (see game.ts startGame).
+        await awaitMatch(queue, (s) => /^d \d+ status\tgame$/.test(s), "status game");
+        await awaitMatch(queue, (s) => /^d \d+ game\tgameinfo\t/.test(s), "game gameinfo");
+        await awaitMatch(queue, (s) => /^d \d+ game\tplayers/.test(s), "game players");
+        await awaitMatch(queue, (s) => /^d \d+ game\towninfo\t0\t/.test(s), "game owninfo");
+        await awaitMatch(queue, (s) => /^d \d+ game\tstart$/.test(s), "game start");
+        await awaitMatch(queue, (s) => /^d \d+ game\tresetvoteskip$/.test(s), "game resetvoteskip");
+        await awaitMatch(queue, (s) => /^d \d+ game\tstarttrack\t/.test(s), "game starttrack");
 
         console.log("\nALL PHASES PASSED");
         ws.close();


### PR DESCRIPTION
The test-handshake Phase 6 strict positional assertions were tripping on the new `lobby tagcounts` port-extension packet that arrives between `lobby ownjoin` and `status game`, shifting all expected d-seq numbers. Switched to a predicate-draining `awaitMatch` helper and dropped the stale `startturn` assertion (server is async-mode now).

test-fullflow already drained on predicates but still expected the removed `startturn` packets — both at game start and after `endstroke`. Removed the first wait and replaced the second with a match against the real `game endstroke <id> <strokes> <status>` broadcast.