### PR TITLE
Port: movable & sunkable blocks (tile IDs 27, 46)

### DIFF
--- a/port/docs/KNOWN_ISSUES.md
+++ b/port/docs/KNOWN_ISSUES.md
@@ -60,10 +60,11 @@ Things we deferred for MVP that the original Java game has:
   ignore the flag. Adding it has determinism implications — any per-iteration
   call ordering must match between clients. The collision math is in
   `GameCanvas.handlePlayerCollisions`.
-- **Movable / sunkable blocks (27, 46) sliding behaviour.** Walls work; but
-  the block doesn't actually slide when hit.
 - **Breakable blocks (40–43) visual updates.** Bounce works; the wall
-  doesn't visually crack/decay.
+  doesn't visually crack/decay. (The mutate-tile / dirty-tile drain plumbing
+  added for movable blocks is reusable here — call `mutateTile` with the
+  decayed shape code from inside the wall-collision dispatch and the
+  renderer will pick up the change automatically.)
 - **3D shading on tile rendering.** The original adds light/shadow at higher
   graphics-quality settings via `GameBackgroundCanvas.drawMap`.
 - **Sound playback.** All 8 .wav files are bundled in
@@ -118,6 +119,24 @@ A few non-obvious pitfalls when modifying things:
 - **HMR delivers physics changes instantly.** The Vite dev server hot-reloads
   edits to anything in `web/src/`. Server changes need a restart of `npm run
   dev:server`.
+
+## Caveats from the recent movable-blocks port
+
+- **Movable-block (27/46) sync in async play.** The implementation is fully
+  client-deterministic: each client mutates `parsedMap.tiles[][]` from the
+  same shared seed, so block positions converge without any new packet. The
+  `canMovableBlockMove` obstruction check uses an `otherPlayers` snapshot
+  taken at beginstroke (in `panels/game.ts`) and skips any peer who is
+  currently mid-stroke — that keeps the check deterministic across clients
+  even when multiple balls are in flight.
+- **Late joiners see the original block layout, not the current one.** Same
+  class as the daily-mode resting-ghost issue: a player who joins a multi
+  game after blocks have already been pushed around won't see the current
+  positions until the next `starttrack` resets the map. To fix properly
+  we'd need a `game blockstate` snapshot in the join sequence; deferred.
+- **A player whose stroke crashes/exits mid-motion can leave the block state
+  diverged on their machine.** Recovery is implicit: on the next
+  `starttrack` (next hole) the map rebuilds from the original `T` line.
 
 ## Resolved (kept for posterity)
 

