### PR TITLE
Port: shareable daily-cup replay links

### DIFF
--- a/port/web/public/style.css
+++ b/port/web/public/style.css
@@ -423,3 +423,54 @@ button.btn-blue   { background: #9090e0; border-color: #9090e0; }
   text-align: center;
   z-index: 100;
 }
+
+/* ---------- Daily replay viewer ---------- */
+
+.replay-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px;
+  gap: 6px;
+  height: 100%;
+  background: #99ff99;
+}
+
+.replay-header {
+  text-align: center;
+  font-family: "Times New Roman", Times, serif;
+}
+
+.replay-title {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.replay-meta {
+  font-size: 12px;
+  color: #333;
+}
+
+.replay-canvas {
+  border: 1px solid #000;
+  background: #000;
+  image-rendering: pixelated;
+}
+
+.replay-controls {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  font-family: "Verdana", sans-serif;
+}
+
+.replay-stroke {
+  font-size: 12px;
+  margin-left: 8px;
+}
+
+.replay-status {
+  font-size: 11px;
+  color: #444;
+  text-align: center;
+}

--- a/port/web/src/daily.ts
+++ b/port/web/src/daily.ts
@@ -100,3 +100,106 @@ export function shareText(r: DailyResult): string {
     ];
     return lines.join("\n");
 }
