### PR TITLE
Port: lobby Back via lobbyselect leave + README refresh

### DIFF
--- a/port/README.md
+++ b/port/README.md
@@ -77,58 +77,100 @@ npm run dev:server   # serves the built web bundle on http://localhost:4242
 
 ```sh
 cd port
-npm test                                       # shared package: Seed, RLE, codec, tools
-node --experimental-strip-types --no-warnings server/src/test-handshake.ts
-node --experimental-strip-types --no-warnings server/src/test-fullflow.ts  # needs a running server
+npm test                                                         # shared (Seed, RLE, codec, tools, tiles, tracks)
+node --experimental-strip-types --no-warnings server/src/test-multi.ts     # 2-client async-MP determinism + cursor relay
+node --experimental-strip-types --no-warnings server/src/test-forfeit.ts   # async forfeit + maxStrokes auto-cap
+node --experimental-strip-types --no-warnings server/src/test-filter.ts    # track-category filtering
+node --experimental-strip-types --no-warnings server/src/test-daily.ts     # daily-challenge room flow
 ```
 
-`test-handshake.ts` boots a self-contained server on port 4243 and
-walks the full guest-login → training-game flow.
-
-`test-fullflow.ts` connects to whatever WS server is on
-`ws://localhost:4242/ws` (override via `WS_URL`) and asserts the same
-exchange end-to-end, including the stroke cycle.
+Each smoke test boots its own self-contained server on a private port
+and tears it down at the end, so they can run in any order or in
+parallel.
 
 The `Seed` PRNG test uses 100 reference values captured from the
 actual Java `agolf.Seed` class running under JDK 17 — every shot's
 randomness is bit-for-bit identical to the original game.
 
-## What's implemented (MVP)
+`test-multi.ts` is the load-bearing one for the **determinism
+contract**: it asserts that both clients receive identical per-stroke
+seeds for the same stroke, that two strokes get different seeds, and
+that the live cursor relay is wired through the right handler order.
 