--- a/port/web/src/game/map.ts
+++ b/port/web/src/game/map.ts
@@ -39,6 +39,91 @@ export interface ParsedMap {
    * units as Java state.magnetMap (clamped to ±2047). null if no magnets.
    */
   magnetMap: Int16Array | null;
+  /**
+   * Tile coords [tx, ty] that have been mutated since the last drain. Movable
+   * and breakable blocks push entries here when they change; the renderer
+   * drains the queue once per frame and re-blits the affected tiles into
+   * its cached background canvas.
+   */
+  dirtyTiles: Array<[number, number]>;
+  /** Atlases the map was built against — held for in-place re-rasterization. */
+  atlases: Atlases;
+}
+
+/**
+ * Rasterize one tile's 15×15 pixels into the collision map. Shared by
+ * `buildMap` (whole-map build) and `mutateTile` (in-place updates) so the
+ * substitution rules — shape 24/26/33/35/37/39 fall through to background,
+ * bricks 40-43 keep their shape ID, magnets 44/45 have water-aware fallback —
+ * can never drift between build and mutate paths.
+ */
+function rasterizeCollisionTile(
+  collision: Uint8Array,
+  tx: number,
+  ty: number,
+  code: number,
+  atlases: Atlases,
+): void {
+  const u = unpackTile(code);
+  const special = u.isNoSpecial;
+  const shape = u.shape;
+  const bg = u.fore;
+  const fg = u.back;
+
+  // Empty tile (special === 0): clear pixels to 0 so isWall/colAt don't see
+  // stale wall data from a previous mutation.
+  if (special === 0) {
+    for (let py = 0; py < PIXEL_PER_TILE; py++) {
+      for (let px = 0; px < PIXEL_PER_TILE; px++) {
+        const cx = tx * PIXEL_PER_TILE + px;
+        const cy = ty * PIXEL_PER_TILE + py;
+        collision[cy * MAP_PIXEL_WIDTH + cx] = 0;
+      }
+    }
+    return;
+  }
+
+  const mask =
+    special === 1 ? atlases.shapeMasks[shape] : atlases.specialMasks[shape];
+  if (!mask) return;
+
+  for (let py = 0; py < PIXEL_PER_TILE; py++) {
+    for (let px = 0; px < PIXEL_PER_TILE; px++) {
+      const m = mask[py * PIXEL_PER_TILE + px];
+      let pixel: number;
+      if (special === 1) {
+        pixel = m === 1 ? bg : fg;
+      } else {
+        const s = shape + 24;
+        pixel = m === 1 ? bg : s;
+        if (s === 24) pixel = bg;
+        else if (s === 26) pixel = bg;
+        else if (s === 33 || s === 35 || s === 37 || s === 39) pixel = bg;
+        else if (s >= 40 && s <= 43) pixel = s;
+        else if (s === 44) {
+          pixel =
+            bg !== 12 && bg !== 13 && bg !== 14 && bg !== 15 ? s : bg;
+        } else if (s === 45) pixel = bg;
+      }
+      const cx = tx * PIXEL_PER_TILE + px;
+      const cy = ty * PIXEL_PER_TILE + py;
+      collision[cy * MAP_PIXEL_WIDTH + cx] = pixel & 0xff;
+    }
+  }
+}
+
+/**
+ * In-place tile update used by movable/breakable blocks during physics.
+ * Mutates `tiles[tx][ty]`, re-rasterizes the 15×15 collision pixels, and
+ * appends the tile to `dirtyTiles` so the renderer can refresh its cached
+ * background. Safe to call multiple times per frame for the same tile —
+ * the renderer dedupes naturally because the final state is what gets blitted.
+ */
+export function mutateTile(map: ParsedMap, tx: number, ty: number, code: number): void {
+  if (tx < 0 || tx >= TILE_WIDTH || ty < 0 || ty >= TILE_HEIGHT) return;
+  map.tiles[tx][ty] = code;
+  rasterizeCollisionTile(map.collision, tx, ty, code, map.atlases);
+  map.dirtyTiles.push([tx, ty]);
 }
 
 export function buildMap(rawTLine: string, atlases: Atlases): ParsedMap {
@@ -57,16 +142,8 @@ export function buildMap(rawTLine: string, atlases: Atlases): ParsedMap {
       const u = unpackTile(code);
       const special = u.isNoSpecial; // 0=empty, 1=elem+elem, 2=elem+special
       const shape = u.shape; // raw byte 2 (the "shapeReduced" value)
-      const bg = u.fore; // Java's `background`
-      const fg = u.back; // Java's `foreground`
 
       if (special === 0) continue;
-
-      const mask =
-        special === 1
-          ? atlases.shapeMasks[shape]
-          : atlases.specialMasks[shape];
-      if (!mask) continue;
 
       // Track start markers, teleport portals, and magnets (uses the +24 form per Java).
       if (special === 2) {
@@ -87,29 +164,7 @@ export function buildMap(rawTLine: string, atlases: Atlases): ParsedMap {
         }
       }
 
-      for (let py = 0; py < PIXEL_PER_TILE; py++) {
-        for (let px = 0; px < PIXEL_PER_TILE; px++) {
-          const m = mask[py * PIXEL_PER_TILE + px];
-          let pixel: number;
-          if (special === 1) {
-            pixel = m === 1 ? bg : fg;
-          } else {
-            const s = shape + 24;
-            pixel = m === 1 ? bg : s;
-            if (s === 24) pixel = bg;
-            else if (s === 26) pixel = bg;
-            else if (s === 33 || s === 35 || s === 37 || s === 39) pixel = bg;
-            else if (s >= 40 && s <= 43) pixel = s;
-            else if (s === 44) {
-              pixel =
-                bg !== 12 && bg !== 13 && bg !== 14 && bg !== 15 ? s : bg;
-            } else if (s === 45) pixel = bg;
-          }
-          const cx = tx * PIXEL_PER_TILE + px;
-          const cy = ty * PIXEL_PER_TILE + py;
-          collision[cy * MAP_PIXEL_WIDTH + cx] = pixel & 0xff;
-        }
-      }
+      rasterizeCollisionTile(collision, tx, ty, code, atlases);
     }
   }
 
