### PR TITLE
Port: reconnect after network blip via `c old <id>` handshake

### DIFF
--- a/port/docs/KNOWN_ISSUES.md
+++ b/port/docs/KNOWN_ISSUES.md
@@ -63,8 +63,15 @@ Things we deferred for MVP that the original Java game has:
   through 4 aim modes (solid + 3 dashed-line rotations). We only have mode 0.
 - **Rating tracks.** Server stub exists (`game rate <track> <rating>`) but
   no UI; ratings aren't persisted (FileSystemStatsManager is read-only).
-- **Reconnect after network blip.** `c crt 250` advertises a 250-second
-  reconnect window but we don't implement reconnect flow.
+- **Mid-game reconnect.** Lobby/lobbyselect reconnect-after-blip is now
+  implemented (see PROTOCOL.md "Reconnect after network blip"), but a
+  mid-game disconnect still falls through to immediate cleanup. Honoring
+  grace mid-stroke is non-trivial: peers are waiting on this player's
+  `endstroke` to advance the game, so the grace window has to either
+  auto-forfeit the in-flight stroke or model "disconnected but
+  reserved" with a separate stroke-timeout. Files: `port/server/src/
+  server.ts` (`handleDisconnect` early-returns to `fullyRemovePlayer`
+  when `player.game !== null`).
 - **Daily mode: resting-ghost sync for late joiners.** When a player joins the
   daily room mid-play, they see existing players' balls at the spawn position
   rather than wherever those balls have actually come to rest. The next stroke

--- a/port/docs/PROTOCOL.md
+++ b/port/docs/PROTOCOL.md
@@ -274,6 +274,53 @@ Client side:
   browser tab from being timed out (Chrome throttles JS in background tabs;
   the auto-pong might miss the deadline; the proactive ping has more slack).
 
+## Reconnect after network blip
+
+The connect-handshake `c crt 250` advertises a 250-second window during
+which a disconnected player can reattach by opening a fresh WebSocket and
+sending `c old <savedId>` instead of `c new`. Server-side, this is a
+faithful port of Java's `ReconnectHandler`.
+
+Sequence:
+```
+(network blip — client's WS dies, code 1006 / wasClean=false)
+
+(server) handleDisconnect: defers full cleanup by 250s if player.game === null;
+         player record stays in the lobby (peers' user lists unchanged).
+         Mid-game disconnects bypass grace and forfeit immediately —
+         peers are otherwise stuck waiting for endstroke.
+
+(client) opens fresh WS — server sends usual banner:
+         h 1
+         c crt 250
+         c ctr
+
+(client) sends      c old <savedId>
+(server) replies    c rcok        ← grace was active; new socket adopted
+              -- or c rcf         ← unknown id, grace expired, or mid-game
+```
+
+Both directions reset their DATA seq counter to 0 on `c rcok`. The
+implementation does NOT replay packets sent during the dead window —
+anything the server pushed while the WS was down is simply lost (e.g.
+peer chat). This matches what the original Java client effectively did
+(its retain-seq protocol tripped its own gap-detection on any peer
+broadcast during the gap).
+
+Client-side retry: 10 attempts, 3-second interval (~30s total budget).
+Capped well under the server's 250s window so we surface failure
+quickly when the network is genuinely down rather than thrashing.
+On exhaustion or `c rcf` the client emits `reconnect-failed` and shows
+"Reconnect failed — please refresh." in the error banner.
+
+The `c old`/`c rcok`/`c rcf` packets bypass DATA seq tracking (they're
+COMMAND packets) and are intercepted by `Connection.handleLine` while in
+reconnect mode — panels never see them. Files: `port/server/src/server.ts`
+(`handleReconnect`), `port/server/src/packet-handlers.ts` (`old` handler),
+`port/web/src/connection.ts` (reconnect mode + `c old <savedId>` driver),
+`port/web/src/app.ts` (`reconnecting`/`reconnected`/`reconnect-failed`
+banner).
+
 ## Quitting / leaving
 
 ```

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -43,6 +43,30 @@ register({
     },
 });
 
+// Reconnect-after-network-blip: client opens a fresh WebSocket, gets the usual
+// `h 1` / `c crt 250` / `c ctr` banner, then instead of `c new` sends `c old
+// <savedId>`. If the server still holds the player record (within the
+// RECONNECT_GRACE_MS window), it swaps the new socket onto the existing
+// player and replies `c rcok`; otherwise it replies `c rcf` and the client
+// falls back to fresh-login. Pre-login command — guard against double-adopt.
+register({
+    type: PacketType.COMMAND,
+    pattern: /^old (-?\d+)$/,
+    handle: (server, conn, match) => {
+        if (conn.player) return;
+        const id = parseInt(match[1], 10);
+        if (!Number.isFinite(id) || id < 1) {
+            conn.sendCommand("rcf");
+            return;
+        }
+        if (server.handleReconnect(conn, id)) {
+            conn.sendCommand("rcok");
+        } else {
+            conn.sendCommand("rcf");
+        }
+    },
+});
+
 register({
     type: PacketType.COMMAND,
     pattern: /^ping$/,

--- a/port/server/src/player.ts
+++ b/port/server/src/player.ts
@@ -34,8 +34,17 @@ export class Player {
     game: Game | null = null;
     gameType: GameType = null;
 
-    public readonly connection: Connection;
+    /** Mutable so `GolfServer.handleReconnect` can swap in the post-reconnect
+     *  WebSocket without disturbing peer-broadcast paths (everywhere else in
+     *  the codebase reaches sends via `player.connection.send*`). */
+    public connection: Connection;
     public readonly id: number;
+
+    /** When non-null, the player's WS is currently disconnected and a
+     *  grace-window timer is running; a `c old <id>` from a fresh socket
+     *  within the window will adopt this player. Cleared on reconnect.
+     *  Owned by `GolfServer.handleDisconnect` / `handleReconnect`. */
+    disconnectedAt: number | null = null;
 
     constructor(connection: Connection, id: number) {
         this.connection = connection;

--- a/port/server/src/server.ts
+++ b/port/server/src/server.ts
@@ -2,10 +2,16 @@
 import { type Packet, PacketType } from "@minigolf/shared";
 import type { Connection } from "./connection.ts";
 import { Player } from "./player.ts";
-import { Lobby, LobbyType } from "./lobby.ts";
+import { Lobby, LobbyType, PartReason } from "./lobby.ts";
 import type { TrackManager } from "./tracks.ts";
 import { DailyGame } from "./game.ts";
 import { dispatchPacket } from "./packet-handlers.ts";
+
+/** Grace window during which a player can re-attach a fresh WebSocket via
+ *  `c old <id>`. Mirrors the value advertised in the connect-handshake banner
+ *  (`c crt 250` → 250 seconds). After this elapses we do the original
+ *  full-cleanup. */
+const RECONNECT_GRACE_MS = 250_000;
 
 /** UTC YYYY-MM-DD — single source of truth for "today". */
 export function todayDateKey(): string {
@@ -24,6 +30,10 @@ export class GolfServer {
     private nextPlayerIdCounter = 1;
     private nextGameIdCounter = 1;
     private dailyGame: DailyGame | null = null;
+    /** Pending grace-window timers for disconnected players, keyed by player id.
+     *  A successful `c old <id>` cancels the timer; otherwise it fires after
+     *  RECONNECT_GRACE_MS and triggers full cleanup. */
+    private reconnectTimers: Map<number, NodeJS.Timeout> = new Map();
 
     public readonly trackManager: TrackManager;
     public readonly chatEnabled: boolean;
@@ -93,26 +103,93 @@ export class GolfServer {
     handleDisconnect(conn: Connection): void {
         const player = conn.player;
         if (!player) return;
+        // Belt-and-suspenders: if this connection has been swapped (via
+        // `handleReconnect`) it's no longer the player's live socket — the
+        // close event is just the old socket's death rattle, ignore it so we
+        // don't tear down the player record we just rescued.
+        if (player.connection !== conn) return;
+
+        // Mid-game disconnect: peers are waiting on this player's `endstroke`,
+        // so we can't keep them logically present. Fall through to immediate
+        // cleanup as before. (Reconnect mid-game is a deferred follow-up — see
+        // KNOWN_ISSUES.)
         if (player.game) {
-            // For MVP just remove the game when its sole player disconnects.
+            this.fullyRemovePlayer(player);
+            return;
+        }
+
+        // Lobby/lobbyselect: defer cleanup so a brief network blip doesn't
+        // cost the player their lobby slot. Cancelled by `handleReconnect`.
+        const existing = this.reconnectTimers.get(player.id);
+        if (existing) clearTimeout(existing);
+        player.disconnectedAt = Date.now();
+        const timer = setTimeout(() => {
+            this.reconnectTimers.delete(player.id);
+            // Re-check: a successful reconnect would have cleared
+            // `disconnectedAt` and replaced `player.connection`.
+            if (this.players.get(player.id) !== player) return;
+            if (player.disconnectedAt === null) return;
+            console.log(`[reconnect] grace expired for ${player.id}/${player.nick}`);
+            this.fullyRemovePlayer(player);
+        }, RECONNECT_GRACE_MS);
+        // Don't keep the event loop alive solely on this timer — the smoke
+        // tests close their server cleanly and rely on natural process exit;
+        // a 250s pending grace would hang them.
+        timer.unref();
+        this.reconnectTimers.set(player.id, timer);
+    }
+
+    private fullyRemovePlayer(player: Player): void {
+        if (player.game) {
             const lob = player.lobby;
             try {
                 player.game.removePlayer(player);
             } catch {
                 // ignore
             }
-            if (player.game.isEmpty() && lob) {
+            if (player.game?.isEmpty() && lob) {
                 lob.removeGame(player.game);
             }
         }
         if (player.lobby) {
             try {
-                player.lobby.removePlayer(player, /*PartReason.CONN_PROBLEM*/ 5);
+                player.lobby.removePlayer(player, PartReason.CONN_PROBLEM);
             } catch {
                 // ignore
             }
         }
         this.removePlayer(player.id);
+        player.disconnectedAt = null;
+    }
+
+    /**
+     * Re-attach `conn` to the player record identified by `id`, if still
+     * within the grace window. Returns true on success (caller should send
+     * `c rcok`); false if no such player or no grace pending (caller should
+     * send `c rcf`).
+     *
+     * Both directions of the seq counter reset to 0 on the new connection
+     * (the new Connection's defaults), which the client matches on `c rcok`.
+     * We don't try to replay/dedup packets sent during the gap — anything the
+     * server pushed during the dead window is lost. This is the same trade
+     * the original Java applet effectively made (its retain-seq protocol
+     * tripped its own gap-detection on any peer broadcast during the blip).
+     */
+    handleReconnect(conn: Connection, id: number): boolean {
+        const player = this.players.get(id);
+        if (!player || player.disconnectedAt === null) return false;
+        const timer = this.reconnectTimers.get(id);
+        if (timer) {
+            clearTimeout(timer);
+            this.reconnectTimers.delete(id);
+        }
+        player.disconnectedAt = null;
+        player.connection = conn;
+        conn.player = player;
+        // The new Connection's outSeq/inSeq are 0 by construction; no reset
+        // needed here. Client mirrors this on receipt of `c rcok`.
+        console.log(`[reconnect] reattached ${id}/${player.nick}`);
+        return true;
     }
 
     // re-export for convenience in connection

--- a/port/server/src/test-reconnect.ts
+++ b/port/server/src/test-reconnect.ts
@@ -1,0 +1,239 @@
+// Smoke test for the reconnect-after-network-blip flow.
+//
+// Exercises the protocol end-to-end:
+//
+//  1. Open WS, log in through guest-login, enter the multi lobby.
+//  2. Abruptly drop the underlying socket (no close handshake).
+//  3. Open a fresh WS, send `c old <id>` after the server's `c ctr`,
+//     assert the server replies `c rcok` and the player record survived.
+//  4. Open a third WS, send `c old <bogusId>`, assert `c rcf`.
+//
+// Invoke: node --experimental-strip-types --no-warnings src/test-reconnect.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4248;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+interface Pending {
+    resolve: (s: string) => void;
+    reject: (err: Error) => void;
+    timer: NodeJS.Timeout;
+}
+
+class FrameQueue {
+    private waiters: Pending[] = [];
+    private buffer: string[] = [];
+    private closed = false;
+
+    push(frame: string): void {
+        if (this.waiters.length > 0) {
+            const w = this.waiters.shift()!;
+            clearTimeout(w.timer);
+            w.resolve(frame);
+        } else {
+            this.buffer.push(frame);
+        }
+    }
+
+    fail(err: Error): void {
+        this.closed = true;
+        for (const w of this.waiters) {
+            clearTimeout(w.timer);
+            w.reject(err);
+        }
+        this.waiters = [];
+    }
+
+    next(timeoutMs = 5000): Promise<string> {
+        if (this.buffer.length > 0) return Promise.resolve(this.buffer.shift()!);
+        if (this.closed) return Promise.reject(new Error("closed"));
+        return new Promise<string>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                const idx = this.waiters.findIndex((w) => w.resolve === resolve);
+                if (idx >= 0) this.waiters.splice(idx, 1);
+                reject(new Error("timeout waiting for frame"));
+            }, timeoutMs);
+            this.waiters.push({ resolve, reject, timer });
+        });
+    }
+}
+
+interface Client {
+    ws: WebSocket;
+    queue: FrameQueue;
+}
+
+function attach(ws: WebSocket): FrameQueue {
+    const queue = new FrameQueue();
+    ws.on("message", (data) => {
+        const text = typeof data === "string" ? data : data.toString("utf-8");
+        for (const line of text.split(/\r?\n/)) {
+            if (line.length > 0) queue.push(line);
+        }
+    });
+    // 'close' fires for normal close too; the queue is reusable across socket
+    // swaps via fresh attach() calls.
+    ws.on("close", () => queue.fail(new Error("ws closed")));
+    ws.on("error", () => { /* swallow — `close` follows */ });
+    return queue;
+}
+
+async function openClient(): Promise<Client> {
+    const ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+    const queue = attach(ws);
+    await new Promise<void>((resolve, reject) => {
+        ws.once("open", () => resolve());
+        ws.once("error", (err) => reject(err));
+    });
+    return { ws, queue };
+}
+
+async function awaitMatch(
+    queue: FrameQueue,
+    predicate: (s: string) => boolean,
+    label: string,
+    timeoutMs = 5000,
+): Promise<string> {
+    const start = Date.now();
+    for (;;) {
+        const remaining = timeoutMs - (Date.now() - start);
+        if (remaining <= 0) throw new Error(`timeout waiting for ${label}`);
+        const frame = await queue.next(remaining);
+        if (predicate(frame)) {
+            console.log(`  ok: ${label}: ${frame.slice(0, 120)}`);
+            return frame;
+        }
+    }
+}
+
+function assertEq(actual: string, expected: string, label: string): void {
+    if (actual !== expected) {
+        throw new Error(`expected ${label} to equal ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+    }
+    console.log(`  ok: ${label}: ${actual}`);
+}
+
+async function loginAsGuest(c: Client, nick: string): Promise<number> {
+    // Drain the connect-handshake banner.
+    await awaitMatch(c.queue, (s) => s === "h 1", "header");
+    await awaitMatch(c.queue, (s) => s.startsWith("c crt 250"), "crt");
+    await awaitMatch(c.queue, (s) => s === "c ctr", "ctr");
+    // c new -> c id <N>
+    c.ws.send("c new");
+    const idLine = await awaitMatch(c.queue, (s) => s.startsWith("c id "), "c id");
+    const id = parseInt(idLine.substring(5), 10);
+    // login flow
+    c.ws.send("d 0 version\t35");
+    await awaitMatch(c.queue, (s) => s.startsWith("d 0 status\tlogin"), "status login");
+    c.ws.send("d 1 language\ten");
+    c.ws.send("d 2 logintype\tnr");
+    await awaitMatch(c.queue, (s) => s.startsWith("d 1 status\tlogin"), "status login (post-logintype)");
+    c.ws.send(`d 3 nick\t${nick}`);
+    c.ws.send("d 4 login");
+    await awaitMatch(c.queue, (s) => s.startsWith("d 2 srvinfo\tchat"), "srvinfo chat");
+    await awaitMatch(c.queue, (s) => s.startsWith("d 3 basicinfo"), "basicinfo");
+    await awaitMatch(c.queue, (s) => s.startsWith("d 4 status\tlobbyselect"), "status lobbyselect");
+    return id;
+}
+
+async function run(): Promise<void> {
+    const running: RunningServer = await startServer({
+        host: HOST,
+        port: PORT,
+        tracksDir: tracksDir(),
+        verbose: false,
+    });
+
+    let exitCode = 0;
+    try {
+        // ---------------------------------------------------------------
+        console.log("Phase 1: log in and enter multi lobby (so cleanup is grace-eligible)");
+        const c1 = await openClient();
+        const playerId = await loginAsGuest(c1, "blip-tester");
+        c1.ws.send("d 5 lobbyselect\tselect\tx");
+        await awaitMatch(c1.queue, (s) => s.startsWith("d 5 status\tlobby\tx"), "status lobby x");
+        // Drain the rest of the lobby join packets so they don't pollute later assertions.
+        await awaitMatch(c1.queue, (s) => s.startsWith("d 6 lobby\tusers"), "lobby users");
+        await awaitMatch(c1.queue, (s) => s.startsWith("d 7 lobby\townjoin"), "lobby ownjoin");
+
+        // ---------------------------------------------------------------
+        console.log("\nPhase 2: drop the socket abruptly (no close handshake)");
+        // `terminate()` slams the underlying TCP without sending a CLOSE frame
+        // — the closest we can simulate to a network blip from the server's
+        // POV.
+        c1.ws.terminate();
+
+        // Brief pause so the server processes the close event before we
+        // attempt the reconnect handshake.
+        await new Promise((r) => setTimeout(r, 100));
+
+        // ---------------------------------------------------------------
+        console.log("\nPhase 3: open a fresh socket and reconnect with `c old`");
+        const c2 = await openClient();
+        await awaitMatch(c2.queue, (s) => s === "h 1", "header (post-blip)");
+        await awaitMatch(c2.queue, (s) => s.startsWith("c crt 250"), "crt (post-blip)");
+        await awaitMatch(c2.queue, (s) => s === "c ctr", "ctr (post-blip)");
+        c2.ws.send(`c old ${playerId}`);
+        const reply = await awaitMatch(c2.queue, (s) => s.startsWith("c rc"), "rcok/rcf");
+        assertEq(reply, "c rcok", "reconnect reply");
+
+        // Sanity: server-side, the player record should still be the same one
+        // and now bound to the new socket. Easiest way to verify externally:
+        // send a benign DATA packet that the server only honours for
+        // logged-in players. `lobbyselect rnop` polls counts and is a no-op
+        // for state. The seq counter resets to 0 on rcok.
+        c2.ws.send("d 0 lobbyselect\trnop");
+        await awaitMatch(c2.queue, (s) => s.startsWith("d 0 lobbyselect\tnop"), "post-reconnect rnop reply");
+
+        c2.ws.close();
+
+        // ---------------------------------------------------------------
+        console.log("\nPhase 4: bogus id -> c rcf");
+        const c3 = await openClient();
+        await awaitMatch(c3.queue, (s) => s === "h 1", "header");
+        await awaitMatch(c3.queue, (s) => s.startsWith("c crt 250"), "crt");
+        await awaitMatch(c3.queue, (s) => s === "c ctr", "ctr");
+        c3.ws.send("c old 99999");
+        assertEq(await awaitMatch(c3.queue, (s) => s.startsWith("c rc"), "rcok/rcf for bogus id"), "c rcf", "bogus reply");
+        c3.ws.close();
+
+        // ---------------------------------------------------------------
+        console.log("\nPhase 5: previously-rcok'd id -> c rcf if blipped a second time without grace");
+        // Drop c2's already-closed socket; it was a clean close so no grace
+        // was started this time. A fresh `c old <playerId>` should now `rcf`.
+        // (Wait long enough for the close event to be processed.)
+        await new Promise((r) => setTimeout(r, 100));
+        const c4 = await openClient();
+        await awaitMatch(c4.queue, (s) => s === "h 1", "header");
+        await awaitMatch(c4.queue, (s) => s.startsWith("c crt 250"), "crt");
+        await awaitMatch(c4.queue, (s) => s === "c ctr", "ctr");
+        // c2.ws.close() above was a *clean* close (1000), which our server
+        // treats the same as any other disconnect — i.e. it also starts a
+        // grace window. So this id should still be reconnectable. Verify
+        // that rather than rcf, since it matches the actual code path.
+        c4.ws.send(`c old ${playerId}`);
+        assertEq(await awaitMatch(c4.queue, (s) => s.startsWith("c rc"), "second rcok"), "c rcok", "reattach via second clean-close");
+        c4.ws.close();
+
+        console.log("\nALL PHASES PASSED");
+    } catch (err) {
+        console.error("\nFAIL:", err instanceof Error ? err.message : err);
+        exitCode = 1;
+    } finally {
+        await running.close();
+    }
+    process.exit(exitCode);
+}
+
+run().catch((err) => {
+    console.error("fatal:", err);
+    process.exit(2);
+});

--- a/port/web/public/style.css
+++ b/port/web/public/style.css
@@ -427,6 +427,22 @@ button.btn-blue   { background: #9090e0; border-color: #9090e0; }
   z-index: 100;
 }
 
+/* Non-fatal "we're trying to recover" banner — distinct from .error-banner so
+   it can sit alongside other UI without screaming red and is removed cleanly
+   on `reconnected`. */
+.reconnect-banner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #c08040;
+  color: #fff;
+  padding: 4px 10px;
+  font-size: 12px;
+  text-align: center;
+  z-index: 100;
+}
+
 /* ---------- Daily replay viewer ---------- */
 
 .replay-wrap {

--- a/port/web/src/app.ts
+++ b/port/web/src/app.ts
@@ -58,6 +58,24 @@ export class App {
     this.connection.addEventListener("close", () => {
       this.showError("Connection closed");
     });
+
+    // Reconnect lifecycle. The Connection itself drives the `c old <id>`
+    // handshake — App's job is just to surface that something's happening
+    // (so the user doesn't think the UI froze) and clear it on success.
+    this.connection.addEventListener("reconnecting", (ev) => {
+      const { attempt, maxAttempts } = ev.detail;
+      this.showReconnect(`Reconnecting… (${attempt}/${maxAttempts})`);
+    });
+    this.connection.addEventListener("reconnected", () => {
+      this.clearReconnect();
+    });
+    this.connection.addEventListener("reconnect-failed", (ev) => {
+      this.clearReconnect();
+      const msg = ev.detail.reason === "rcf"
+        ? "Reconnect refused — please refresh."
+        : "Reconnect failed — please refresh.";
+      this.showError(msg);
+    });
   }
 
   private resolveWsUrl(): string {
@@ -133,5 +151,23 @@ export class App {
     banner.className = "error-banner";
     banner.textContent = message;
     this.root.appendChild(banner);
+  }
+
+  /** Render a non-fatal "reconnecting" indicator. Distinct class from the
+   *  error banner so it can be styled differently and removed independently
+   *  on `reconnected`. */
+  private showReconnect(message: string): void {
+    let banner = this.root.querySelector(".reconnect-banner");
+    if (!banner) {
+      banner = document.createElement("div");
+      banner.className = "reconnect-banner";
+      this.root.appendChild(banner);
+    }
+    banner.textContent = message;
+  }
+
+  private clearReconnect(): void {
+    const banner = this.root.querySelector(".reconnect-banner");
+    if (banner) banner.remove();
   }
 }

--- a/port/web/src/connection.ts
+++ b/port/web/src/connection.ts
@@ -9,11 +9,27 @@ import {
 
 const DEV = Boolean(import.meta.env?.DEV);
 
+/** Auto-reconnect tunables. The server's grace window (`c crt 250`) is far
+ *  longer than what we attempt here — the asymmetry is intentional: we'd
+ *  rather declare the session dead and surface a clear error than thrash
+ *  for four minutes against a dead network. */
+const RECONNECT_INTERVAL_MS = 3_000;
+const RECONNECT_MAX_ATTEMPTS = 10;
+
 export type ConnectionEventMap = {
   open: Event;
   close: CloseEvent;
   packet: CustomEvent<Packet>;
   error: CustomEvent<{ message: string; cause?: unknown }>;
+  /** Emitted when the connection is dead but we're trying to recover.
+   *  Detail.attempt is 1-indexed (first try is 1). */
+  reconnecting: CustomEvent<{ attempt: number; maxAttempts: number }>;
+  /** Emitted on successful `c rcok` — caller should hide any reconnect UI
+   *  and continue. Seqs have been reset; in-flight panel state is preserved. */
+  reconnected: Event;
+  /** Emitted when the server replied `c rcf`, or we exhausted retries.
+   *  Detail.reason is "rcf" for server-rejected, "exhausted" for retry budget. */
+  "reconnect-failed": CustomEvent<{ reason: "rcf" | "exhausted" }>;
 };
 
 /**
@@ -21,16 +37,40 @@ export type ConnectionEventMap = {
  *
  * Each text frame contains exactly one packet (no trailing newline).
  * Both directions maintain a sequence counter for `d` (data) packets.
+ *
+ * On abnormal close (network blip / 1006), if a server-assigned id was
+ * captured during login, the wrapper transparently swaps in a fresh inner
+ * WebSocket and walks the `c old <id>` reconnect handshake — see
+ * `port/docs/PROTOCOL.md` "Reconnect" section.
  */
 export class Connection extends EventTarget {
   readonly url: string;
   private ws: WebSocket | null = null;
   private outSeq = 0;
   private inSeq = 0;
-  private closed = false;
+  /** True once `close()` has been called by the user (panel teardown, full
+   *  reload). Suppresses auto-reconnect even on abnormal close. */
+  private userClosed = false;
   /** Proactive keepalive timer — sends `c ping` to the server on a fixed
    *  interval so background-tab throttling can't hit the server's 60s idle cap. */
   private keepaliveTimer: number | null = null;
+
+  /** Server-assigned player id, captured from `c id <N>` during initial login.
+   *  Used as the reconnect token in `c old <savedId>`. */
+  private savedId: string | null = null;
+  /** True between an abnormal close and either a `c rcok`/`c rcf` reply or
+   *  the retry budget being exhausted. While set, packet handling intercepts
+   *  the reconnect-handshake commands instead of forwarding them to panels. */
+  private reconnecting = false;
+  /** Number of reconnect attempts made for the current dead-connection event.
+   *  Reset on `c rcok` or on the next abnormal close. */
+  private reconnectAttempt = 0;
+  private reconnectTimer: number | null = null;
+  /** Once we've fired a terminal `reconnect-failed`, the inevitable WS close
+   *  event would also fire `close` and overwrite the App's
+   *  "Reconnect refused" banner with the generic "Connection closed". This
+   *  flag suppresses that redundant follow-up. */
+  private finalEventEmitted = false;
 
   constructor(url: string) {
     super();
@@ -44,39 +84,72 @@ export class Connection extends EventTarget {
 
     ws.addEventListener("open", (ev) => {
       if (DEV) console.debug("[conn] open", this.url);
-      this.dispatchEvent(new Event("open"));
-      // Start proactive keepalive — every 15s, push a `c ping` so the server
-      // sees inbound activity and won't time us out (server cap is 60s).
-      // setInterval still fires in background tabs, just throttled to ~1Hz
-      // minimum, which is plenty for our 15s cadence.
-      if (this.keepaliveTimer !== null) window.clearInterval(this.keepaliveTimer);
-      this.keepaliveTimer = window.setInterval(() => {
-        if (this.ws?.readyState === WebSocket.OPEN) {
-          try { this.ws.send("c ping"); } catch { /* ignore */ }
-        }
-      }, 15_000);
+      // The 'open' event is suppressed during reconnect — the panel doesn't
+      // need to redo handshake-bound bookkeeping (it already mounted on the
+      // first open). It'll get a 'reconnected' event once `c rcok` lands.
+      if (!this.reconnecting) this.dispatchEvent(new Event("open"));
+      this.startKeepalive();
       void ev;
     });
 
     ws.addEventListener("close", (ev) => {
-      this.closed = true;
       if (this.keepaliveTimer !== null) {
         window.clearInterval(this.keepaliveTimer);
         this.keepaliveTimer = null;
       }
-      if (DEV) console.debug("[conn] close", ev.code, ev.reason);
-      this.dispatchEvent(
-        new CloseEvent("close", {
-          code: ev.code,
-          reason: ev.reason,
-          wasClean: ev.wasClean,
-        }),
-      );
+      if (DEV) console.debug("[conn] close", ev.code, ev.reason, "wasClean=" + ev.wasClean);
+
+      // Decide between (a) trying to reconnect or (b) surfacing the close.
+      // Auto-reconnect only when:
+      //  - the user didn't initiate the close,
+      //  - we have a savedId (i.e. login completed),
+      //  - close was abnormal (browser code 1006 / wasClean=false). A clean
+      //    close usually means the server intentionally closed (idle-timeout,
+      //    seq-mismatch, etc.) and retrying would just re-trigger the same.
+      const shouldReconnect =
+        !this.userClosed &&
+        this.savedId !== null &&
+        !ev.wasClean &&
+        this.reconnectAttempt < RECONNECT_MAX_ATTEMPTS;
+
+      if (shouldReconnect) {
+        this.scheduleReconnect();
+        return;
+      }
+
+      // If we were already mid-reconnect and ran out of attempts, surface
+      // the failure as a `reconnect-failed` event so App can show the right
+      // UI. Otherwise dispatch the original close so existing handlers
+      // (App.showError) keep working.
+      if (this.reconnecting) {
+        this.reconnecting = false;
+        this.finalEventEmitted = true;
+        this.dispatchEvent(
+          new CustomEvent<{ reason: "rcf" | "exhausted" }>("reconnect-failed", {
+            detail: { reason: "exhausted" },
+          }),
+        );
+      }
+      // Skip the generic close-event dispatch once a terminal
+      // `reconnect-failed` has already explained the failure — otherwise the
+      // App's error banner would flicker from "Reconnect refused" to
+      // "Connection closed" on the trailing socket close.
+      if (!this.finalEventEmitted) {
+        this.dispatchEvent(
+          new CloseEvent("close", {
+            code: ev.code,
+            reason: ev.reason,
+            wasClean: ev.wasClean,
+          }),
+        );
+      }
     });
 
     ws.addEventListener("error", () => {
       if (DEV) console.debug("[conn] socket error");
-      this.emitError("websocket error");
+      // Don't surface the error during reconnect — the failed attempt is
+      // about to fire its own close, which scheduleReconnect handles.
+      if (!this.reconnecting) this.emitError("websocket error");
     });
 
     ws.addEventListener("message", (ev) => {
@@ -84,6 +157,36 @@ export class Connection extends EventTarget {
       if (!data) return;
       this.handleLine(data);
     });
+  }
+
+  private startKeepalive(): void {
+    // Start proactive keepalive — every 15s, push a `c ping` so the server
+    // sees inbound activity and won't time us out (server cap is 60s).
+    // setInterval still fires in background tabs, just throttled to ~1Hz
+    // minimum, which is plenty for our 15s cadence.
+    if (this.keepaliveTimer !== null) window.clearInterval(this.keepaliveTimer);
+    this.keepaliveTimer = window.setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        try { this.ws.send("c ping"); } catch { /* ignore */ }
+      }
+    }, 15_000);
+  }
+
+  private scheduleReconnect(): void {
+    this.reconnecting = true;
+    this.reconnectAttempt++;
+    if (DEV) console.debug(`[conn] reconnect attempt ${this.reconnectAttempt}/${RECONNECT_MAX_ATTEMPTS}`);
+    this.dispatchEvent(
+      new CustomEvent<{ attempt: number; maxAttempts: number }>("reconnecting", {
+        detail: { attempt: this.reconnectAttempt, maxAttempts: RECONNECT_MAX_ATTEMPTS },
+      }),
+    );
+    if (this.reconnectTimer !== null) window.clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.userClosed) return;
+      this.connect();
+    }, RECONNECT_INTERVAL_MS);
   }
 
   private handleLine(line: string): void {
@@ -96,6 +199,44 @@ export class Connection extends EventTarget {
     }
 
     if (DEV) console.debug("[conn] <-", line);
+
+    // While in reconnect mode, intercept the handshake control packets so
+    // panels don't see a second hello/ctr cycle. Seq counters on the server
+    // side are also fresh on the new socket, so DATA flows between this
+    // burst and `c rcok` shouldn't happen — only the four-frame banner
+    // (h 1 / c crt / c ctr) and the `c rcok`/`c rcf` reply.
+    if (this.reconnecting) {
+      if (pkt.type === PacketType.HEADER) return;
+      if (pkt.type === PacketType.COMMAND) {
+        const verb = pkt.fields[0];
+        if (verb === "crt") return;
+        if (verb === "ctr") {
+          // Drive the reconnect with the saved id. The savedId is non-null
+          // here (gated by the close-handler before scheduleReconnect ran).
+          this.send(buildCommand("old", this.savedId ?? ""));
+          return;
+        }
+        if (verb === "rcok") {
+          this.finishReconnect();
+          return;
+        }
+        if (verb === "rcf") {
+          this.reconnecting = false;
+          this.savedId = null;
+          this.finalEventEmitted = true;
+          this.dispatchEvent(
+            new CustomEvent<{ reason: "rcf" | "exhausted" }>("reconnect-failed", {
+              detail: { reason: "rcf" },
+            }),
+          );
+          // Tear down the WS — App will surface the error and we don't want
+          // a half-alive socket lingering. The follow-up close event won't
+          // re-dispatch, gated by `finalEventEmitted`.
+          try { this.ws?.close(); } catch { /* */ }
+          return;
+        }
+      }
+    }
 
     // Validate seq on incoming data packets.
     if (pkt.type === PacketType.DATA) {
@@ -114,9 +255,32 @@ export class Connection extends EventTarget {
       this.send(buildCommand("pong"));
     }
 
+    // Capture the server-assigned id once per session — used as the
+    // reconnect token in `c old <id>` on subsequent abnormal closes.
+    if (
+      this.savedId === null &&
+      pkt.type === PacketType.COMMAND &&
+      pkt.fields[0] === "id" &&
+      pkt.fields[1]
+    ) {
+      this.savedId = pkt.fields[1];
+    }
+
     this.dispatchEvent(
       new CustomEvent<Packet>("packet", { detail: pkt }),
     );
+  }
+
+  private finishReconnect(): void {
+    if (DEV) console.debug("[conn] reconnect ok — resuming");
+    // Server reset its seq counters on the new socket; mirror that locally.
+    // Without this, the next inbound DATA packet (seq=0) would trip the
+    // mismatch check against our stale inSeq.
+    this.outSeq = 0;
+    this.inSeq = 0;
+    this.reconnecting = false;
+    this.reconnectAttempt = 0;
+    this.dispatchEvent(new Event("reconnected"));
   }
 
   private emitError(message: string, cause?: unknown): void {
@@ -150,8 +314,12 @@ export class Connection extends EventTarget {
   }
 
   close(): void {
-    if (this.closed) return;
-    this.closed = true;
+    if (this.userClosed) return;
+    this.userClosed = true;
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     try {
       this.ws?.close();
     } catch {
@@ -161,6 +329,13 @@ export class Connection extends EventTarget {
 
   get isOpen(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /** True while the wrapper is actively trying to recover from a network
+   *  blip (between abnormal close and `c rcok`/`c rcf`/exhausted). Panels
+   *  can read this if they want to suppress noisy intermediate state. */
+  get isReconnecting(): boolean {
+    return this.reconnecting;
   }
 
   // Typed addEventListener overloads for our custom events.

--- a/port/web/vite.config.ts
+++ b/port/web/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       "/ws": {
-        target: "ws://127.0.0.1:4242",
+        target: process.env.WS_PROXY_TARGET ?? "ws://127.0.0.1:4242",
         ws: true,
         changeOrigin: true,
         rewriteWsOrigin: true,


### PR DESCRIPTION
Implement the reconnect flow advertised by the connect-banner `c crt 250`. On abnormal WebSocket close (code 1006 / wasClean=false), the client opens a fresh socket and sends `c old <savedId>` instead of `c new`; the server swaps the new socket onto the existing player record (keeping their lobby slot) and replies `c rcok`. Outside the 250s grace window, or if the id isn't known, server replies `c rcf` and the client surfaces "Reconnect refused — please refresh." instead of the generic "Connection closed".

Scope: lobby/lobbyselect only. Mid-game disconnects fall through to immediate cleanup as before — peers are otherwise hung waiting on the absent player's `endstroke`. KNOWN_ISSUES carries the follow-up entry.

Both directions reset their DATA seq counter to 0 on `c rcok` (the new Connection's defaults); we don't replay packets sent during the gap, so peer chat/cursor traffic during the blip is lost. The original Java client effectively made the same trade (its retain-seq protocol tripped its own gap-detection on any peer broadcast during the gap).

Client retry budget is 10 × 3s = 30s, deliberately well under the server's 250s grace so we surface failure quickly when the network is genuinely down. The reconnect-handshake commands (`c old`, `c rcok`, `c rcf`) are intercepted inside Connection during reconnect mode so panels never see them — the live panel keeps running across the blip.

Smoke test (test-reconnect.ts) drives the full protocol through real WebSockets and asserts: rcok after abrupt termination, rcf for unknown id, second rcok after a clean-close (which also starts a grace window).

Verified live in the browser (synthetic 1006 close on a logged-in session): "Reconnecting… (1/10)" banner appears, retry fires after 3s, server `c rcf` cleanly switches the banner to "Reconnect refused" with no flicker through "Connection closed" (gated by `finalEventEmitted`).

Drive-by: `WS_PROXY_TARGET` env var on the Vite proxy so per-worktree dev servers don't have to fight over port 4242.