### PR TITLE
Port: chosen nick, daily re-entry, tile shading, drop tag chips

### DIFF
--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -556,16 +556,35 @@ export class DailyGame extends GolfGame {
     /** Late-join entry. Called from the daily-select handler. */
     joinDaily(player: Player): void {
         if (this.players.includes(player)) return;
+        // Singleton room: previous occupants leave incremented `numberIndex`
+        // and finished `playStatus` chars ('t'/'p') behind. A fresh joiner into
+        // an empty room must start from id 0 with a 'f' slot, otherwise the
+        // beginstroke gate (`playStatus.charAt(playerId) === 'f'`) silently
+        // rejects every shot they try to take.
+        if (this.players.length === 0) {
+            this.numberIndex = 0;
+            this.playStatus = "";
+            this.strokeSeedCounter = 0;
+            for (let i = 0; i < this.playerStrokesThisTrack.length; i++) {
+                this.playerStrokesThisTrack[i] = 0;
+                this.playerStrokesTotal[i] = 0;
+            }
+        }
         // super.addPlayer broadcasts `game join` to existing players, sends
         // gameInfo/players/owninfo to the newcomer, and pushes the slot.
         this.addPlayer(player);
-        // Grow per-player arrays to match the new size.
-        while (this.playerStrokesThisTrack.length < this.players.length) {
+        // After addPlayer, this.numberIndex == newId + 1. Grow the per-id
+        // arrays / playStatus to that length, NOT players.length: ids are
+        // sparse (a finisher who later leaves still owned a slot in
+        // playStatus), so padding only to players.length leaves the joiner's
+        // own slot off the end and beginstroke silently rejects them.
+        const idCapacity = this.numberIndex;
+        while (this.playerStrokesThisTrack.length < idCapacity) {
             this.playerStrokesThisTrack.push(0);
             this.playerStrokesTotal.push(0);
         }
-        if (this.playStatus.length < this.players.length) {
-            this.playStatus = this.playStatus.padEnd(this.players.length, "f");
+        if (this.playStatus.length < idCapacity) {
+            this.playStatus = this.playStatus.padEnd(idCapacity, "f");
         }
         // Personal starttrack so the newcomer renders the map.
         const stats = this.dailyTrackManager.getStats(this.tracks[0]);

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -94,6 +94,30 @@ register({
     },
 });
 
+/**
+ * Browser-port extension: client sends `nick <name>` between `logintype` and
+ * `login` so the player's chosen display name flows through to other clients
+ * (scoreboards, chat, daily-mode ghost labels). Without this the server would
+ * stamp every guest with a random `~anonym-NNNN` placeholder.
+ *
+ * Sanitisation: trim, drop framing chars, cap at 20 chars (matches the
+ * client-side input maxLength). Empty is treated as "no nick sent" so the
+ * `login` handler falls back to the anonym placeholder.
+ */
+register({
+    type: PacketType.DATA,
+    pattern: /^nick\t(.+)$/,
+    handle: (_server, conn, match) => {
+        const player = conn.player;
+        if (!player) return;
+        // Strip both wire-framing chars (\r\n\t) and the structured-field
+        // separators (^, :) that Player.toString triangelizes — a nick with `^`
+        // or `:` would corrupt the lobby/owninfo lines for everyone.
+        const cleaned = match[1].replace(/[\r\n\t^:]+/g, " ").trim().slice(0, 20);
+        if (cleaned) player.nick = cleaned;
+    },
+});
+
 register({
     type: PacketType.DATA,
     pattern: /^login$/,
@@ -103,8 +127,13 @@ register({
             conn.close("login-without-player");
             return;
         }
-        const username = `~anonym-${Math.floor(Math.random() * 10000)}`;
-        player.nick = username;
+        // Honour the nick the client sent during the handshake; only fall back
+        // to the random placeholder if they didn't send one (or it sanitised
+        // away to nothing — `nick` handler leaves `player.nick` at the "-"
+        // default in that case).
+        if (player.nick === "-" || player.nick === "") {
+            player.nick = `~anonym-${Math.floor(Math.random() * 10000)}`;
+        }
         player.emailVerified = true;
         player.registered = false;
         // basicinfo\t<emailVerified>\t<accessLevel>\tt\tt

--- a/port/server/src/test-daily.ts
+++ b/port/server/src/test-daily.ts
@@ -175,6 +175,29 @@ async function main(): Promise<void> {
         await a.waitFor((s) => /^d \d+ status\tlobbyselect\t/.test(s), "A back to lobbyselect");
         console.log("[OK] back from daily routes straight to lobbyselect");
 
+        // Regression: B also leaves, then a fresh client C re-enters the
+        // (now-empty) singleton daily room and must be able to shoot. Pre-fix,
+        // C would inherit the stale `numberIndex` (=2 after A and B) and the
+        // stale `playStatus` ("tp" from A's hole-in + B's forfeit), so its
+        // beginstroke would be silently rejected by the playStatus gate.
+        b.sendData("game", "back");
+        await b.waitFor((s) => /^d \d+ status\tlobbyselect\t/.test(s), "B back to lobbyselect");
+
+        const c = new Client("C");
+        await c.open();
+        await login(c);
+        await enterDaily(c);
+        // Owninfo must show id=0 — the room reset on empty-join, otherwise C's
+        // numberIndex would still be 2 here and the next assert (charAt 0) is
+        // the wrong slot.
+        const owninfo = await c.waitFor((s) => /^d \d+ game\towninfo\t/.test(s), "C owninfo");
+        const cid = parseInt(owninfo.split("\t")[2] ?? "-1", 10);
+        if (cid !== 0) throw new Error(`C re-entered daily with id=${cid}; want 0 (numberIndex was not reset)`);
+        c.sendData("game", "beginstroke", ball, mouseA);
+        await c.waitFor((s) => /^d \d+ game\tbeginstroke\t0\t/.test(s), "C sees own stroke after re-entry");
+        console.log("[OK] daily re-entry into empty room: C can shoot with id=0");
+        c.close();
+
         a.close();
         b.close();
         console.log("\nALL DAILY-CHALLENGE PHASES PASSED");

--- a/port/web/src/game/render.ts
+++ b/port/web/src/game/render.ts
@@ -160,7 +160,87 @@ export class TrackRenderer {
         this.writeTile(img, tx, ty, code);
       }
     }
+    this.applyShading(img);
     ctx.putImageData(img, 0, 0);
+  }
+
+  /**
+   * Per-pixel edge-lighting + drop-shadow + grain pass, ported from Java
+   * GameBackgroundCanvas.drawMap (graphicsQualityIndex >= 2 branch).
+   *
+   * Light source is the top-left of the playfield. For each "solid" pixel
+   * (collision 16..23, illusion-wall id 19 excluded by default) we look at the
+   * up-left and down-right neighbours:
+   *   - inner-corner solid (only down-right neighbour is solid): big +128 boost
+   *     on top of the corner pixel — that's what gives walls the chiselled bevel.
+   *   - top/left edge: +24 (bright)
+   *   - bottom/right edge: −24 (dark)
+   * Then for each solid pixel we cast a 7-pixel down-right drop shadow (−8 per
+   * pixel) onto the non-solid neighbours, faked ambient occlusion.
+   * Teleport-start markers (col 32/34/36/38) get the same brightness pass at a
+   * lighter weight (±16 instead of ±24/±128).
+   * Finally, a ±5 random grain across every pixel for the painterly texture.
+   */
+  private applyShading(img: ImageData): void {
+    const W = MAP_PIXEL_WIDTH;
+    const H = MAP_PIXEL_HEIGHT;
+    const data = img.data;
+    const collision = this.parsedMap.collision;
+
+    const isSolid = (x: number, y: number): boolean => {
+      if (x < 0 || x >= W || y < 0 || y >= H) return false;
+      const c = collision[y * W + x];
+      // Java: c >= 16 && c <= 23 && c != 19  (specialSettings[3]==false; the
+      // illusion-wall block doesn't cast shadows in the default ruleset).
+      return c >= 16 && c <= 23 && c !== 19;
+    };
+    const isTeleStart = (x: number, y: number): boolean => {
+      if (x < 0 || x >= W || y < 0 || y >= H) return false;
+      const c = collision[y * W + x];
+      return c === 32 || c === 34 || c === 36 || c === 38;
+    };
+    const shift = (x: number, y: number, off: number): void => {
+      const o = (y * W + x) * 4;
+      const r = data[o] + off;
+      const g = data[o + 1] + off;
+      const b = data[o + 2] + off;
+      data[o] = r < 0 ? 0 : r > 255 ? 255 : r;
+      data[o + 1] = g < 0 ? 0 : g > 255 ? 255 : g;
+      data[o + 2] = b < 0 ? 0 : b > 255 ? 255 : b;
+    };
+
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        if (isSolid(x, y)) {
+          const ul = isSolid(x - 1, y - 1);
+          const dr = isSolid(x + 1, y + 1);
+          if (!ul && dr && !isSolid(x, y - 1) && !isSolid(x - 1, y)) {
+            // Inner corner: this pixel is the top-left tip of a solid block.
+            shift(x, y, 128);
+          } else {
+            if (!ul && dr) shift(x, y, 24);
+            if (!dr && ul) shift(x, y, -24);
+          }
+          // Drop-shadow trail (quality≥2 in Java). Up to 7 px down-right onto
+          // non-solid neighbours.
+          for (let i = 1; i <= 7 && x + i < W && y + i < H; i++) {
+            if (!isSolid(x + i, y + i)) shift(x + i, y + i, -8);
+          }
+        }
+        if (isTeleStart(x, y)) {
+          const ul = isTeleStart(x - 1, y - 1);
+          const dr = isTeleStart(x + 1, y + 1);
+          if (!ul && dr && !isTeleStart(x, y - 1) && !isTeleStart(x - 1, y)) {
+            shift(x, y, 16);
+          } else {
+            if (!ul && dr) shift(x, y, 16);
+            if (!dr && ul) shift(x, y, -16);
+          }
+        }
+        // Grain — Math.floor(Math.random()*11) − 5 ∈ [-5, 5].
+        shift(x, y, ((Math.random() * 11) | 0) - 5);
+      }
+    }
   }
 
   drawFrame(

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -45,24 +45,6 @@ interface TrackInfoLine {
   numBestPar: number;
 }
 
-const CATEGORY_NAMES: Record<number, string> = {
-  1: "Basic",
-  2: "Traditional",
-  3: "Modern",
-  4: "HIO",
-  5: "Short",
-  6: "Long",
-};
-
-/** Parse a "C <csv>" line value into category IDs. */
-function parseCategories(s: string | null): number[] {
-  if (!s) return [];
-  return s
-    .split(",")
-    .map((p) => parseInt(p.trim(), 10))
-    .filter((n) => Number.isFinite(n) && n > 0);
-}
-
 function parseInfoLine(s: string | null): TrackInfoLine | null {
   if (!s) return null;
   const parts = s.split(",");
@@ -141,7 +123,6 @@ export class GamePanel implements Panel {
   private atlases: Atlases | null = null;
   private scoreboardEl: HTMLElement | null = null;
   private trackTitleEl: HTMLElement | null = null;
-  private trackTagsEl: HTMLElement | null = null;
   private trackAuthorEl: HTMLElement | null = null;
   private trackProgressEl: HTMLElement | null = null;
   private bestParEl: HTMLElement | null = null;
@@ -231,15 +212,9 @@ export class GamePanel implements Panel {
     const trackProgress = document.createElement("div");
     const trackTitle = document.createElement("div");
     trackTitle.style.fontWeight = "bold";
-    const trackTags = document.createElement("div");
-    trackTags.style.display = "flex";
-    trackTags.style.gap = "3px";
-    trackTags.style.flexWrap = "wrap";
-    trackTags.style.marginTop = "1px";
     const trackAuthor = document.createElement("div");
     left.appendChild(trackProgress);
     left.appendChild(trackTitle);
-    left.appendChild(trackTags);
     left.appendChild(trackAuthor);
 
     const center = document.createElement("div");
@@ -287,7 +262,6 @@ export class GamePanel implements Panel {
     this.canvas = canvas;
     this.trackProgressEl = trackProgress;
     this.trackTitleEl = trackTitle;
-    this.trackTagsEl = trackTags;
     this.trackAuthorEl = trackAuthor;
     this.statusEl = statusEl;
     this.strokeCountEl = strokeCountEl;
@@ -378,7 +352,6 @@ export class GamePanel implements Panel {
     this.strokeCountEl = null;
     this.trackProgressEl = null;
     this.trackTitleEl = null;
-    this.trackTagsEl = null;
     this.trackAuthorEl = null;
     this.avgParEl = null;
     this.bestParEl = null;
@@ -570,8 +543,7 @@ export class GamePanel implements Panel {
       const name = extractField(f, "N ") ?? "";
       const info = parseInfoLine(extractField(f, "I "));
       const bestPlayer = (extractField(f, "B ") ?? "").split(",")[0] ?? "";
-      const tags = parseCategories(extractField(f, "C "));
-      this.setTrackMeta(author, name, info, bestPlayer, tags);
+      this.setTrackMeta(author, name, info, bestPlayer);
 
       this.setStatus("Click to shoot when you're ready.");
       this.removeOverlay();
@@ -768,7 +740,6 @@ export class GamePanel implements Panel {
     name: string,
     info: TrackInfoLine | null,
     bestPlayer: string,
-    tags: number[] = [],
   ): void {
     if (this.trackProgressEl) {
       this.trackProgressEl.textContent = `Track ${this.currentTrackIdx}/${this.numTracks}`;
@@ -778,23 +749,6 @@ export class GamePanel implements Panel {
     this.trackName = name;
     this.trackAverage = info && info.plays > 0 ? info.totalStrokes / info.plays : 0;
     if (this.trackTitleEl) this.trackTitleEl.textContent = name;
-    if (this.trackTagsEl) {
-      while (this.trackTagsEl.firstChild) {
-        this.trackTagsEl.removeChild(this.trackTagsEl.firstChild);
-      }
-      for (const tagId of tags) {
-        const name = CATEGORY_NAMES[tagId];
-        if (!name) continue;
-        const chip = document.createElement("span");
-        chip.textContent = name;
-        chip.style.fontSize = "10px";
-        chip.style.padding = "0 4px";
-        chip.style.background = "#406040";
-        chip.style.color = "#fff";
-        chip.style.borderRadius = "2px";
-        this.trackTagsEl.appendChild(chip);
-      }
-    }
     if (this.trackAuthorEl) {
       this.trackAuthorEl.textContent = author ? `by ${author}` : "";
     }

--- a/port/web/src/panels/login.ts
+++ b/port/web/src/panels/login.ts
@@ -160,12 +160,21 @@ export class LoginPanel implements Panel {
     this.setEnabled(false);
 
     const lang = (this.langSelect?.value ?? "en") as Lang;
+    const rawNick = (this.nameInput?.value ?? "").trim();
+    // Server-side sanitiser will accept/reject; we only strip our own framing
+    // chars here so we never split the packet on the wire.
+    const nick = rawNick.replace(/[\r\n\t]+/g, " ").slice(0, 20);
 
     // Full guest-login handshake. The server processes these in order; the
     // final `login` is what triggers basicinfo + status\tlobbyselect.
+    // `nick` is the port's extension to the original handshake — the server
+    // uses it as the player's display name instead of the random `~anonym-`
+    // placeholder, so other players (and ghost labels in daily mode) see the
+    // name the user chose at the login screen.
     this.app.connection.sendData("version", 35);
     this.app.connection.sendData("language", lang);
     this.app.connection.sendData("logintype", "nr");
+    if (nick) this.app.connection.sendData("nick", nick);
     this.app.connection.sendData("login");
 
     this.setStatus("Authenticating...");


### PR DESCRIPTION
- Login form now sends a `nick` packet so the user's chosen name flows through to scoreboards and daily-mode ghost labels (server sanitises and falls back to the random anonym placeholder if absent).
- DailyGame.joinDaily resets numberIndex / playStatus / stroke counters when the singleton room becomes empty, and pads playStatus to numberIndex (id-capacity) instead of players.length so re-entrants and sparse-id late joiners aren't silently rejected at the beginstroke gate. Regression covered in test-daily.ts.
- Tile background gets the original GameBackgroundCanvas edge-light pass: corner highlight, bevel edges, 7-px drop shadow on solids, ±16 on teleport markers, ±5 grain. One-time at track build.
- Track info panel drops the category tag chips (not part of the original UI) and the now-unused CATEGORY_NAMES helper.