+
+// ----- Replay sharing -------------------------------------------------------
+//
+// A daily run is fully reproducible from the broadcast `beginstroke` packets:
+// each carries `(ballCoords, mouseCoords, seed)` and the physics is
+// deterministic. We pack the run plus the track's RLE tile data ("T <map>"
+// line value) into the URL fragment, so the link is self-contained — playback
+// works on any future day with no server lookup of past tracks.
+//
+// Lossy in two known edge cases (acceptable for v1; bounded errors because the
+// next stroke's recorded ballCoords re-snaps the ball):
+//
+// 1. `PhysicsContext.otherPlayers` — peers' resting positions feed the
+//    movable-block obstruction check. Daily-room strokes from concurrent
+//    players are NOT recorded here, so movable blocks during playback move as
+//    if the player were alone. If a daily track ever combines movable blocks
+//    with high-traffic ghost positions, divergence is possible.
+// 2. `PhysicsContext.startX/Y` — used by water-event=0 ("respawn at stroke
+//    start"). Replay sets these to the recorded ball position, which is the
+//    same value the live game uses, so this is only lossy if the original
+//    server had `waterEvent !== 0` (unlikely; daily uses default 0).
+//
+// Capturing peer positions and the per-slot spawn into the tuple would close
+// both gaps; defer until they're observed to matter.
+
+export interface DailyReplay {
+    /** Format version. Bump on breaking changes. */
+    v: 1;
+    /** UTC date key the run was played on (informational; YYYY-MM-DD). */
+    d: string;
+    /** Track display name and author (for the playback HUD). */
+    n: string;
+    a: string;
+    /** Track average for the playback share-screen, if known. */
+    avg?: number;
+    /**
+     * Raw value of the `T <map>` line from the original `starttrack` payload.
+     * Fed straight into `buildMap()` during playback. The full 32-bit per-stroke
+     * seed (broadcast by the server) embeds the original gameId, so playback
+     * doesn't need to mirror server seat assignment — we drop the ball at each
+     * stroke's recorded ballCoords and the seed alone reproduces the trajectory.
+     */
+    t: string;
+    /** Strokes in order. Tuple = [ballCoords, mouseCoords, seed]. */
+    s: Array<[string, string, number]>;
+    /** True if the player holed in; false if forfeited. */
+    holed: boolean;
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+    let bin = "";
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(s: string): Uint8Array | null {
+    try {
+        const padded = s.replace(/-/g, "+").replace(/_/g, "/")
+            + "=".repeat((4 - (s.length % 4)) % 4);
+        const bin = atob(padded);
+        const out = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+        return out;
+    } catch {
+        return null;
+    }
+}
+
+export function encodeReplay(r: DailyReplay): string {
+    const json = JSON.stringify(r);
+    const bytes = new TextEncoder().encode(json);
+    return toBase64Url(bytes);
+}
+
+export function decodeReplay(s: string): DailyReplay | null {
+    const bytes = fromBase64Url(s);
+    if (!bytes) return null;
+    try {
+        const parsed = JSON.parse(new TextDecoder().decode(bytes)) as DailyReplay;
+        if (parsed?.v !== 1) return null;
+        if (typeof parsed.t !== "string" || !Array.isArray(parsed.s)) return null;
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+/** Build a shareable URL with the replay payload in the fragment. */
+export function replayLink(r: DailyReplay): string {
+    const enc = encodeReplay(r);
+    const base = window.location.origin + window.location.pathname;
+    return `${base}#replay=${enc}`;
+}
+
+/** Pull and parse a replay from the current `window.location.hash`, if any. */
+export function readReplayFromHash(): DailyReplay | null {
+    const h = window.location.hash;
+    if (!h.startsWith("#")) return null;
+    const params = new URLSearchParams(h.slice(1));
+    const raw = params.get("replay");
+    if (!raw) return null;
+    return decodeReplay(raw);
+}

--- a/port/web/src/main.ts
+++ b/port/web/src/main.ts
@@ -1,7 +1,17 @@
 import { App } from "./app.ts";
+import { readReplayFromHash } from "./daily.ts";
+import { ReplayPanel } from "./panels/replay.ts";
 
 const root = document.getElementById("app");
 if (!root) {
   throw new Error("Missing #app root element");
 }
-new App(root).start();
+
+// Replay viewer is a separate boot path — fully self-contained, no server
+// connection. Triggered by `#replay=<base64url>` in the URL.
+const replay = readReplayFromHash();
+if (replay) {
+  new ReplayPanel(replay).mount(root);
+} else {
+  new App(root).start();
+}

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -12,7 +12,16 @@ import {
   type BallState,
   type PhysicsContext,
 } from "../game/physics.ts";
-import { copyToClipboard, dailyScore, saveDailyResult, shareText, todayKey, type DailyResult } from "../daily.ts";
+import {
+  copyToClipboard,
+  dailyScore,
+  replayLink,
+  saveDailyResult,
+  shareText,
+  todayKey,
+  type DailyReplay,
+  type DailyResult,
+} from "../daily.ts";
 
 const DEV = Boolean(import.meta.env?.DEV);
 
@@ -170,6 +179,16 @@ export class GamePanel implements Panel {
   private trackName = "";
   /** Set once we have shown the daily share screen, to avoid double-saving. */
   private dailyResultRecorded = false;
+  /**
+   * Per-stroke recording of the local player's daily run. Captured from the
+   * server's `beginstroke` broadcasts (which carry the deterministic inputs)
+   * so the run can be replayed bit-exactly without server cooperation.
+   */
+  private dailyReplayStrokes: Array<[string, string, number]> = [];
+  /** Raw `T <map>` line from the most recent starttrack — embedded in replay links. */
+  private dailyTLine: string | null = null;
+  /** Track author from starttrack — surfaced in playback HUD. */
+  private trackAuthor = "";
 
   constructor(app: App) {
     this.app = app;
@@ -544,6 +563,15 @@ export class GamePanel implements Panel {
       const info = parseInfoLine(extractField(f, "I "));
       const bestPlayer = (extractField(f, "B ") ?? "").split(",")[0] ?? "";
       this.setTrackMeta(author, name, info, bestPlayer);
+      this.trackAuthor = author;
+      // Capture the raw T-line for replay-link generation (daily only).
+      // Reset stroke recording on each starttrack so a fresh run starts clean
+      // even if the daily room rotated (date roll-over) mid-session.
+      if (this.dailyMode) {
+        this.dailyTLine = tLine;
+        this.dailyReplayStrokes = [];
+        this.dailyResultRecorded = false;
+      }
 
       this.setStatus("Click to shoot when you're ready.");
       this.removeOverlay();
@@ -620,6 +648,12 @@ export class GamePanel implements Panel {
     // is a no-op for the shooter.
     slot.cursorX = null;
     slot.cursorY = null;
+    // Record OUR strokes when in daily mode for the share-link replay. Stored
+    // raw (4-char base36 coords + uint32 seed) so encoding the link is just a
+    // straight JSON pack — no further processing needed.
+    if (this.dailyMode && id === this.myPlayerId) {
+      this.dailyReplayStrokes.push([ballRaw, mouseRaw, seedNum]);
+    }
     this.renderScoreboard();
   }
 
@@ -1125,6 +1159,46 @@ export class GamePanel implements Panel {
       });
     });
     btnRow.appendChild(copyBtn);
+
+    // "Copy replay link" — only present when we have both the track tile data
+    // (T-line) and at least one recorded stroke. Forfeit-without-shooting runs
+    // give an empty replay, which we hide rather than offering a no-op link.
+    if (this.dailyTLine && this.dailyReplayStrokes.length > 0) {
+      const replay: DailyReplay = {
+        v: 1,
+        d: dateKey,
+        n: this.trackName,
+        a: this.trackAuthor,
+        avg: this.trackAverage > 0 ? this.trackAverage : undefined,
+        t: this.dailyTLine,
+        s: this.dailyReplayStrokes,
+        holed: !!me?.holedThisTrack,
+      };
+      const linkBtn = document.createElement("button");
+      linkBtn.type = "button";
+      linkBtn.className = "btn-blue";
+      linkBtn.textContent = "Copy replay link";
+      linkBtn.addEventListener("click", () => {
+        const url = replayLink(replay);
+        void copyToClipboard(url).then((ok) => {
+          linkBtn.textContent = ok ? "Link copied!" : "Copy failed";
+          if (!ok) {
+            // Fallback: drop into a textarea the user can hand-select.
+            const ta = document.createElement("textarea");
+            ta.value = url;
+            ta.rows = 3;
+            ta.style.width = "320px";
+            ta.style.fontFamily = '"Lucida Console", monospace';
+            ta.style.fontSize = "11px";
+            ta.style.marginTop = "6px";
+            ov.appendChild(ta);
+            ta.select();
+          }
+          window.setTimeout(() => { linkBtn.textContent = "Copy replay link"; }, 2000);
+        });
+      });
+      btnRow.appendChild(linkBtn);
+    }
 
     const backBtn = document.createElement("button");
     backBtn.type = "button";

--- a/port/web/src/panels/replay.ts
+++ b/port/web/src/panels/replay.ts
@@ -1,0 +1,328 @@
+/**
+ * Daily replay viewer. Self-contained playback of a recorded daily run from
+ * a `#replay=<base64url>` URL fragment.
+ *
+ * Determinism: the recording stores each stroke as `(ballCoords, mouseCoords,
+ * seed)`. The 32-bit seed already embeds the original gameId — feeding it to
+ * `new Seed(BigInt(seed))` and replaying via the same physics path the live
+ * game uses for peers reproduces the trajectory bit-exactly. We don't need a
+ * server connection, the original gameId, or seat assignment; we just drop
+ * the ball at each stroke's start and watch.
+ *
+ * Pacing: strokes fire one at a time. The next stroke arms only after the
+ * current ball comes to rest, mirroring the way GamePanel sequences peers.
+ */
+
+import { PacketType, Seed, type Packet } from "@minigolf/shared";
+import { loadAtlases, type Atlases } from "../game/sprites.ts";
+import { buildMap, type ParsedMap } from "../game/map.ts";
+import { TrackRenderer } from "../game/render.ts";
+import {
+  applyStrokeImpulse,
+  newBall,
+  PHYSICS_STEP_MS,
+  step,
+  type BallState,
+  type PhysicsContext,
+} from "../game/physics.ts";
+import type { DailyReplay } from "../daily.ts";
+import type { Panel } from "../panel.ts";
+
+const DEV = Boolean(import.meta.env?.DEV);
+
+function decodeCoords(s: string): { x: number; y: number } {
+  const v = parseInt(s, 36);
+  return { x: Math.floor(v / 1500), y: Math.floor((v % 1500) / 4) };
+}
+
+export class ReplayPanel implements Panel {
+  private replay: DailyReplay;
+  private root: HTMLElement | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private statusEl: HTMLElement | null = null;
+  private strokeEl: HTMLElement | null = null;
+  private playBtn: HTMLButtonElement | null = null;
+
+  private atlases: Atlases | null = null;
+  private parsedMap: ParsedMap | null = null;
+  private renderer: TrackRenderer | null = null;
+  private ball: BallState;
+  private ctx: PhysicsContext | null = null;
+
+  private strokeIdx = 0;
+  private simulating = false;
+  private paused = true;
+  private finished = false;
+
+  private rafHandle = 0;
+  private physicsAccumMs = 0;
+  private lastTickMs = 0;
+
+  constructor(replay: DailyReplay) {
+    this.replay = replay;
+    // Initial ball position is taken from the first stroke's ballCoords once
+    // the map is built; this default just gives us a non-null ball before then.
+    this.ball = newBall(367.5, 187.5);
+  }
+
+  mount(root: HTMLElement): void {
+    this.root = root;
+    root.classList.add("replay-root");
+
+    const wrap = document.createElement("div");
+    wrap.className = "replay-wrap";
+    root.appendChild(wrap);
+
+    const header = document.createElement("div");
+    header.className = "replay-header";
+    const title = document.createElement("div");
+    title.className = "replay-title";
+    title.textContent = `Daily Cup Replay — ${this.replay.d}`;
+    const meta = document.createElement("div");
+    meta.className = "replay-meta";
+    const tn = this.replay.n || "(unknown track)";
+    const ta = this.replay.a ? ` by ${this.replay.a}` : "";
+    meta.textContent = `${tn}${ta}`;
+    header.appendChild(title);
+    header.appendChild(meta);
+    wrap.appendChild(header);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 735;
+    canvas.height = 375;
+    canvas.className = "replay-canvas";
+    wrap.appendChild(canvas);
+    this.canvas = canvas;
+
+    const controls = document.createElement("div");
+    controls.className = "replay-controls";
+
+    this.playBtn = document.createElement("button");
+    this.playBtn.type = "button";
+    this.playBtn.className = "btn-green";
+    this.playBtn.textContent = "Play";
+    this.playBtn.addEventListener("click", () => this.togglePlay());
+    controls.appendChild(this.playBtn);
+
+    const restartBtn = document.createElement("button");
+    restartBtn.type = "button";
+    restartBtn.className = "btn-blue";
+    restartBtn.textContent = "Restart";
+    restartBtn.addEventListener("click", () => this.restart());
+    controls.appendChild(restartBtn);
+
+    const exitBtn = document.createElement("button");
+    exitBtn.type = "button";
+    exitBtn.className = "btn-blue";
+    exitBtn.textContent = "Exit replay";
+    exitBtn.addEventListener("click", () => {
+      // Clearing the hash & reloading drops us back into the regular app boot.
+      window.location.hash = "";
+      window.location.reload();
+    });
+    controls.appendChild(exitBtn);
+
+    this.strokeEl = document.createElement("span");
+    this.strokeEl.className = "replay-stroke";
+    controls.appendChild(this.strokeEl);
+
+    wrap.appendChild(controls);
+
+    this.statusEl = document.createElement("div");
+    this.statusEl.className = "replay-status";
+    this.statusEl.textContent = "Loading sprites…";
+    wrap.appendChild(this.statusEl);
+
+    this.boot();
+  }
+
+  unmount(): void {
+    if (this.rafHandle) cancelAnimationFrame(this.rafHandle);
+    this.rafHandle = 0;
+    if (this.root) this.root.classList.remove("replay-root");
+    this.root = null;
+  }
+
+  // ReplayPanel never receives network packets, but the Panel interface needs
+  // this method. Stub: no-op.
+  onPacket(_p: Packet): void {
+    void _p;
+    void PacketType;
+  }
+
+  // ----- boot -----------------------------------------------------------
+
+  private async boot(): Promise<void> {
+    try {
+      this.atlases = await loadAtlases();
+      this.parsedMap = buildMap(this.replay.t, this.atlases);
+      this.renderer = new TrackRenderer(this.parsedMap, this.atlases);
+      this.placeAtFirstStrokeOrigin();
+      this.updateStrokeLabel();
+      this.setStatus(this.replay.s.length > 0
+        ? `Press Play to watch ${this.replay.s.length} stroke${this.replay.s.length === 1 ? "" : "s"}.`
+        : "No strokes recorded — this run was forfeited before shooting.");
+      this.draw();
+      this.startLoop();
+    } catch (err) {
+      if (DEV) console.warn("[replay] boot failed", err);
+      this.setStatus("Replay failed to load: " + String(err));
+    }
+  }
+
+  private placeAtFirstStrokeOrigin(): void {
+    if (this.replay.s.length > 0) {
+      const c = decodeCoords(this.replay.s[0][0]);
+      this.ball = newBall(c.x, c.y);
+    } else {
+      // Empty recording — drop the ball roughly centre-ish so the canvas
+      // isn't blank. The user only sees this when the run was forfeited
+      // without a single shot.
+      this.ball = newBall(367.5, 187.5);
+    }
+  }
+
+  // ----- controls -------------------------------------------------------
+
+  private togglePlay(): void {
+    if (this.finished) {
+      this.restart();
+      return;
+    }
+    this.paused = !this.paused;
+    if (this.playBtn) this.playBtn.textContent = this.paused ? "Play" : "Pause";
+    if (!this.paused && !this.simulating) {
+      this.armNextStroke();
+    }
+  }
+
+  private restart(): void {
+    this.strokeIdx = 0;
+    this.simulating = false;
+    this.finished = false;
+    this.paused = true;
+    if (this.playBtn) this.playBtn.textContent = "Play";
+    this.placeAtFirstStrokeOrigin();
+    this.updateStrokeLabel();
+    this.setStatus(this.replay.s.length > 0
+      ? `Press Play to watch ${this.replay.s.length} stroke${this.replay.s.length === 1 ? "" : "s"}.`
+      : "No strokes recorded.");
+    this.draw();
+  }
+
+  private armNextStroke(): void {
+    if (!this.parsedMap) return;
+    if (this.strokeIdx >= this.replay.s.length) {
+      this.finishPlayback();
+      return;
+    }
+    const [ballRaw, mouseRaw, seedNum] = this.replay.s[this.strokeIdx];
+    const b = decodeCoords(ballRaw);
+    const m = decodeCoords(mouseRaw);
+
+    // Snap the ball to the recorded start-of-stroke position. Even if our
+    // local sim drifted by a sub-pixel from the original (it shouldn't, but
+    // defence-in-depth), this keeps each subsequent stroke faithful.
+    this.ball.x = b.x;
+    this.ball.y = b.y;
+
+    this.ctx = {
+      map: this.parsedMap,
+      seed: new Seed(BigInt(seedNum >>> 0)),
+      norandom: false,
+      // Replay is single-ball with no live water-event metadata. 0 = "respawn
+      // at stroke start", which is the most common server setting and the
+      // safest default — a rare edge case where a daily track sends the ball
+      // into water on shore-respawn would visually diverge, but the recorded
+      // ballCoords for the next stroke would re-snap it before then.
+      waterEvent: 0,
+      startX: this.ball.x,
+      startY: this.ball.y,
+      // Single-ball replay — no peers to obstruct movable blocks. Pad to
+      // length 1 since the obstruction loop is keyed by index.
+      otherPlayers: [null],
+    };
+    applyStrokeImpulse(this.ball, this.ctx, m.x, m.y);
+    this.simulating = true;
+    this.strokeIdx++;
+    this.updateStrokeLabel();
+  }
+
+  private finishPlayback(): void {
+    this.finished = true;
+    this.paused = true;
+    this.simulating = false;
+    if (this.playBtn) this.playBtn.textContent = "Restart";
+    const verb = this.replay.holed ? "Holed in" : "Forfeited at";
+    const n = this.replay.s.length;
+    this.setStatus(`${verb} ${n} stroke${n === 1 ? "" : "s"}.`);
+  }
+
+  // ----- physics tick ---------------------------------------------------
+
+  private startLoop(): void {
+    const tick = () => {
+      this.rafHandle = requestAnimationFrame(tick);
+      this.draw();
+      if (this.paused || !this.simulating || !this.ctx) {
+        this.lastTickMs = 0;
+        this.physicsAccumMs = 0;
+        return;
+      }
+      const now = performance.now();
+      if (this.lastTickMs === 0) this.lastTickMs = now;
+      const elapsed = now - this.lastTickMs;
+      this.lastTickMs = now;
+      this.physicsAccumMs += Math.min(elapsed, 100);
+      let safety = 200;
+      while (this.physicsAccumMs >= PHYSICS_STEP_MS && safety-- > 0 && this.simulating) {
+        this.physicsAccumMs -= PHYSICS_STEP_MS;
+        const r = step(this.ball, this.ctx);
+        if (r.stopped) {
+          this.simulating = false;
+          if (this.strokeIdx >= this.replay.s.length) {
+            this.finishPlayback();
+          } else {
+            // Brief pause between strokes so the viewer can register the stop.
+            window.setTimeout(() => {
+              if (!this.paused) this.armNextStroke();
+            }, 350);
+          }
+        }
+      }
+    };
+    this.rafHandle = requestAnimationFrame(tick);
+  }
+
+  // ----- render ---------------------------------------------------------
+
+  private draw(): void {
+    if (!this.canvas || !this.renderer) return;
+    const c = this.canvas.getContext("2d");
+    if (!c) return;
+    this.renderer.drawFrame(
+      c,
+      [{
+        x: this.ball.x,
+        y: this.ball.y,
+        playerIdx: 0,
+        moving: false,
+        hidden: this.ball.inHole,
+      }],
+      null,
+    );
+  }
+
+  private setStatus(s: string): void {
+    if (this.statusEl) this.statusEl.textContent = s;
+  }
+
+  private updateStrokeLabel(): void {
+    if (!this.strokeEl) return;
+    const total = this.replay.s.length;
+    // strokeIdx is incremented when a stroke is armed, so it doubles as the
+    // 1-based count of strokes already started.
+    const cur = Math.min(this.strokeIdx, total);
+    this.strokeEl.textContent = total > 0 ? `Stroke ${cur} / ${total}` : "";
+  }
+}


### PR DESCRIPTION
Daily strokes are already deterministic from the server's broadcast (ballCoords, mouseCoords, seed) per beginstroke — capture them on the local player, pack them with the track's RLE tile data into a base64url URL fragment, and offer "Copy replay link" on the daily share screen. A new ReplayPanel boots from #replay=<...> and replays the run through the same physics path the live game uses, with no server connection.