@@ -156,6 +211,8 @@ export function buildMap(rawTLine: string, atlases: Atlases): ParsedMap {
     teleportStarts,
     teleportExits,
     magnetMap,
+    dirtyTiles: [],
+    atlases,
   };
 }
 

--- a/port/web/src/game/physics.ts
+++ b/port/web/src/game/physics.ts
@@ -8,8 +8,8 @@
 //   - Mines (28, 30): on contact, eject ball with random velocity.
 //   - Magnets (44 attract, 45 repel): apply field force from precomputed map.
 
-import { calculateFriction, type Seed } from "@minigolf/shared";
-import { colAt, MAGNET_W, type ParsedMap } from "./map.ts";
+import { calculateFriction, PIXEL_PER_TILE, TILE_WIDTH, TILE_HEIGHT, type Seed } from "@minigolf/shared";
+import { colAt, mutateTile, MAGNET_W, type ParsedMap } from "./map.ts";
 
 export interface BallState {
   x: number;
@@ -49,6 +49,18 @@ export interface PhysicsContext {
   /** Pixel coords of the active start position (chosen by gameId %). */
   startX: number;
   startY: number;
+  /**
+   * Snapshot of OTHER players' resting pixel positions at the moment this
+   * stroke's beginstroke broadcast was processed. Used by movable-block
+   * obstruction checks (Java's `state.playerX/playerY` per-player loop).
+   * `null` for any slot that's currently in motion or the shooter themselves
+   * (they're skipped in the obstruction check).
+   *
+   * Snapshotting once per stroke keeps `canMovableBlockMove` deterministic
+   * across clients even though local ball positions otherwise drift between
+   * clients during async play.
+   */
+  otherPlayers: Array<{ x: number; y: number } | null>;
 }
 
 export function newBall(x: number, y: number): BallState {
@@ -128,6 +140,145 @@ export function applyStrokeImpulse(
   ball.shoreY = ball.y;
 }
 
+/**
+ * Center-in-tile test mirroring Java `Map.isPlayerAtPosition` (Map.java:315).
+ * Pixel-precise: player is "at" tile (tx, ty) iff their CENTER is strictly
+ * inside the tile's 15×15 footprint, with a 1-px exclusion on the +x/+y
+ * edges (Java uses `< x*15 + 15 - 1`, not `<= x*15 + 15`). NOT a radius
+ * overlap — Java doesn't account for the ball's sprite size here.
+ */
+function ballOnTile(tx: number, ty: number, px: number, py: number): boolean {
+  const x0 = tx * PIXEL_PER_TILE;
+  const y0 = ty * PIXEL_PER_TILE;
+  return (
+    px > x0 && px < x0 + PIXEL_PER_TILE - 1 &&
+    py > y0 && py < y0 + PIXEL_PER_TILE - 1
+  );
+}
+
+/**
+ * Whether a movable block at (tx, ty) can slide into the destination tile.
+ * Returns the destination tile's background id (so the caller can decide
+ * if the block keeps sliding on a downhill), or -1 if the destination is
+ * not empty / contains a player.
+ *
+ * Mirrors Java `Map.canMovableBlockMove`: the destination must have
+ * `special === 1`, `shape === 0`, `bg <= 15` (no walls / specials), and no
+ * player ball overlapping it.
+ */
+function canMovableBlockMove(
+  map: ParsedMap,
+  tx: number,
+  ty: number,
+  others: Array<{ x: number; y: number } | null>,
+): number {
+  if (tx < 0 || tx >= TILE_WIDTH || ty < 0 || ty >= TILE_HEIGHT) return -1;
+  const code = map.tiles[tx][ty];
+  const special = (code >>> 24) & 0xff;
+  const shape = (code >>> 16) & 0xff;
+  const bg = (code >>> 8) & 0xff;
+  if (special !== 1 || shape !== 0 || bg > 15) return -1;
+  for (const p of others) {
+    if (!p) continue;
+    if (ballOnTile(tx, ty, p.x, p.y)) return -1;
+  }
+  return bg;
+}
+
+/**
+ * Recursively follow a sunkable block (shape 46) down a chain of downhill
+ * tiles until it either rests on flat ground or hits an obstruction. Returns
+ * `[finalTx, finalTy, finalBg]`. Mirrors Java's
+ * `calculateMovableBlockEndPosition` — same i<1078 recursion cap, same gate
+ * `!nonSunkable && background1 in 4..11`, so non-sunkable shape 27 always
+ * stops after the first slide step.
+ */
+function calculateMovableBlockEndPosition(
+  map: ParsedMap,
+  toTx: number,
+  toTy: number,
+  toBg: number,
+  nonSunkable: boolean,
+  depth: number,
+  others: Array<{ x: number; y: number } | null>,
+): [number, number, number] {
+  let result: [number, number, number] = [toTx, toTy, toBg];
+  if (!nonSunkable && toBg >= 4 && toBg <= 11 && depth < 1078) {
+    let nextTx = toTx;
+    let nextTy = toTy;
+    // Direction by downhill code (4=N, 5=NE, 6=E, 7=SE, 8=S, 9=SW, 10=W, 11=NW).
+    if (toBg === 4 || toBg === 5 || toBg === 11) nextTy--;
+    if (toBg === 8 || toBg === 7 || toBg === 9) nextTy++;
+    if (toBg === 5 || toBg === 6 || toBg === 7) nextTx++;
+    if (toBg === 9 || toBg === 10 || toBg === 11) nextTx--;
+    const nextBg = canMovableBlockMove(map, nextTx, nextTy, others);
+    if (nextBg >= 0) {
+      result = calculateMovableBlockEndPosition(
+        map, nextTx, nextTy, nextBg, nonSunkable, depth + 1, others,
+      );
+    }
+  }
+  return result;
+}
+
+/**
+ * Try to push a movable block at tile (blockTx, blockTy) one step in
+ * direction (dx, dy) (each ±1 or 0). Mutates the map in place: clears the
+ * source tile to bare floor, places the block at its rest position, and
+ * (for sunkable blocks ending on water/acid) flips it to the sunken
+ * silhouette.
+ *
+ * Returns true if the block actually moved (caller uses this to switch the
+ * ball's restitution from 0.8 → 0.325, matching Java getSpeedEffect).
+ */
+function handleMovableBlock(
+  map: ParsedMap,
+  blockTx: number,
+  blockTy: number,
+  dx: number,
+  dy: number,
+  nonSunkable: boolean,
+  others: Array<{ x: number; y: number } | null>,
+): boolean {
+  if (blockTx < 0 || blockTx >= TILE_WIDTH || blockTy < 0 || blockTy >= TILE_HEIGHT) {
+    return false;
+  }
+  const code = map.tiles[blockTx][blockTy];
+  const special = (code >>> 24) & 0xff;
+  const shape = (code >>> 16) & 0xff; // shapeReduced (Java's `shape` is +24)
+  const bg = (code >>> 8) & 0xff;
+  // Validate it really is a live movable block. The collision pixel may have
+  // been a 27/46 even if a previous push has since cleared the source — bail
+  // unless the tile-data still says it's there.
+  const fullShape = shape + 24;
+  if (special !== 2 || (fullShape !== 27 && fullShape !== 46)) return false;
+
+  const destTx = blockTx + dx;
+  const destTy = blockTy + dy;
+  const destBg = canMovableBlockMove(map, destTx, destTy, others);
+  if (destBg === -1) return false;
+
+  // Clear source tile to empty floor with the original background.
+  // 16777216 = (1 << 24): special=1, shape=0, fg=0.
+  mutateTile(map, blockTx, blockTy, 16777216 + bg * 256);
+
+  const [finalTx, finalTy, finalBg] = calculateMovableBlockEndPosition(
+    map, destTx, destTy, destBg, nonSunkable, 0, others,
+  );
+
+  if (!nonSunkable && (finalBg === 12 || finalBg === 13)) {
+    // Sunken: special=2, shapeReduced=23 (shape 47), fg=0, bg=water/acid.
+    // 35061760 = (2 << 24) | (23 << 16).
+    mutateTile(map, finalTx, finalTy, 35061760 + finalBg * 256);
+  } else {
+    // Place block at its rest tile preserving the destination background.
+    // 33554432 = (2 << 24); shapeReduced is 3 for shape 27, 22 for shape 46.
+    const shapeReduced = (nonSunkable ? 27 : 46) - 24;
+    mutateTile(map, finalTx, finalTy, 33554432 + shapeReduced * 256 * 256 + finalBg * 256);
+  }
+  return true;
+}
+
 function isWall(v: number): boolean {
   // 16..23 except 19, plus 27, 40..43, 46. Per handleWallCollision.
   if (v >= 16 && v <= 23 && v !== 19) return true;
@@ -186,10 +337,44 @@ function readNeighbors(map: ParsedMap, x: number, y: number): Neighbors {
 }
 
 /**
+ * Compute restitution for a wall hit, AND if the wall happens to be a
+ * movable/sunkable block (27/46) try to push it. Block-push uses the
+ * same per-edge offset Java's `getSpeedEffect` does: dx/dy point from the
+ * ball's centre to the neighbour we just sampled, and the block slides
+ * one tile further in that direction.
+ *
+ * The collision pixel may not always be in the block's tile (e.g. the ball
+ * grazes a wall pixel that belongs to the neighbouring tile due to mask
+ * shape) — `handleMovableBlock` validates the tile-data and bails if it
+ * isn't a real block tile, which keeps us correct for those edge cases.
+ */
+function bounceCoeff(
+  ball: BallState,
+  ctx: PhysicsContext,
+  v: number,
+  ix: number,
+  iy: number,
+  sampleDx: number,
+  sampleDy: number,
+  unitDx: number,
+  unitDy: number,
+): number {
+  if (v === 27 || v === 46) {
+    const blockTx = Math.floor((ix + sampleDx) / PIXEL_PER_TILE);
+    const blockTy = Math.floor((iy + sampleDy) / PIXEL_PER_TILE);
+    const moved = handleMovableBlock(
+      ctx.map, blockTx, blockTy, unitDx, unitDy, v === 27, ctx.otherPlayers,
+    );
+    return moved ? 0.325 : 0.8;
+  }
+  return getRestitution(v, ball);
+}
+
+/**
  * Wall collision — port of GameCanvas.handleWallCollision (lines 1205-1451).
  * Includes one-way wall (20-23) directional pass-through.
  */
-function handleWallCollision(ball: BallState, n: Neighbors): void {
+function handleWallCollision(ball: BallState, ctx: PhysicsContext, n: Neighbors, ix: number, iy: number): void {
   let top = isWall(n.t);
   let right = isWall(n.r);
   let bottom = isWall(n.b);
@@ -251,7 +436,7 @@ function handleWallCollision(ball: BallState, n: Neighbors): void {
         (ball.vx < 0 && ball.vy < 0 && -ball.vy > -ball.vx) ||
         (ball.vx > 0 && ball.vy > 0 && ball.vx > ball.vy))
     ) {
-      const e = getRestitution(n.tr, ball);
+      const e = bounceCoeff(ball, ctx, n.tr, ix, iy, DIAG_OFFSET, -DIAG_OFFSET, 1, -1);
       temp = ball.vx;
       ball.vx = ball.vy * e;
       ball.vy = temp * e;
@@ -263,7 +448,7 @@ function handleWallCollision(ball: BallState, n: Neighbors): void {
         (ball.vx > 0 && ball.vy < 0 && ball.vx > -ball.vy) ||
         (ball.vx < 0 && ball.vy > 0 && ball.vy > -ball.vx))
     ) {
-      const e = getRestitution(n.br, ball);
+      const e = bounceCoeff(ball, ctx, n.br, ix, iy, DIAG_OFFSET, DIAG_OFFSET, 1, 1);
       temp = ball.vx;
       ball.vx = -ball.vy * e;
       ball.vy = -temp * e;
@@ -275,7 +460,7 @@ function handleWallCollision(ball: BallState, n: Neighbors): void {
         (ball.vx > 0 && ball.vy > 0 && ball.vy > ball.vx) ||
         (ball.vx < 0 && ball.vy < 0 && -ball.vx > -ball.vy))
     ) {
-      const e = getRestitution(n.bl, ball);
+      const e = bounceCoeff(ball, ctx, n.bl, ix, iy, -DIAG_OFFSET, DIAG_OFFSET, -1, 1);
       temp = ball.vx;
       ball.vx = ball.vy * e;
       ball.vy = temp * e;
@@ -287,7 +472,7 @@ function handleWallCollision(ball: BallState, n: Neighbors): void {
         (ball.vx < 0 && ball.vy > 0 && -ball.vx > ball.vy) ||
         (ball.vx > 0 && ball.vy < 0 && -ball.vy > ball.vx))
     ) {
-      const e = getRestitution(n.tl, ball);
+      const e = bounceCoeff(ball, ctx, n.tl, ix, iy, -DIAG_OFFSET, -DIAG_OFFSET, -1, -1);
       temp = ball.vx;
       ball.vx = -ball.vy * e;
       ball.vy = -temp * e;
@@ -296,22 +481,22 @@ function handleWallCollision(ball: BallState, n: Neighbors): void {
   }
 
   if (top && ball.vy < 0) {
-    const e = getRestitution(n.t, ball);
+    const e = bounceCoeff(ball, ctx, n.t, ix, iy, 0, -6, 0, -1);
     ball.vx *= e;
     ball.vy *= -e;
   } else if (bottom && ball.vy > 0) {
-    const e = getRestitution(n.b, ball);
+    const e = bounceCoeff(ball, ctx, n.b, ix, iy, 0, 6, 0, 1);
     ball.vx *= e;
     ball.vy *= -e;
   }
   if (right && ball.vx > 0) {
-    const e = getRestitution(n.r, ball);
+    const e = bounceCoeff(ball, ctx, n.r, ix, iy, 6, 0, 1, 0);
     ball.vx *= -e;
     ball.vy *= e;
     return;
   }
   if (left && ball.vx < 0) {
-    const e = getRestitution(n.l, ball);
+    const e = bounceCoeff(ball, ctx, n.l, ix, iy, -6, 0, -1, 0);
     ball.vx *= -e;
     ball.vy *= e;
   }
@@ -538,7 +723,7 @@ export function step(ball: BallState, ctx: PhysicsContext): StepResult {
         handleMine(ball, ctx);
       }
 
-      handleWallCollision(ball, n);
+      handleWallCollision(ball, ctx, n, ix, iy);
     }
 
     const ix = (ball.x + 0.5) | 0;

--- a/port/web/src/game/render.ts
+++ b/port/web/src/game/render.ts
@@ -142,6 +142,72 @@ export class TrackRenderer {
     }
   }
 
+  /**
+   * Re-blit a single tile into the cached background canvas. Called after
+   * physics mutates the map (movable blocks, breakable bricks) — keeps the
+   * background image in sync with `parsedMap.tiles[][]` without rebuilding
+   * the entire 735×375 bitmap.
+   *
+   * Drained from `parsedMap.dirtyTiles` once per frame in the panel tick.
+   */
+  invalidateTile(tx: number, ty: number): void {
+    const ctx = this.bgCanvas.getContext("2d");
+    if (!ctx) return;
+    const code = this.parsedMap.tiles[tx][ty];
+    const img = ctx.createImageData(PIXEL_PER_TILE, PIXEL_PER_TILE);
+    // Default fill so empty / non-mask pixels start as the playable-area bg
+    // (white per Java default 0xFFFFFF) — matches buildBackground's empty
+    // fall-through.
+    for (let i = 0; i < img.data.length; i += 4) {
+      img.data[i] = 255;
+      img.data[i + 1] = 255;
+      img.data[i + 2] = 255;
+      img.data[i + 3] = 255;
+    }
+    // writeTile expects an ImageData sized to MAP_PIXEL_WIDTH * MAP_PIXEL_HEIGHT
+    // and writes at absolute coords. Build a tiny tile-only ImageData here
+    // and copy via a temp full-size one to reuse writeTile? Simpler: do the
+    // raster inline.
+    this.writeTileToImage(img, tx, ty, code);
+    ctx.putImageData(img, tx * PIXEL_PER_TILE, ty * PIXEL_PER_TILE);
+  }
+
+  /**
+   * Tile-local rasterizer mirroring `writeTile` but writing into a 15×15
+   * ImageData instead of an MAP_PIXEL_WIDTH × MAP_PIXEL_HEIGHT one. Kept
+   * in this class so any future changes to writeTile's substitution rules
+   * stay locally co-located.
+   */
+  private writeTileToImage(img: ImageData, _tx: number, _ty: number, code: number): void {
+    const u = unpackTile(code);
+    const special = u.isNoSpecial;
+    if (special === 0) return; // already filled white above
+    const shape = u.shape;
+    const bgIdx = u.fore;
+    const fgIdx = u.back;
+    const mask =
+      special === 1 ? this.atlases.shapeMasks[shape] : this.atlases.specialMasks[shape];
+    if (!mask) return;
+    const bgPixels = this.atlases.elementPixels[bgIdx];
+    const fgPixels =
+      special === 1
+        ? this.atlases.elementPixels[fgIdx]
+        : this.atlases.specialPixels[shape];
+    if (!bgPixels || !fgPixels) return;
+    for (let py = 0; py < PIXEL_PER_TILE; py++) {
+      for (let px = 0; px < PIXEL_PER_TILE; px++) {
+        const m = mask[py * PIXEL_PER_TILE + px];
+        const src = m === 1 ? bgPixels : fgPixels;
+        const si = (py * PIXEL_PER_TILE + px) * 4;
+        const oi = (py * PIXEL_PER_TILE + px) * 4;
+        img.data[oi] = src[si];
+        img.data[oi + 1] = src[si + 1];
+        img.data[oi + 2] = src[si + 2];
+        img.data[oi + 3] = 255;
+      }
+    }
+  }
+
   private buildBackground(): void {
     const ctx = this.bgCanvas.getContext("2d");
     if (!ctx) return;

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -610,6 +610,23 @@ export class GamePanel implements Panel {
     slot.ball.y = ballCoords.y;
 
     const mouse = decodeCoords(mouseRaw);
+    // Snapshot all OTHER players' resting positions for the movable-block
+    // obstruction check. Skip the shooter (their ball is the one moving) and
+    // any peer currently mid-stroke (we'd diverge across clients otherwise —
+    // local positions for in-flight balls aren't authoritative).
+    const otherPlayers: Array<{ x: number; y: number } | null> = [];
+    for (let pi = 0; pi < this.players.length; pi++) {
+      if (pi === id) {
+        otherPlayers.push(null);
+        continue;
+      }
+      const peer = this.players[pi];
+      if (peer.simulating || peer.ball.inHole) {
+        otherPlayers.push(null);
+        continue;
+      }
+      otherPlayers.push({ x: peer.ball.x, y: peer.ball.y });
+    }
     const ctx: PhysicsContext = {
       map: this.parsedMap,
       seed: new Seed(BigInt(seedNum)),
@@ -620,6 +637,7 @@ export class GamePanel implements Panel {
       // same per-slot spawn from the same map+gameId.
       startX: slot.startX,
       startY: slot.startY,
+      otherPlayers,
     };
     slot.ctx = ctx;
     applyStrokeImpulse(slot.ball, ctx, mouse.x, mouse.y);
@@ -950,6 +968,14 @@ export class GamePanel implements Panel {
       ctx.fillStyle = "#99ff99";
       ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
       return;
+    }
+    // Drain any tile mutations (movable blocks, breakable bricks) into the
+    // renderer's cached background. Must happen before drawFrame so the new
+    // tile state is visible this frame.
+    if (this.parsedMap && this.parsedMap.dirtyTiles.length > 0) {
+      const dirty = this.parsedMap.dirtyTiles;
+      for (const [tx, ty] of dirty) this.renderer.invalidateTile(tx, ty);
+      dirty.length = 0;
     }
     let aim: AimLine | null = null;
     const me = this.players[this.myPlayerId];


### PR DESCRIPTION
Port Java's GameCanvas.handleMovableBlock + Map.canMovableBlockMove from the original client. Each client mutates the local tile state during physics; deterministic from the shared per-stroke seed, so no new packet is needed for sync. Non-shooter positions are snapshotted at beginstroke to keep canMovableBlockMove agreement across clients in async play.