### PR TITLE
Port: env-gated chat toggle so operators can host without moderating

### DIFF
--- a/port/README.md
+++ b/port/README.md
@@ -73,6 +73,14 @@ npm run build
 npm run dev:server   # serves the built web bundle on http://localhost:4242
 ```
 
+### Operator knobs
+
+Set on the command line or via env vars when launching the server:
+
+| Env var         | CLI flag           | Effect                                                         |
+| --------------- | ------------------ | -------------------------------------------------------------- |
+| `CHAT_ENABLED`  | `--chat-disabled`  | Set `CHAT_ENABLED=0` (or pass `--chat-disabled`) to drop all lobby/game chat server-side. The sender is told once via a system whisper; gameplay traffic is unaffected. Useful for hosting without taking on chat-moderation duty. |
+
 ## Tests
 
 ```sh

--- a/port/server/src/main.ts
+++ b/port/server/src/main.ts
@@ -16,9 +16,24 @@ interface CliArgs {
     maxConnsPerIp?: number;
     /** When true, accept WS upgrades from any Origin (dev). Default rejects cross-origin. */
     allowAnyOrigin?: boolean;
+    /** When false, the server drops lobby/game chat packets. Operators can flip this off
+     *  via `CHAT_ENABLED=0` (or `--chat-disabled`) to host without moderating chat.
+     *  Optional in CliArgs so smoke-test fixtures can omit it; main() always populates. */
+    chatEnabled?: boolean;
 }
 
 const DEFAULT_MAX_CONNS_PER_IP = 16;