-- WebSocket transport with sequence-number validation and ping/pong.
-- Connect → guest login (`~anonym-NNNN`) → lobby-select → enter
-  single-player lobby → start training game → receive track and stats.
-- Training game lifecycle: `starttrack`, `startturn`, `beginstroke`,
-  `endstroke`, `nextTrack`, `endGame` cycle.
-- 49×25 RLE map decoding, byte-for-byte match with the Java
-  `Map.parse()` algorithm (incl. A/B/C inline + D-I copy-references).
-- 735×375 pixel collision map, built from sprite atlases the same way
-  Java does it (`shapes.gif` / `special.gif` masks composited with
-  `elements.gif` background/foreground indices).
-- Ball physics: deterministic shot impulse with seeded random noise,
-  integration with friction, wall reflection (cardinal + diagonal),
-  hole pull and 7+-neighbour lock, hole-in detection.
-- Mouse aim with power scaling per the Java `getStrokePower()`.
-- Atlas-based ball sprite (player 0 = white).
+> `test-handshake.ts` and `test-fullflow.ts` are stale — see
+> `docs/KNOWN_ISSUES.md` #6.
+
+## What's implemented
+
+**Multiplayer & lobbies**
+- Single-player training games (track-type filter, 1/3/5/9/18 tracks,
+  water-event mode, max-strokes cap).
+- Multi-player lobby with game list, password-protected games, in-lobby
+  chat with `/msg <nick>` whispers, create-game form.
+- **Async multi-player**: every player can shoot whenever their own
+  ball is at rest — no turn arbiter. Server picks a unique 32-bit seed
+  per stroke and broadcasts it to all clients (incl. shooter) so every
+  client computes byte-identical trajectories.
+- **Daily challenge room**: singleton `DailyGame` with a deterministic
+  per-day track. Other players in the room render as translucent
+  ghosts with name labels. Daily result is saved to localStorage; the
+  end overlay offers a copy-to-clipboard share text.
+
+**Physics** (faithful port of `GameCanvas.run`'s 166 Hz inner loop)
+- Velocity integration (10 substeps × 0.1).
+- Friction per surface, wall reflection (cardinal + diagonal),
+  inside-corner suppression, restitution table.
+- One-way walls (20–23) with directional pass-through.
+- Slopes (4–11) with 8-direction acceleration.
+- Water (12, 14) with both `waterEvent` modes (back to last hit /
+  back to shore).
+- Acid (13, 15) — always reset to track start.
+- Hole pull (25) + 7+-neighbour lock.
+- Teleports (32–38 / 33–39) with random exit selection.
+- Mines (28, 30) ejecting at random velocity.
+- Magnets (44 attract, 45 repel) with pre-computed 147×75 force field.
+- Super-bouncy block (18) with the dynamic
+  `bounciness * 6.5 / speed` restitution, decaying per hit.
+- Per-player spawn resolution matching Java `resetPosition()` —
+  per-color reset markers (48..51) win, common shape-24 start is the
+  fallback, centre is the last resort.
+
+**UX**
+- Live peer aim preview — cursor stream at 15 Hz lets every player see
+  every other player's aim line as they line up.
+- Per-hole final scores in the scoreboard, with the running total
+  derived from the same array.
+- Anti-repeat ringbuffer in `TrackManager` (last 50 served names) so
+  the same maps don't recur within a few games.
+
+**Rendering**
+- 49×25 RLE map decoding, byte-for-byte match with Java `Map.parse()`
+  (A/B/C inline + D-I copy-references).
+- Sprite-accurate tile compositing from `shapes.gif` / `elements.gif`
+  / `special.gif` masks — slope arrows, mine markings, magnet field
+  patterns, hole shading, etc.
+- Atlas-based ball sprites with per-player colour.
 
 ## What's deferred
 
-These were intentionally left out of MVP scope to keep one autonomous
-implementation pass tractable:
+See `docs/KNOWN_ISSUES.md` "Gaps from a faithful 1:1 port" for the
+running list. Highlights:
 
-- Dual / multi-player lobbies and lobby chat.
-- Track-test mode.
-- Slopes, water, sand, mines, magnets, teleports, breakable /
-  movable blocks (most tracks still play; tracks that *require* these
-  features to reach the hole won't be completable yet).
-- One-way wall directional pass-through (treated as solid).
-- Localisation routing (XML files are bundled but not consumed).
-- Sprite-accurate tile rendering (uses a simple colour palette
-  driven by element index).
+- Player-player ball collision (gated on `collision: 1`; not ported).
+- Movable / breakable block visual updates (collision works).
+- 3D shading on tile rendering at higher quality settings.
+- Sound playback (.wav files bundled in `web/public/sound/shared/`
+  but not yet hooked up to Web Audio).
+- Localisation routing (XML files bundled, not consumed).
+- Track-test mode (`logintype ttm`).
+- DUAL lobby (UI button disabled).
+- Aim modes (right-click rotation between solid + 3 dashed lines).
+- Reconnect after network blip.
+- Track ratings UI / persistence.
 
 ## Architecture notes
 
-- The shared package is the single source of truth for the wire
+- The **shared** package is the single source of truth for the wire
   protocol and map format. Both server and client import from it via
   TypeScript path mapping (`@minigolf/shared`).
 - The server is single-threaded and event-driven — every Netty event
@@ -139,4 +181,8 @@ implementation pass tractable:
   `Packet` objects to the active panel.
 - Game rendering uses an offscreen canvas for the static background
   (drawn once when the track loads) and `requestAnimationFrame` for
-  the ball + aim line overlay.
+  the ball, aim line, and peer aim previews on top.
+- Server state is **all in-memory** — track ringbuffer, lobbies,
+  games, daily-room state. A restart wipes everything; only the
+  daily result history survives because it's stored client-side in
+  the user's browser localStorage.

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -5,7 +5,7 @@ import { type Packet, PacketType, tabularize } from "@minigolf/shared";
 import type { Connection } from "./connection.ts";
 import type { GolfServer } from "./server.ts";
 import { Player } from "./player.ts";
-import { JoinType, LobbyType } from "./lobby.ts";
+import { JoinType, LobbyType, PartReason } from "./lobby.ts";
 import { MultiGame, TrainingGame } from "./game.ts";
 
 interface Handler {
@@ -115,11 +115,31 @@ register({
 
 register({
     type: PacketType.DATA,
-    pattern: /^lobbyselect\t(rnop|select|qmpt|daily)(?:\t([12xd])(h)?)?$/,
+    pattern: /^lobbyselect\t(rnop|select|qmpt|daily|leave)(?:\t([12xd])(h)?)?$/,
     handle: (server, conn, match) => {
         const sub = match[1];
         const player = conn.player;
         if (!player) return;
+        if (sub === "leave") {
+            // Player asked to go back to the lobby-select screen from a lobby
+            // (e.g. clicked "Back" in the single-player or multi lobby). Pull
+            // them out of any current lobby with USERLEFT, which causes the
+            // server to send `status lobbyselect 300` to the leaver.
+            //
+            // Defensive about double-leaves: if `removePlayer` returns false
+            // (the player was sticky-referenced but not actually in
+            // lobby.players any more, e.g. they're in a game) we still need
+            // to send the status so the client UI moves.
+            if (player.lobby) {
+                const removed = player.lobby.removePlayer(player, PartReason.USERLEFT);
+                if (!removed) {
+                    conn.sendData("status", "lobbyselect", "300");
+                }
+            } else {
+                conn.sendData("status", "lobbyselect", "300");
+            }
+            return;
+        }
         if (sub === "rnop") {
             const single = server.getLobby(LobbyType.SINGLE).totalPlayerCount();
             const dual = server.getLobby(LobbyType.DUAL).totalPlayerCount();

--- a/port/server/src/test-multi.ts
+++ b/port/server/src/test-multi.ts
@@ -207,6 +207,15 @@ async function main(): Promise<void> {
         await b.waitFor((s) => /lobby\tsay\thi from A/.test(s), "B sees A's chat");
         console.log("[OK] lobby chat works");
 
+        // Lobby `back` button — `lobbyselect leave` must remove from current
+        // lobby and bounce back to lobbyselect. The historical bug was that
+        // the single-player Back sent `lobbyselect select 1` which re-entered
+        // the same lobby, so the panel snapped right back. We send `leave`
+        // and assert the server replies with `status lobbyselect`.
+        a.sendData("lobbyselect", "leave");
+        await a.waitFor((s) => /^d \d+ status\tlobbyselect\t/.test(s), "A leaves lobby");
+        console.log("[OK] lobbyselect leave routes back to main menu");
+
         a.close();
         b.close();
         console.log("\nALL ASYNC-MULTIPLAYER PHASES PASSED");

--- a/port/web/src/panels/lobby-multi.ts
+++ b/port/web/src/panels/lobby-multi.ts
@@ -685,11 +685,13 @@ export class LobbyMultiPanel implements Panel {
   }
 
   private goBack(): void {
-    // Server doesn't have an explicit "leave lobby" — closing the panel and
-    // re-entering lobbyselect via a fresh `lobbyselect rnop` is fine, but for
-    // a clean semantic we just switch panels; the disconnect on game start
-    // will remove us from lobby anyway.
-    this.app.setPanel("lobbyselect");
+    // Ask the server to remove us from the multi lobby. The server replies
+    // with `status lobbyselect 300` which we handle in `onPacket` to flip
+    // the panel. Doing the roundtrip (instead of a local-only setPanel)
+    // keeps server and client lobby state consistent — otherwise our
+    // sticky `player.lobby` reference would still inflate the multi
+    // player count in `lobbyselect rnop` until we joined a different lobby.
+    this.app.connection.sendData("lobbyselect", "leave");
   }
 
   private bind<K extends keyof HTMLElementEventMap>(

--- a/port/web/src/panels/lobby.ts
+++ b/port/web/src/panels/lobby.ts
@@ -100,8 +100,12 @@ export class LobbyPanel implements Panel {
     backBtn.className = "btn-red";
     backBtn.textContent = "Back";
     const backHandler = (): void => {
-      this.app.connection.sendData("lobbyselect", "select", 1);
-      this.app.setPanel("lobbyselect");
+      // `lobbyselect leave` removes us from this lobby on the server and the
+      // server replies with `status lobbyselect 300`, which routes us back.
+      // The previous code sent `lobbyselect select 1` (which RE-ENTERS the
+      // single-player lobby) — the local panel switch was immediately undone
+      // when the server replied with `status lobby 1`.
+      this.app.connection.sendData("lobbyselect", "leave");
     };
     backBtn.addEventListener("click", backHandler);
     this.listeners.push(() => backBtn.removeEventListener("click", backHandler));
@@ -129,6 +133,11 @@ export class LobbyPanel implements Panel {
     const fields = pkt.fields;
     if (fields[0] === "status" && fields[1] === "game") {
       this.app.setPanel("game");
+      return;
+    }
+    if (fields[0] === "status" && fields[1] === "lobbyselect") {
+      // Server pulled us back to the main menu (e.g. after `lobbyselect leave`).
+      this.app.setPanel("lobbyselect");
       return;
     }
     if (fields[0] === "lobby" && fields[1] === "tagcounts") {


### PR DESCRIPTION
Lobby Back button used to be a local-only setPanel switch, which left the player still in the lobby on the server side. Symptoms:
- The lobby count returned by `lobbyselect rnop` stayed inflated until the player joined a different lobby.
- Re-entering the same lobby type immediately bounced back via `status lobby ...`.

Single-player Back was worse: it sent `lobbyselect select 1`, which actively RE-ENTERS the single-player lobby, undoing the local panel switch on the server's reply.

Fix:
- New `lobbyselect leave` server handler removes the player from their current lobby (USERLEFT) and replies with `status lobbyselect 300`. Defensive fallback for the sticky-reference edge case where `removePlayer` returns false but the panel still needs to advance.
- Both lobby panels now send `lobbyselect leave` and react to the resulting `status lobbyselect` to flip the panel.
- test-multi.ts asserts the leave roundtrip.

README refresh:
- Updated test list to the actually-passing smoke tests (test-multi/forfeit/filter/daily); test-handshake/test-fullflow noted as stale per KNOWN_ISSUES #6.
- Expanded "What's implemented" to cover async multiplayer, daily mode, full physics surface set, live aim preview, anti-repeat ringbuffer, per-hole scoreboard.
- Trimmed "What's deferred" — most of the original MVP gaps are now shipped.
- Added a note that all server state is in-memory; only the daily result history persists (client-side localStorage).