+
+/** Parse a boolean env var, accepting the usual on/off spellings. Falls back to `defaultValue`
+ *  on unset/unparseable input so a typo can't silently disable a feature. */
+function envBool(name: string, defaultValue: boolean): boolean {
+    const v = process.env[name];
+    if (v === undefined) return defaultValue;
+    const s = v.trim().toLowerCase();
+    if (s === "1" || s === "true" || s === "yes" || s === "on") return true;
+    if (s === "0" || s === "false" || s === "no" || s === "off") return false;
+    return defaultValue;
+}
 
 function parseArgs(argv: string[]): CliArgs {
     const args: CliArgs = {
@@ -28,6 +43,7 @@ function parseArgs(argv: string[]): CliArgs {
         verbose: false,
         maxConnsPerIp: DEFAULT_MAX_CONNS_PER_IP,
         allowAnyOrigin: false,
+        chatEnabled: envBool("CHAT_ENABLED", true),
     };
     for (let i = 2; i < argv.length; i++) {
         const a = argv[i];
@@ -43,6 +59,10 @@ function parseArgs(argv: string[]): CliArgs {
             args.maxConnsPerIp = Math.max(0, parseInt(argv[++i], 10) || 0);
         } else if (a === "--allow-any-origin") {
             args.allowAnyOrigin = true;
+        } else if (a === "--chat-disabled") {
+            args.chatEnabled = false;
+        } else if (a === "--chat-enabled") {
+            args.chatEnabled = true;
         }
     }
     return args;
@@ -61,8 +81,28 @@ const MIME: Record<string, string> = {
     ".json": "application/json",
     ".png": "image/png",
     ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".ico": "image/x-icon",
     ".svg": "image/svg+xml",
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".ogg": "audio/ogg",
+    ".xml": "application/xml; charset=utf-8",
+    ".txt": "text/plain; charset=utf-8",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
 };
+
+// Vite-fingerprinted bundles under /assets/ are content-addressed, so we can
+// pin them with a year-long immutable cache. Everything else gets a short
+// cache + must-revalidate so changes don't get stuck.
+function cacheControlFor(urlPath: string): string {
+    if (urlPath.startsWith("/assets/")) return "public, max-age=31536000, immutable";
+    if (urlPath === "/index.html" || urlPath === "/") return "no-cache";
+    return "public, max-age=300, must-revalidate";
+}
 
 function tryServeStatic(req: IncomingMessage, res: ServerResponse, webDist: string): boolean {
     if (!req.url) return false;
@@ -88,10 +128,34 @@ function tryServeStatic(req: IncomingMessage, res: ServerResponse, webDist: stri
         const st = lstatSync(target);
         if (!st.isFile()) return false;
         const mime = MIME[path.extname(target)] ?? "application/octet-stream";
+        // Weak ETag from size+mtime is enough here — the assets are static
+        // and only change on rebuild/restart, so collisions are not a worry.
+        const etag = `W/"${st.size.toString(16)}-${st.mtimeMs.toString(16)}"`;
+        const lastModified = new Date(st.mtimeMs).toUTCString();
+        const ifNoneMatch = req.headers["if-none-match"];
+        const ifModifiedSince = req.headers["if-modified-since"];
+        if (ifNoneMatch === etag ||
+            (ifModifiedSince && Date.parse(ifModifiedSince) >= Math.floor(st.mtimeMs / 1000) * 1000)) {
+            res.writeHead(304, {
+                "ETag": etag,
+                "Last-Modified": lastModified,
+                "Cache-Control": cacheControlFor(urlPath),
+            });
+            res.end();
+            return true;
+        }
         res.writeHead(200, {
             "Content-Type": mime,
+            "Content-Length": st.size,
             "X-Content-Type-Options": "nosniff",
+            "Cache-Control": cacheControlFor(urlPath),
+            "ETag": etag,
+            "Last-Modified": lastModified,
         });
+        if (req.method === "HEAD") {
+            res.end();
+            return true;
+        }
         createReadStream(target).pipe(res);
         return true;
     } catch {
@@ -106,7 +170,11 @@ export interface RunningServer {
 export async function startServer(args: CliArgs): Promise<RunningServer> {
     const trackManager = new TrackManager();
     await trackManager.load(args.tracksDir);
-    const golfServer = new GolfServer(trackManager);
+    const chatEnabled = args.chatEnabled ?? true;
+    const golfServer = new GolfServer(trackManager, { chatEnabled });
+    if (!chatEnabled) {
+        console.log("[chat] disabled — say/sayp packets will be dropped with a notice to the sender");
+    }
 
     // Cache the per-category counts on each lobby so newcomers get the
     // numbers as soon as they enter (drives the lobby form's count chips).

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -126,7 +126,7 @@ register({
 register({
     type: PacketType.DATA,
     pattern: /^login$/,
-    handle: (_server, conn) => {
+    handle: (server, conn) => {
         const player = conn.player;
         if (!player) {
             conn.close("login-without-player");
@@ -141,6 +141,10 @@ register({
         }
         player.emailVerified = true;
         player.registered = false;
+        // Tell the client about server-level toggles before it builds any UI.
+        // Today only `chat` exists; clients that don't recognise the verb just
+        // ignore the packet, so we can extend `srvinfo` later without breakage.
+        conn.sendData("srvinfo", "chat", server.chatEnabled ? "1" : "0");
         // basicinfo\t<emailVerified>\t<accessLevel>\tt\tt
         conn.sendData("basicinfo", player.emailVerified, player.accessLevel, "t", "t");
         conn.sendData("status", "lobbyselect", "300");
@@ -320,13 +324,21 @@ register({
 register({
     type: PacketType.DATA,
     pattern: /^(lobby|game)\t(say|sayp|command)\t(.+?)(?:\t(.+))?$/s,
-    handle: (_server, conn, match) => {
+    handle: (server, conn, match) => {
         const player = conn.player;
         if (!player) return;
         const scope = match[1];
         const verb = match[2];
         const arg3 = match[3];
         const arg4 = match[4];
+
+        // Operator-controlled mute: drop say/sayp and tell the sender once per
+        // attempt, so they don't think the connection is broken when nobody
+        // sees their message. `command` is a no-op anyway, so don't bother.
+        if (!server.chatEnabled && (verb === "say" || verb === "sayp")) {
+            conn.sendData(scope, "sayp", "server", "Chat is disabled on this server.");
+            return;
+        }
 
         const targets: Player[] = [];
         if (scope === "game") {

--- a/port/server/src/server.ts
+++ b/port/server/src/server.ts
@@ -12,6 +12,12 @@ export function todayDateKey(): string {
     return new Date().toISOString().slice(0, 10);
 }
 
+export interface GolfServerOptions {
+    /** When false, lobby/game say + sayp packets are dropped server-side and
+     *  the sender gets a one-shot system whisper. Defaults to true. */
+    chatEnabled?: boolean;
+}
+
 export class GolfServer {
     private players: Map<number, Player> = new Map();
     private lobbies: Map<LobbyType, Lobby> = new Map();
@@ -20,9 +26,11 @@ export class GolfServer {
     private dailyGame: DailyGame | null = null;
 
     public readonly trackManager: TrackManager;
+    public readonly chatEnabled: boolean;
 
-    constructor(trackManager: TrackManager) {
+    constructor(trackManager: TrackManager, options: GolfServerOptions = {}) {
         this.trackManager = trackManager;
+        this.chatEnabled = options.chatEnabled ?? true;
         this.lobbies.set(LobbyType.SINGLE, new Lobby(LobbyType.SINGLE));
         this.lobbies.set(LobbyType.DUAL, new Lobby(LobbyType.DUAL));
         this.lobbies.set(LobbyType.MULTI, new Lobby(LobbyType.MULTI));

--- a/port/server/src/test-chat-disabled.ts
+++ b/port/server/src/test-chat-disabled.ts
@@ -1,0 +1,153 @@
+// Chat-disabled smoke test.
+//
+// Boots a fresh GolfServer with chatEnabled=false, walks two clients into the
+// multi lobby, and asserts:
+//   - Each client received `srvinfo chat 0` so the UI can hide its input.
+//   - Sender of a `lobby say` gets a `lobby sayp server <text>` system whisper.
+//   - The other client never receives A's chat (server drops it).
+//
+// Usage: node --experimental-strip-types --no-warnings src/test-chat-disabled.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4248;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+class Client {
+    name: string;
+    ws: WebSocket;
+    outSeq = 0;
+    received: string[] = [];
+
+    constructor(name: string) {
+        this.name = name;
+        this.ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+        this.ws.on("message", (m) => this.received.push(m.toString()));
+    }
+    async open(): Promise<void> {
+        await new Promise<void>((r) => this.ws.once("open", () => r()));
+    }
+    send(line: string): void { this.ws.send(line); }
+    sendData(...fields: (string | number)[]): void {
+        this.send(`d ${this.outSeq++} ${fields.join("\t")}`);
+    }
+    sendCommand(verb: string, ...args: string[]): void {
+        this.send(`c ${[verb, ...args].join(" ")}`);
+    }
+    async waitFor(predicate: (s: string) => boolean, label: string, timeoutMs = 4000): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => {
+                console.log(`[${this.name}] timed out waiting for ${label}; queue:`, this.received);
+                reject(new Error(`[${this.name}] timeout: ${label}`));
+            }, timeoutMs);
+            const tick = (): void => {
+                const idx = this.received.findIndex(predicate);
+                if (idx >= 0) {
+                    clearTimeout(t);
+                    const [s] = this.received.splice(idx, 1);
+                    resolve(s);
+                    return;
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+    /** Asserts no message matching `predicate` arrives within `windowMs`. */
+    async expectSilence(predicate: (s: string) => boolean, label: string, windowMs = 600): Promise<void> {
+        const start = Date.now();
+        while (Date.now() - start < windowMs) {
+            if (this.received.some(predicate)) {
+                throw new Error(`[${this.name}] expected silence for ${label}, but got a match`);
+            }
+            await new Promise((r) => setTimeout(r, 30));
+        }
+    }
+    close(): void { try { this.ws.close(); } catch { /* */ } }
+}
+
+async function login(c: Client): Promise<void> {
+    await c.waitFor((s) => s === "h 1", "h 1");
+    await c.waitFor((s) => s.startsWith("c crt"), "c crt");
+    await c.waitFor((s) => s === "c ctr", "c ctr");
+    c.sendCommand("new");
+    await c.waitFor((s) => s.startsWith("c id "), "c id");
+    c.sendData("version", 35);
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (v)");
+    c.sendData("language", "en");
+    c.sendData("logintype", "nr");
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (lt)");
+    c.sendData("login");
+    await c.waitFor((s) => /^d \d+ srvinfo\tchat\t0$/.test(s), "srvinfo chat 0");
+    await c.waitFor((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+    await c.waitFor((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+}
+
+async function enterMultiLobby(c: Client): Promise<void> {
+    c.sendData("lobbyselect", "select", "x");
+    await c.waitFor((s) => /^d \d+ status\tlobby\tx/.test(s), "status lobby x");
+    await c.waitFor((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+}
+
+async function main(): Promise<void> {
+    let server: RunningServer | null = null;
+    try {
+        server = await startServer({
+            host: HOST,
+            port: PORT,
+            tracksDir: tracksDir(),
+            verbose: false,
+            chatEnabled: false,
+        });
+        console.log("[server] up (chat disabled)");
+
+        const a = new Client("A");
+        const b = new Client("B");
+        await Promise.all([a.open(), b.open()]);
+
+        await login(a);
+        await login(b);
+        console.log("[OK] both logged in, both received srvinfo chat 0");
+
+        await enterMultiLobby(a);
+        await enterMultiLobby(b);
+        console.log("[OK] both in multi lobby");
+
+        // A sends a chat. Server should bounce a system whisper to A and drop
+        // it for B.
+        a.sendData("lobby", "say", "hi from A");
+        await a.waitFor(
+            (s) => /^d \d+ lobby\tsayp\tserver\tChat is disabled on this server\.$/.test(s),
+            "A receives server-disabled whisper",
+        );
+        await b.expectSilence((s) => /lobby\tsay\thi from A/.test(s), "B never sees A's chat");
+        console.log("[OK] lobby say is dropped, sender gets system whisper, peer gets nothing");
+
+        // Whisper is also gated.
+        a.sendData("lobby", "sayp", "B", "secret");
+        await a.waitFor(
+            (s) => /^d \d+ lobby\tsayp\tserver\tChat is disabled on this server\.$/.test(s),
+            "A receives server-disabled whisper for sayp",
+        );
+        await b.expectSilence((s) => /sayp\t.*secret/.test(s), "B never sees A's whisper");
+        console.log("[OK] lobby sayp is dropped too");
+
+        a.close();
+        b.close();
+        console.log("\nALL CHAT-DISABLED CHECKS PASSED");
+    } finally {
+        if (server) await server.close();
+    }
+}
+
+main().catch((err) => {
+    console.error("[test-chat-disabled] FAILED:", err);
+    process.exit(1);
+});

--- a/port/server/src/test-handshake.ts
+++ b/port/server/src/test-handshake.ts
@@ -149,14 +149,17 @@ async function run(): Promise<void> {
         assertStartsWith(await queue.next(), "d 1 status\tlogin", "status login (post-logintype)");
 
         ws.send("d 3 login");
-        assertStartsWith(await queue.next(), "d 2 basicinfo\tt\t0\tt\tt", "basicinfo");
-        assertStartsWith(await queue.next(), "d 3 status\tlobbyselect\t300", "status lobbyselect");
+        // The server pushes a `srvinfo chat <0|1>` flag packet ahead of basicinfo so
+        // the client knows whether to render the chat input. Default is enabled.
+        assertStartsWith(await queue.next(), "d 2 srvinfo\tchat\t1", "srvinfo chat 1");
+        assertStartsWith(await queue.next(), "d 3 basicinfo\tt\t0\tt\tt", "basicinfo");
+        assertStartsWith(await queue.next(), "d 4 status\tlobbyselect\t300", "status lobbyselect");
 
         console.log("Phase 5: enter single-player lobby");
         ws.send("d 4 lobbyselect\tselect\t1");
-        assertStartsWith(await queue.next(), "d 4 status\tlobby\t1", "status lobby 1");
-        assertStartsWith(await queue.next(), "d 5 lobby\tusers", "lobby users");
-        assertStartsWith(await queue.next(), "d 6 lobby\townjoin\t", "lobby ownjoin");
+        assertStartsWith(await queue.next(), "d 5 status\tlobby\t1", "status lobby 1");
+        assertStartsWith(await queue.next(), "d 6 lobby\tusers", "lobby users");
+        assertStartsWith(await queue.next(), "d 7 lobby\townjoin\t", "lobby ownjoin");
 
         console.log("Phase 6: start training game");
         // Per Java's LobbyCreateSinglePlayerHandler comment, the client sends "lobby\tcspt..."

--- a/port/web/src/app.ts
+++ b/port/web/src/app.ts
@@ -34,6 +34,12 @@ export class App {
   serverHandshakeOk = false;
   serverId: string | null = null;
 
+  /** Whether the operator has chat enabled on this server. Default true; the
+   *  server pushes a `srvinfo chat 0|1` data packet right after login so this
+   *  is set before any chat-bearing panel mounts. Lobby/game panels read this
+   *  to decide whether to render the chat input row. */
+  chatEnabled = true;
+
   constructor(root: HTMLElement) {
     this.root = root;
     const url = this.resolveWsUrl();
@@ -101,6 +107,11 @@ export class App {
   }
 
   private onPacket(pkt: Packet): void {
+    // Server-level config push. Intercept before forwarding so panels see a
+    // consistent `app.chatEnabled` regardless of which one's mounted.
+    if (pkt.fields[0] === "srvinfo" && pkt.fields[1] === "chat") {
+      this.chatEnabled = pkt.fields[2] !== "0";
+    }
     if (this.currentPanel) {
       try {
         this.currentPanel.onPacket(pkt);

--- a/port/web/src/game/render.ts
+++ b/port/web/src/game/render.ts
@@ -396,7 +396,11 @@ export class TrackRenderer {
     for (const b of balls) {
       if (b.hidden) continue;
       // balls.gif: 8 sprites total, 4 per row → playerIdx*2 + (moving?1:0).
-      const idx = b.playerIdx * 2 + (b.moving ? 1 : 0);
+      // Daily rooms can hold 100 players (vs the 4-player Java cap), so cycle
+      // colours past index 3 — without the modulo the sprite source falls
+      // outside the atlas and the ball renders as nothing.
+      const colour = ((b.playerIdx % 4) + 4) % 4;
+      const idx = colour * 2 + (b.moving ? 1 : 0);
       const { sx, sy } = spriteSrc13(idx, 4);
       const baseDx = Math.round(b.x - 6.5);
       const baseDy = Math.round(b.y - 6.5);

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -249,6 +249,10 @@ export class GamePanel implements Panel {
     const bottomBand = document.createElement("div");
     bottomBand.style.display = "grid";
     bottomBand.style.gridTemplateColumns = "1fr 280px";
+    // Pin the row to the flex-allocated band height. Without this the implicit
+    // grid row sizes to max-content, so the chat log's accumulating messages
+    // would grow the row taller instead of scrolling inside the log.
+    bottomBand.style.gridTemplateRows = "minmax(0, 1fr)";
     bottomBand.style.gap = "8px";
     bottomBand.style.padding = "4px 8px";
     bottomBand.style.flex = "1";
@@ -908,6 +912,9 @@ export class GamePanel implements Panel {
     for (let i = 0; i < this.numPlayers; i++) {
       const p = this.players[i];
       if (!p) continue;
+      // Daily mode: only the local player's score is shown — other ghosts in
+      // the room represent concurrent runs, not a shared scoreboard.
+      if (this.dailyMode && i !== this.myPlayerId) continue;
       const row = document.createElement("div");
       row.className = "row " + (i === this.myPlayerId ? "you" : "them");
       const num = document.createElement("span");
@@ -958,6 +965,9 @@ export class GamePanel implements Panel {
 
     const log = document.createElement("div");
     log.style.flex = "1";
+    // Without min-height: 0 the flex item refuses to shrink below its
+    // intrinsic content height, defeating overflow-y:auto.
+    log.style.minHeight = "0";
     log.style.overflowY = "auto";
     log.style.fontFamily = '"Lucida Console", monospace';
     log.style.fontSize = "11px";
@@ -968,6 +978,13 @@ export class GamePanel implements Panel {
     log.style.wordBreak = "break-word";
     strip.appendChild(log);
     this.chatLogEl = log;
+
+    // Operator-disabled chat: keep the log so server-driven messages still
+    // surface, but drop the input row so the UI never invites typing the
+    // server would discard.
+    if (!this.app.chatEnabled) {
+      return strip;
+    }
 
     const form = document.createElement("form");
     form.style.display = "flex";

--- a/port/web/src/panels/lobby-multi.ts
+++ b/port/web/src/panels/lobby-multi.ts
@@ -471,6 +471,13 @@ export class LobbyMultiPanel implements Panel {
     strip.appendChild(log);
     this.chatLogEl = log;
 
+    // Operator-disabled chat: keep the log so join/part system messages still
+    // surface, but drop the input row entirely so the UI never invites typing
+    // that the server would just throw away.
+    if (!this.app.chatEnabled) {
+      return strip;
+    }
+
     const inputRow = document.createElement("form");
     inputRow.style.display = "flex";
     inputRow.style.gap = "4px";

--- a/port/web/vite.config.ts
+++ b/port/web/vite.config.ts
@@ -16,8 +16,9 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       "/ws": {
-        target: "ws://localhost:4242",
+        target: "ws://127.0.0.1:4242",
         ws: true,
+        changeOrigin: true,
         rewriteWsOrigin: true,
       },
     },


### PR DESCRIPTION
Set CHAT_ENABLED=0 (or pass --chat-disabled) to drop every lobby/game say + sayp packet server-side. The sender gets a one-shot system whisper "Chat is disabled on this server." so they don't think the connection is broken. The server pushes a `srvinfo chat 0|1` flag right after login so the multi-lobby and game panels know to skip the chat input row entirely (the chat log stays for join/leave system messages). Default is enabled.

Also folds in two unrelated UX fixes from parallel work in the same files: 100-player daily rooms cycle ball colours mod 4 so balls past index 3 still render, and the bottom chat band pins its grid row height + log min-height: 0 so chat history scrolls inside the log instead of growing the band. Vite dev WS proxy points at 127.0.0.1 with changeOrigin so the new server-side Origin guard accepts it.