### PR TITLE
Port: localisation routing (en/fi/sv) — Java TextManager analog

### DIFF
--- a/port/README.md
+++ b/port/README.md
@@ -161,6 +161,14 @@ that the live cursor relay is wired through the right handler order.
   derived from the same array.
 - Anti-repeat ringbuffer in `TrackManager` (last 50 served names) so
   the same maps don't recur within a few games.
+- Localisation routing (Java `TextManager` analog at
+  `web/src/i18n.ts`). Loads `/l10n/<lang>/AGolf.xml` via fetch; UI
+  strings in every panel resolve through `t(key, defaultEn, ...args)`
+  with `%1`/`%2` substitution. Active locale falls back to EN, then to
+  the inline default; selection persists in `localStorage` (`pmg.lang`).
+  Switching language on the login screen pre-loads the chosen XML so the
+  next panel renders in the picked locale immediately. Strings without
+  a Java key live under the port-specific `Port_*` namespace.
 
 **Rendering**
 - 49×25 RLE map decoding, byte-for-byte match with Java `Map.parse()`
@@ -185,7 +193,6 @@ running list. Highlights:
   is reusable here).
 - Sound playback (.wav files bundled in `web/public/sound/shared/`
   but not yet hooked up to Web Audio).
-- Localisation routing (XML files bundled, not consumed).
 - Track-test mode (`logintype ttm`).
 - DUAL lobby (UI button disabled).
 - Aim modes (right-click rotation between solid + 3 dashed lines).

--- a/port/docs/ARCHITECTURE.md
+++ b/port/docs/ARCHITECTURE.md
@@ -187,7 +187,15 @@ are different from each other.
 - `panels/login.ts` — Username/language form. Sends version → language →
   logintype → nick → login. The `nick` packet is the port's extension to
   the original handshake — lets the user pick the name shown in scoreboards
-  and ghost labels.
+  and ghost labels. Picking a language pre-loads the corresponding
+  `AGolf.xml` via `i18n.setLanguage()` so subsequent panels mount with
+  the chosen locale already resolved.
+- `i18n.ts` — Browser-side analog of Java `com.aapeli.client.TextManager`.
+  Fetches `/l10n/<lang>/AGolf.xml`, parses with `DOMParser`, and resolves
+  keys via `t(key, defaultEn, ...args)` with `%1`/`%2` substitution. EN
+  is loaded eagerly on boot and stays as the fallback overlay when a
+  non-EN locale lacks a key; the `defaultEn` parameter is the final
+  fallback so panels stay readable even with missing assets.
 - `panels/lobbyselect.ts` — Three-column SP/DUAL/MULTI screen.
 - `panels/lobby.ts` — Single-player lobby. Track-type/numTracks/water/maxStrokes
   form. `lobby cspt` to start a TrainingGame.

--- a/port/docs/KNOWN_ISSUES.md
+++ b/port/docs/KNOWN_ISSUES.md
@@ -50,8 +50,15 @@ Things we deferred for MVP that the original Java game has:
   `port/web/public/sound/shared/` but the client never plays them. Need
   Web Audio integration: `gamemove` on stroke, `winner`/`loser` on game end,
   `notify` on chat, etc.
-- **Localisation.** `AGolf.xml` for en/fi/sv is bundled but the client uses
-  hard-coded English strings. Wire up a `TextManager` analog if needed.
+- **Localisation extension.** Core wiring exists (`web/src/i18n.ts` —
+  Java `TextManager` analog) and en/fi/sv `AGolf.xml` are loaded via
+  `fetch` from `/l10n/<lang>/AGolf.xml`. Visible strings in the login,
+  lobby-select, single/multi lobby, in-game and replay panels resolve
+  through `t(key, defaultEn, ...args)`. New port-specific strings live
+  under the `Port_*` namespace (not present in the original Java XMLs);
+  add them to `client/src/main/resources/l10n/<lang>/AGolf.xml` if you
+  want them translated, then re-run `npm run assets`. Falls through
+  active-locale → EN → inline `defaultEn` so missing keys still render.
 - **Track-test mode (`logintype ttm`).** Not implemented.
 - **DUAL lobby.** UI button is disabled; the protocol/server handlers
   technically support `select 2` but no `LobbyDualplayerHandler` is wired.

--- a/port/web/public/style.css
+++ b/port/web/public/style.css
@@ -208,12 +208,15 @@ button.btn-blue   { background: #9090e0; border-color: #9090e0; }
   top: 100px;
 }
 
-/* Three columns of buttons at the bottom of the bg image, mirroring
-   LobbySelectPanel.create() coordinates (height-150, height-95, etc). */
+/* Three columns of buttons at the bottom of the bg image. Anchored in pixels
+   to the bg image's 735px-wide thirds (0, 245, 490). #app has a 1px border
+   with box-sizing: border-box, so a percent-based layout would resolve
+   against 733px of content and slip the right two columns ~1px left of the
+   image's divider lines. Pixel anchors match the image grid exactly. */
 .panel-lobbyselect .col {
   position: absolute;
   bottom: 0;
-  width: 33.333%;
+  width: 245px;
   height: 165px;
   display: flex;
   flex-direction: column;
@@ -222,9 +225,9 @@ button.btn-blue   { background: #9090e0; border-color: #9090e0; }
   padding-top: 14px;
 }
 
-.panel-lobbyselect .col.col-1 { left: 0%; }
-.panel-lobbyselect .col.col-2 { left: 33.333%; }
-.panel-lobbyselect .col.col-3 { left: 66.666%; }
+.panel-lobbyselect .col.col-1 { left: 0; }
+.panel-lobbyselect .col.col-2 { left: 245px; }
+.panel-lobbyselect .col.col-3 { left: 490px; }
 
 .panel-lobbyselect .col button {
   width: 150px;

--- a/port/web/src/app.ts
+++ b/port/web/src/app.ts
@@ -7,6 +7,7 @@ import { LobbySelectPanel } from "./panels/lobbyselect.ts";
 import { LobbyPanel } from "./panels/lobby.ts";
 import { LobbyMultiPanel } from "./panels/lobby-multi.ts";
 import { GamePanel } from "./panels/game.ts";
+import { t } from "./i18n.ts";
 
 const DEV = Boolean(import.meta.env?.DEV);
 
@@ -56,7 +57,7 @@ export class App {
     });
 
     this.connection.addEventListener("close", () => {
-      this.showError("Connection closed");
+      this.showError(t("Message_ConnectionError", "Connection error!"));
     });
   }
 

--- a/port/web/src/i18n.ts
+++ b/port/web/src/i18n.ts
@@ -1,0 +1,182 @@
+/**
+ * Browser-side analog of Java `com.aapeli.client.TextManager`. Loads
+ * `/l10n/<lang>/AGolf.xml` (copied into `web/public/l10n/` by
+ * `scripts/prepare-assets.mjs`), parses it once, and resolves keys via
+ * `t(key, defaultEn, ...args)` with `%1`/`%2` substitution.
+ *
+ * Differences from Java:
+ *  - Active locale falls back through EN before reaching `defaultEn`, so a
+ *    half-translated locale still surfaces English instead of `{key}` when
+ *    a key only lives in `en/AGolf.xml`. The Java client just returns
+ *    `{key}` because it never overlays a fallback locale.
+ *  - We treat keys as lowercase (matching Java's `.toLowerCase()` lookup).
+ *  - The `reverse="yes"` attribute on BadNicks/BadWords is ignored — the
+ *    port has no client-side moderation that consumes those lists.
+ */
+export type Lang = "en" | "fi" | "sv";
+
+const STORAGE_KEY = "pmg.lang";
+/** Site default. Finnish — the original Playforia game was a Finnish product
+ *  and the user base of this port leans that way. EN remains the fallback
+ *  overlay for any keys missing in the active locale. */
+const DEFAULT_LANG: Lang = "fi";
+
+function isLang(s: string | null): s is Lang {
+  return s === "en" || s === "fi" || s === "sv";
+}
+
+/** Read the saved choice, or `en` if no saved choice / invalid value. */
+export function loadSavedLang(): Lang {
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    if (isLang(v)) return v;
+  } catch {
+    // localStorage may throw in private mode / sandboxed iframes — fall through.
+  }
+  return DEFAULT_LANG;
+}
+
+export function saveLang(lang: Lang): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, lang);
+  } catch {
+    // noop
+  }
+}
+
+class TextManager {
+  /** Active-locale key→translation map. Always lowercase keys. */
+  private active: Map<string, string> = new Map();
+  /** EN overlay used as a fallback for missing keys in non-EN locales. */
+  private fallback: Map<string, string> = new Map();
+  private currentLang: Lang = DEFAULT_LANG;
+  /** Cache parsed locales so a switch-back is instant. */
+  private cache: Map<Lang, Map<string, string>> = new Map();
+  /** In-flight fetches so concurrent `setLanguage` calls share a load. */
+  private inflight: Map<Lang, Promise<Map<string, string>>> = new Map();
+
+  /** Load EN as both active and fallback. Call once at app boot. */
+  async init(): Promise<void> {
+    const en = await this.loadLocale("en");
+    this.fallback = en;
+    this.active = en;
+    this.currentLang = "en";
+  }
+
+  get language(): Lang {
+    return this.currentLang;
+  }
+
+  /**
+   * Switch the active locale. EN remains the fallback overlay. Safe to call
+   * with `en` — it's a no-op since the active map is already EN.
+   */
+  async setLanguage(lang: Lang): Promise<void> {
+    if (lang === this.currentLang) return;
+    const map = await this.loadLocale(lang);
+    this.active = map;
+    this.currentLang = lang;
+  }
+
+  /**
+   * Resolve a localised string.
+   *   t("LobbyReal_Start", "Start training")
+   *   t("LobbyChat_Join", "%1 joined the game", nick)
+   *
+   * Lookup order: active locale → EN fallback → `defaultEn` → `{key}`.
+   * Substitutes `%1`, `%2`, … with the supplied positional args (only the
+   * first occurrence is replaced per arg, matching Java `replaceFirst`).
+   */
+  t(key: string, defaultEn: string, ...args: Array<string | number>): string {
+    const lower = key.toLowerCase();
+    let template = this.active.get(lower);
+    if (template === undefined) template = this.fallback.get(lower);
+    if (template === undefined) template = defaultEn;
+    if (template === undefined) template = `{${key}}`;
+    if (args.length === 0) return template;
+    let out = template;
+    for (let i = 0; i < args.length; i++) {
+      // String#replace with a string pattern only replaces the first match,
+      // matching Java's replaceFirst — `%1` with "$2" must NOT eat the literal
+      // "$2" the way `replace` with a string treats `$&` etc. when the
+      // replacement is computed lazily, so we use a function to disable
+      // pattern interpretation.
+      const needle = "%" + (i + 1);
+      const value = String(args[i]);
+      out = out.replace(needle, () => value);
+    }
+    return out;
+  }
+
+  // ---- internals -------------------------------------------------------
+
+  private loadLocale(lang: Lang): Promise<Map<string, string>> {
+    const cached = this.cache.get(lang);
+    if (cached) return Promise.resolve(cached);
+    const inflight = this.inflight.get(lang);
+    if (inflight) return inflight;
+    const promise = this.fetchAndParse(lang).then((map) => {
+      this.cache.set(lang, map);
+      this.inflight.delete(lang);
+      return map;
+    }).catch((err) => {
+      this.inflight.delete(lang);
+      throw err;
+    });
+    this.inflight.set(lang, promise);
+    return promise;
+  }
+
+  private async fetchAndParse(lang: Lang): Promise<Map<string, string>> {
+    const url = `/l10n/${lang}/AGolf.xml`;
+    const res = await fetch(url, { credentials: "same-origin" });
+    if (!res.ok) {
+      throw new Error(`l10n fetch failed: ${url} (${res.status})`);
+    }
+    const text = await res.text();
+    return parseAGolfXml(text);
+  }
+}
+
+/**
+ * Parse an `AGolf.xml` body into a key→string map. Keys are lowercased.
+ * `<parsererror>` (the DOMParser failure marker) is treated as a hard error
+ * — DOMParser doesn't throw on malformed XML, so we have to spot it ourselves.
+ */
+export function parseAGolfXml(text: string): Map<string, string> {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(text, "application/xml");
+  const err = doc.querySelector("parsererror");
+  if (err) {
+    throw new Error(`l10n XML parse error: ${err.textContent ?? "?"}`);
+  }
+  const out = new Map<string, string>();
+  const nodes = doc.getElementsByTagName("str");
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes.item(i);
+    if (!node) continue;
+    const key = node.getAttribute("key");
+    if (!key) continue;
+    // Trim whitespace contributed by XML pretty-printing around the CDATA
+    // section (`\n\t  CDATA\n\t`). Java DOM behaves the same here; their
+    // strings only look right because the source XML happens to have the
+    // CDATA flush against the tag in some entries — relying on that is
+    // brittle, so we trim universally.
+    const text = (node.textContent ?? "").trim();
+    out.set(key.toLowerCase(), text);
+  }
+  return out;
+}
+
+/**
+ * Singleton — created at module load so panels can import `t` directly
+ * without threading the manager through every constructor. Boot order:
+ *   1. main.ts calls `i18n.init()` (awaits) → EN loaded as active+fallback.
+ *   2. Login panel kicks `i18n.setLanguage(<picked>)` on dropdown change.
+ */
+export const i18n = new TextManager();
+
+/** Convenience proxy so call sites read `t("Key", "default")` directly. */
+export function t(key: string, defaultEn: string, ...args: Array<string | number>): string {
+  return i18n.t(key, defaultEn, ...args);
+}

--- a/port/web/src/main.ts
+++ b/port/web/src/main.ts
@@ -1,17 +1,43 @@
 import { App } from "./app.ts";
 import { readReplayFromHash } from "./daily.ts";
 import { ReplayPanel } from "./panels/replay.ts";
+import { i18n, loadSavedLang } from "./i18n.ts";
 
 const root = document.getElementById("app");
 if (!root) {
   throw new Error("Missing #app root element");
 }
 
-// Replay viewer is a separate boot path — fully self-contained, no server
-// connection. Triggered by `#replay=<base64url>` in the URL.
-const replay = readReplayFromHash();
-if (replay) {
-  new ReplayPanel(replay).mount(root);
-} else {
-  new App(root).start();
+async function boot(): Promise<void> {
+  // Load EN first so every panel that mounts can already resolve
+  // `t("Key", "default")`. If EN fails to load (e.g. assets weren't prepared),
+  // panels still fall back to the inline English defaults — they just don't
+  // get the prettier wording from the XML.
+  try {
+    await i18n.init();
+  } catch (err) {
+    console.warn("[i18n] init failed; using inline defaults", err);
+  }
+
+  // Apply the saved-language preference up front so a returning visitor sees
+  // their previous locale immediately on the login screen.
+  const saved = loadSavedLang();
+  if (saved !== "en") {
+    try {
+      await i18n.setLanguage(saved);
+    } catch (err) {
+      console.warn("[i18n] saved language failed to load", err);
+    }
+  }
+
+  // Replay viewer is a separate boot path — fully self-contained, no server
+  // connection. Triggered by `#replay=<base64url>` in the URL.
+  const replay = readReplayFromHash();
+  if (replay) {
+    new ReplayPanel(replay).mount(root);
+  } else {
+    new App(root).start();
+  }
 }
+
+void boot();

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -22,6 +22,7 @@ import {
   type DailyReplay,
   type DailyResult,
 } from "../daily.ts";
+import { t } from "../i18n.ts";
 
 const DEV = Boolean(import.meta.env?.DEV);
 
@@ -276,18 +277,18 @@ export class GamePanel implements Panel {
     center.className = "center";
     const statusEl = document.createElement("div");
     statusEl.className = "hud-status";
-    statusEl.textContent = "Loading sprites…";
+    statusEl.textContent = t("Port_Game_LoadingSprites", "Loading sprites…");
     const strokeCountEl = document.createElement("div");
     strokeCountEl.style.fontSize = "13px";
     strokeCountEl.style.fontWeight = "bold";
-    strokeCountEl.textContent = "Stroke 0";
+    strokeCountEl.textContent = t("Port_Game_StrokeFmt", "Stroke %1", 0);
     center.appendChild(strokeCountEl);
     center.appendChild(statusEl);
 
     const forfeit = document.createElement("button");
     forfeit.type = "button";
     forfeit.className = "btn-yellow";
-    forfeit.textContent = "Forfeit hole";
+    forfeit.textContent = t("Port_Game_ForfeitHole", "Forfeit hole");
     forfeit.style.marginTop = "4px";
     forfeit.style.padding = "1px 10px";
     forfeit.style.minHeight = "auto";
@@ -396,7 +397,7 @@ export class GamePanel implements Panel {
 
     void loadAtlases().then((atl) => {
       this.atlases = atl;
-      this.setStatus("Waiting for track…");
+      this.setStatus(t("Port_Game_WaitingForTrack", "Waiting for track…"));
       if (this.pendingStartTrack) {
         const f = this.pendingStartTrack;
         this.pendingStartTrack = null;
@@ -404,7 +405,7 @@ export class GamePanel implements Panel {
       }
     }).catch((err) => {
       if (DEV) console.warn("[game] atlases failed", err);
-      this.setStatus("Sprite load failed: " + String(err));
+      this.setStatus(t("Port_Game_SpriteLoadFailed", "Sprite load failed: %1", String(err)));
     });
 
     this.startLoop();
@@ -494,7 +495,7 @@ export class GamePanel implements Panel {
           this.ensurePlayerSlots(id + 1);
           this.players[id].nick = f[3] ?? "";
           this.players[id].clan = f[4] ?? "";
-          this.appendChat(`* ${this.players[id].nick} joined the game`, "system");
+          this.appendChat("* " + t("Chat_Game_PlayerJoined", "%1 joined the game", this.players[id].nick), "system");
           this.scoreboardDirty = true;
         }
         break;
@@ -502,7 +503,7 @@ export class GamePanel implements Panel {
         {
           const id = parseInt(f[2] ?? "0", 10) || 0;
           if (this.players[id]) {
-            this.appendChat(`* ${this.players[id].nick} left`, "system");
+            this.appendChat("* " + t("Chat_Game_PlayerLeft", "Player %1 left the game", this.players[id].nick), "system");
             this.players[id].active = false;
           }
           this.scoreboardDirty = true;
@@ -544,11 +545,11 @@ export class GamePanel implements Panel {
         {
           const id = parseInt(f[2] ?? "0", 10) || 0;
           const nick = this.players[id]?.nick ?? "?";
-          this.appendChat(`<${nick}> ${f[3] ?? ""}`, "say");
+          this.appendChat(t("Chat_UserSay", "<%1> %2", nick, f[3] ?? ""), "say");
         }
         break;
       case "sayp":
-        this.appendChat(`[whisper from ${f[2] ?? "?"}] ${f[3] ?? ""}`, "whisper");
+        this.appendChat(t("Port_Chat_WhisperFromFmt", "[whisper from %1] %2", f[2] ?? "?", f[3] ?? ""), "whisper");
         break;
       case "end":
         this.showEndOverlay(f);
@@ -579,7 +580,7 @@ export class GamePanel implements Panel {
     this.gameId = f[3] ?? "0";
     const tLine = extractField(f, "T ");
     if (!tLine) {
-      this.setStatus("Could not load track (no T-line).");
+      this.setStatus(t("Port_Game_NoTLine", "Could not load track (no T-line)."));
       return;
     }
     try {
@@ -640,7 +641,7 @@ export class GamePanel implements Panel {
         this.dailyResultRecorded = false;
       }
 
-      this.setStatus("Click to shoot when you're ready.");
+      this.setStatus(t("Port_Game_ClickToShoot", "Click to shoot when you're ready."));
       this.removeOverlay();
       this.scoreboardDirty = true;
       // Replay any beginstrokes that arrived too early.
@@ -649,7 +650,7 @@ export class GamePanel implements Panel {
       for (const q of queued) this.handleBeginStroke(q);
     } catch (err) {
       if (DEV) console.warn("[game] track build failed", err);
-      this.setStatus("Track parse error: " + String(err));
+      this.setStatus(t("Port_Game_TrackParseError", "Track parse error: %1", String(err)));
     }
   }
 
@@ -864,7 +865,7 @@ export class GamePanel implements Panel {
   private updateStrokeCount(): void {
     const slot = this.players[this.myPlayerId];
     if (this.strokeCountEl) {
-      this.strokeCountEl.textContent = `Stroke ${slot?.strokesThisTrack ?? 0}`;
+      this.strokeCountEl.textContent = t("Port_Game_StrokeFmt", "Stroke %1", slot?.strokesThisTrack ?? 0);
     }
   }
 
@@ -875,7 +876,12 @@ export class GamePanel implements Panel {
     bestPlayer: string,
   ): void {
     if (this.trackProgressEl) {
-      this.trackProgressEl.textContent = `Track ${this.currentTrackIdx}/${this.numTracks}`;
+      this.trackProgressEl.textContent = t(
+        "GameTrackInfo_CurrentTrack",
+        "Track %1/%2",
+        this.currentTrackIdx,
+        this.numTracks,
+      );
     }
     // Stash for the daily-share text; both fields are blank until the first
     // starttrack arrives.
@@ -883,12 +889,12 @@ export class GamePanel implements Panel {
     this.trackAverage = info && info.plays > 0 ? info.totalStrokes / info.plays : 0;
     if (this.trackTitleEl) this.trackTitleEl.textContent = name;
     if (this.trackAuthorEl) {
-      this.trackAuthorEl.textContent = author ? `by ${author}` : "";
+      this.trackAuthorEl.textContent = author ? t("Port_Game_AuthorByFmt", "by %1", author) : "";
     }
     if (this.avgParEl) {
       if (info && info.plays > 0) {
         const avg = info.totalStrokes / info.plays;
-        this.avgParEl.textContent = `Average: ${avg.toFixed(1)} strokes`;
+        this.avgParEl.textContent = t("GameTrackInfo_AverageResultL", "Average of all players: %1 strokes", avg.toFixed(1));
       } else {
         this.avgParEl.textContent = "";
       }
@@ -896,9 +902,12 @@ export class GamePanel implements Panel {
     if (this.bestParEl) {
       if (info && info.plays > 0 && info.bestPar > 0) {
         const pct = (info.numBestPar / info.plays) * 100;
-        const who = bestPlayer ? ` by ${bestPlayer}` : "";
-        this.bestParEl.textContent =
-          `Best: ${info.bestPar} stroke${info.bestPar === 1 ? "" : "s"} (${pct.toFixed(1)}%)${who}`;
+        // Stitch the L-form "Best: %1 strokes" with the optional "by <player>"
+        // tail; mirrors how Java assembles the line at runtime.
+        const head = t("GameTrackInfo_BestResultL", "Best: %1 strokes", info.bestPar);
+        const pctSuffix = t("GameTrackInfo_BestResultPercentL", "(%1% of players)", pct.toFixed(1));
+        const who = bestPlayer ? " " + t("Port_Game_BestByFmt", "by %1", bestPlayer) : "";
+        this.bestParEl.textContent = `${head} ${pctSuffix}${who}`;
       } else {
         this.bestParEl.textContent = "";
       }
@@ -920,7 +929,7 @@ export class GamePanel implements Panel {
       const num = document.createElement("span");
       num.textContent = `${i + 1}.`;
       const name = document.createElement("span");
-      name.textContent = p.nick || `Player ${i + 1}`;
+      name.textContent = p.nick || t("Port_Game_PlayerFmt", "Player %1", i + 1);
       const tracksCol = document.createElement("span");
       const cells: string[] = [];
       let totalSoFar = 0;
@@ -940,9 +949,9 @@ export class GamePanel implements Panel {
       const total = document.createElement("span");
       total.textContent = "= " + totalSoFar;
       const note = document.createElement("span");
-      if (p.holedThisTrack) note.textContent = "in hole";
-      else if (p.forfeitedThisTrack) note.textContent = "forfeited";
-      else if (p.simulating) note.textContent = "shooting";
+      if (p.holedThisTrack) note.textContent = t("Port_Game_StatusInHole", "in hole");
+      else if (p.forfeitedThisTrack) note.textContent = t("Port_Game_StatusForfeited", "forfeited");
+      else if (p.simulating) note.textContent = t("Port_Game_StatusShooting", "shooting");
       row.appendChild(num);
       row.appendChild(name);
       row.appendChild(tracksCol);
@@ -994,7 +1003,7 @@ export class GamePanel implements Panel {
     const input = document.createElement("input");
     input.type = "text";
     input.maxLength = 200;
-    input.placeholder = "Chat (Enter to send)";
+    input.placeholder = t("Port_Chat_GameInputHelp", "Chat (Enter to send)");
     input.style.flex = "1";
     input.style.fontSize = "11px";
     form.appendChild(input);
@@ -1002,7 +1011,7 @@ export class GamePanel implements Panel {
 
     const send = document.createElement("button");
     send.type = "submit";
-    send.textContent = "Send";
+    send.textContent = t("Port_Chat_Send", "Send");
     send.style.padding = "1px 8px";
     send.style.minHeight = "auto";
     send.style.fontSize = "11px";
@@ -1025,7 +1034,7 @@ export class GamePanel implements Panel {
     if (!text) return;
     input.value = "";
     this.app.connection.sendData("game", "say", text);
-    this.appendChat(`<${this.myNick}> ${text}`, "say-self");
+    this.appendChat(t("Chat_UserSay", "<%1> %2", this.myNick, text), "say-self");
   }
 
   private appendChat(line: string, kind: "say" | "say-self" | "whisper" | "system"): void {
@@ -1144,7 +1153,7 @@ export class GamePanel implements Panel {
     ov.className = "game-end-overlay";
 
     const title = document.createElement("div");
-    title.textContent = "Game over";
+    title.textContent = t("GameFin_W_GameOver", "Game over!");
     ov.appendChild(title);
 
     if (f.length > 2) {
@@ -1155,8 +1164,11 @@ export class GamePanel implements Panel {
       lines.style.textAlign = "center";
       for (let i = 0; i < this.numPlayers; i++) {
         const result = parseInt(f[2 + i] ?? "0", 10);
-        const nick = this.players[i]?.nick ?? `Player ${i + 1}`;
-        const word = result === 1 ? "Winner" : result === 0 ? "Draw" : "—";
+        const nick = this.players[i]?.nick ?? t("Port_Game_PlayerFmt", "Player %1", i + 1);
+        const word =
+          result === 1 ? t("GamePlayerInfo_Winner", "Winner!").replace(/!$/, "") :
+          result === 0 ? t("GamePlayerInfo_Draw", "Draw") :
+          "—";
         const row = document.createElement("div");
         row.textContent = `${nick}: ${word}`;
         lines.appendChild(row);
@@ -1167,7 +1179,7 @@ export class GamePanel implements Panel {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "btn-green";
-    btn.textContent = "Back to lobby";
+    btn.textContent = t("GameControl_Back", "« To menu");
     btn.addEventListener("click", () => {
       this.app.connection.sendData("game", "back");
     });
@@ -1204,7 +1216,7 @@ export class GamePanel implements Panel {
     ov.className = "game-end-overlay";
 
     const title = document.createElement("div");
-    title.textContent = `Daily Cup — ${dateKey}`;
+    title.textContent = t("Port_Daily_OverlayTitle", "Daily Cup — %1", dateKey);
     ov.appendChild(title);
 
     const lines = document.createElement("div");
@@ -1216,29 +1228,36 @@ export class GamePanel implements Panel {
 
     const score = dailyScore(result.strokes, result.average, result.forfeited);
     const verdict = result.forfeited
-      ? "Forfeited"
+      ? t("Port_Daily_VerdictForfeited", "Forfeited")
       : result.average > 0 && result.strokes < result.average
-        ? "Below average — nice!"
+        ? t("Port_Daily_VerdictBelow", "Below average — nice!")
         : result.average > 0 && result.strokes === Math.round(result.average)
-          ? "Right on average."
+          ? t("Port_Daily_VerdictOn", "Right on average.")
           : result.average > 0
-            ? "Above average."
-            : "First play!";
+            ? t("Port_Daily_VerdictAbove", "Above average.")
+            : t("Port_Daily_VerdictFirst", "First play!");
 
     const row1 = document.createElement("div");
     row1.textContent = result.forfeited
-      ? `You forfeited "${result.trackName}".`
-      : `You finished "${result.trackName}" in ${result.strokes} stroke${result.strokes === 1 ? "" : "s"}.`;
+      ? t("Port_Daily_RowForfeited", "You forfeited \"%1\".", result.trackName)
+      : t(
+          result.strokes === 1 ? "Port_Daily_RowFinished1" : "Port_Daily_RowFinishedN",
+          result.strokes === 1
+            ? "You finished \"%1\" in %2 stroke."
+            : "You finished \"%1\" in %2 strokes.",
+          result.trackName,
+          result.strokes,
+        );
     lines.appendChild(row1);
     if (result.average > 0) {
       const row2 = document.createElement("div");
-      row2.textContent = `Track average: ${result.average.toFixed(1)} strokes`;
+      row2.textContent = t("Port_Daily_RowAverage", "Track average: %1 strokes", result.average.toFixed(1));
       lines.appendChild(row2);
     }
     const row3 = document.createElement("div");
     row3.style.fontWeight = "bold";
     row3.style.marginTop = "4px";
-    row3.textContent = `Score: ${score}  —  ${verdict}`;
+    row3.textContent = t("Port_Daily_RowScore", "Score: %1  —  %2", score, verdict);
     lines.appendChild(row3);
     ov.appendChild(lines);
 
@@ -1250,11 +1269,13 @@ export class GamePanel implements Panel {
     const copyBtn = document.createElement("button");
     copyBtn.type = "button";
     copyBtn.className = "btn-green";
-    copyBtn.textContent = "Copy share text";
+    copyBtn.textContent = t("Port_Daily_CopyShareText", "Copy share text");
     copyBtn.addEventListener("click", () => {
       const text = shareText(result);
       void copyToClipboard(text).then((ok) => {
-        copyBtn.textContent = ok ? "Copied!" : "Copy failed — select & copy manually";
+        copyBtn.textContent = ok
+          ? t("Port_Daily_Copied", "Copied!")
+          : t("Port_Daily_CopyFailed", "Copy failed — select & copy manually");
         if (!ok) {
           // Fallback: drop the text into a visible textarea so the user can
           // hand-copy when the Clipboard API is gated (older browsers / iframes).
@@ -1268,7 +1289,9 @@ export class GamePanel implements Panel {
           ov.appendChild(ta);
           ta.select();
         }
-        window.setTimeout(() => { copyBtn.textContent = "Copy share text"; }, 2000);
+        window.setTimeout(() => {
+          copyBtn.textContent = t("Port_Daily_CopyShareText", "Copy share text");
+        }, 2000);
       });
     });
     btnRow.appendChild(copyBtn);
@@ -1290,11 +1313,13 @@ export class GamePanel implements Panel {
       const linkBtn = document.createElement("button");
       linkBtn.type = "button";
       linkBtn.className = "btn-blue";
-      linkBtn.textContent = "Copy replay link";
+      linkBtn.textContent = t("Port_Daily_CopyReplayLink", "Copy replay link");
       linkBtn.addEventListener("click", () => {
         const url = replayLink(replay);
         void copyToClipboard(url).then((ok) => {
-          linkBtn.textContent = ok ? "Link copied!" : "Copy failed";
+          linkBtn.textContent = ok
+            ? t("Port_Daily_LinkCopied", "Link copied!")
+            : t("Port_Daily_CopyFailedShort", "Copy failed");
           if (!ok) {
             // Fallback: drop into a textarea the user can hand-select.
             const ta = document.createElement("textarea");
@@ -1307,7 +1332,9 @@ export class GamePanel implements Panel {
             ov.appendChild(ta);
             ta.select();
           }
-          window.setTimeout(() => { linkBtn.textContent = "Copy replay link"; }, 2000);
+          window.setTimeout(() => {
+            linkBtn.textContent = t("Port_Daily_CopyReplayLink", "Copy replay link");
+          }, 2000);
         });
       });
       btnRow.appendChild(linkBtn);
@@ -1316,7 +1343,7 @@ export class GamePanel implements Panel {
     const backBtn = document.createElement("button");
     backBtn.type = "button";
     backBtn.className = "btn-blue";
-    backBtn.textContent = "Back to menu";
+    backBtn.textContent = t("GameControl_Back", "« To menu");
     backBtn.addEventListener("click", () => {
       this.app.connection.sendData("game", "back");
     });
@@ -1326,7 +1353,7 @@ export class GamePanel implements Panel {
 
     // Hint that other players keep playing even after you exit.
     const hint = document.createElement("div");
-    hint.textContent = "Other players are still on the same track.";
+    hint.textContent = t("Port_Daily_HintOthersStillPlaying", "Other players are still on the same track.");
     hint.style.fontSize = "11px";
     hint.style.color = "#666";
     hint.style.marginTop = "4px";
@@ -1354,7 +1381,7 @@ export class GamePanel implements Panel {
     const me = this.players[this.myPlayerId];
     if (!me) return;
     if (me.holedThisTrack || me.forfeitedThisTrack) return;
-    if (!window.confirm("Forfeit this hole? You'll be capped at the stroke limit.")) return;
+    if (!window.confirm(t("Port_Game_ForfeitConfirm", "Forfeit this hole? You'll be capped at the stroke limit."))) return;
     this.app.connection.sendData("game", "forfeit");
   }
 

--- a/port/web/src/panels/loading.ts
+++ b/port/web/src/panels/loading.ts
@@ -1,6 +1,7 @@
 import { PacketType, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
+import { t } from "../i18n.ts";
 
 /**
  * First panel shown. Waits for:
@@ -27,7 +28,7 @@ export class LoadingPanel implements Panel {
     wrap.className = "panel-loading";
 
     const heading = document.createElement("h1");
-    heading.textContent = "Loading...";
+    heading.textContent = t("Loader_LoadingGame", "Loading game...");
     wrap.appendChild(heading);
 
     const progress = document.createElement("div");

--- a/port/web/src/panels/lobby-multi.ts
+++ b/port/web/src/panels/lobby-multi.ts
@@ -1,6 +1,7 @@
 import { PacketType, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
+import { t } from "../i18n.ts";
 
 /** A row from the lobby's game list. Mirrors the 15-field gameString. */
 interface GameInfo {
@@ -27,18 +28,23 @@ interface PlayerInfo {
   language: string;
 }
 
-/** Index in this list = the trackType integer the server understands (1..6).
- *  The server treats trackType=0 as ALL (random across every category), so the
- *  form's "Basic" must be 1, not 0. */
-const TRACK_TYPES = ["Basic", "Traditional", "Modern", "Hole-in-one", "Short", "Long"];
-/** Convert form-array index (0-based) to server trackType id (1-based). */
-function trackTypeToServerId(formIdx: number): number {
-  return formIdx + 1;
+/** Index in this list = (server trackType id - 1). The server treats
+ *  trackType=0 as ALL (random across every category), so the form's "Basic"
+ *  is server-id 1, not 0. Resolved through `t()` so the language picker
+ *  affects rendering on both the create-game form and the game-list rows. */
+function trackTypeName(serverId: number): string {
+  switch (serverId) {
+    case 0: return t("LobbyReal_TrackTypes0", "All kind");
+    case 1: return t("LobbyReal_TrackTypes1", "Basic");
+    case 2: return t("LobbyReal_TrackTypes2", "Traditional");
+    case 3: return t("LobbyReal_TrackTypes3", "Modern");
+    case 4: return t("LobbyReal_TrackTypes4", "Hole-in-one");
+    case 5: return t("LobbyReal_TrackTypes5", "Short");
+    case 6: return t("LobbyReal_TrackTypes6", "Long");
+    default: return "?";
+  }
 }
-/** Convert server trackType id to form-array index. */
-function serverIdToTrackType(serverId: number): number {
-  return Math.max(0, serverId - 1);
-}
+const TRACK_TYPE_SERVER_IDS = [1, 2, 3, 4, 5, 6];
 
 /** Parse "3:Nick^flags^ranking^lang^profile^avatar" into a PlayerInfo. */
 function parsePlayerString(s: string): PlayerInfo {
@@ -106,32 +112,34 @@ export class LobbyMultiPanel implements Panel {
     wrap.style.background =
       "#99ff99 url('/picture/agolf/bg-lobby-multi.gif') no-repeat top left";
 
-    // Top bar: title + back
-    const topBar = document.createElement("div");
-    topBar.style.position = "absolute";
-    topBar.style.top = "8px";
-    topBar.style.left = "0";
-    topBar.style.right = "0";
-    topBar.style.display = "flex";
-    topBar.style.alignItems = "center";
-    topBar.style.justifyContent = "space-between";
-    topBar.style.padding = "0 12px";
-
+    // Top bar: centred title + back button anchored top-right. The title sits
+    // on top of the metallic-plate label baked into bg-lobby-multi.gif
+    // (centred horizontally on image-x=367, ≈ app-x=368). Absolute positioning
+    // around the panel midpoint keeps it on the plate regardless of the
+    // translated string's width.
     const title = document.createElement("div");
-    title.textContent = "Multiplayer";
+    title.textContent = t("LobbySelect_MultiPlayer", "Multiplayer");
+    title.style.position = "absolute";
+    title.style.top = "12px";
+    title.style.left = "50%";
+    title.style.transform = "translateX(-50%)";
     title.style.fontFamily = '"Times New Roman", serif';
     title.style.fontSize = "20px";
     title.style.fontWeight = "bold";
-    topBar.appendChild(title);
+    title.style.color = "#000";
+    title.style.whiteSpace = "nowrap";
+    title.style.pointerEvents = "none";
+    wrap.appendChild(title);
 
     const backBtn = document.createElement("button");
     backBtn.type = "button";
     backBtn.className = "btn-red";
-    backBtn.textContent = "Back";
+    backBtn.textContent = t("LobbyControl_Main", "« Back");
+    backBtn.style.position = "absolute";
+    backBtn.style.top = "8px";
+    backBtn.style.right = "12px";
     this.bind(backBtn, "click", () => this.goBack());
-    topBar.appendChild(backBtn);
-
-    wrap.appendChild(topBar);
+    wrap.appendChild(backBtn);
 
     // Main area: 2 columns (left = game list, right = players + create form)
     const main = document.createElement("div");
@@ -141,11 +149,21 @@ export class LobbyMultiPanel implements Panel {
     main.style.right = "8px";
     main.style.bottom = "150px";
     main.style.display = "grid";
-    main.style.gridTemplateColumns = "1fr 280px";
+    // Column widths chosen so the gap between the games box and the right
+    // column lines up with the vertical divider painted into bg-lobby-multi.gif
+    // (a black bar centred on image-x=367, ≈ app-x=368). Main is positioned
+    // at left:8 right:8 inside #app's 733px content area, so it spans
+    // app-x 9..726. With gap=8, splitting at app-x 368 gives:
+    //   games:  app-x 9 → 363  (width 355)
+    //   right:  app-x 371 → 725 (width 354)
+    // 354px is enough for the longest Finnish dropdown option
+    // ("Takaisin lyöntipaikkaan") given the form's label-auto / select-fill
+    // grid layout below.
+    main.style.gridTemplateColumns = "1fr 354px";
     main.style.gap = "8px";
 
     // Game list
-    const gamesBox = this.makeBox("Games");
+    const gamesBox = this.makeBox(t("Port_Lobby_Games", "Games"));
     const gamesScroll = document.createElement("div");
     gamesScroll.style.overflowY = "auto";
     gamesScroll.style.flex = "1";
@@ -162,7 +180,7 @@ export class LobbyMultiPanel implements Panel {
     rightCol.style.gridTemplateRows = "1fr auto";
     rightCol.style.gap = "8px";
 
-    const playersBox = this.makeBox("Players");
+    const playersBox = this.makeBox(t("LobbyReal_ListTitlePlayers", "Players"));
     const playersScroll = document.createElement("div");
     playersScroll.style.overflowY = "auto";
     playersScroll.style.flex = "1";
@@ -221,7 +239,9 @@ export class LobbyMultiPanel implements Panel {
           const p = parsePlayerString(f[2] ?? "");
           this.players.set(p.nick, p);
           this.refreshPlayers();
-          if (verb === "join") this.appendChat(`* ${p.nick} joined the lobby`, "system");
+          if (verb === "join") {
+            this.appendChat("* " + t("LobbyChat_UserJoined", "%1 joined the lobby", p.nick), "system");
+          }
           break;
         }
         case "ownjoin": {
@@ -235,7 +255,7 @@ export class LobbyMultiPanel implements Panel {
           const nick = f[2] ?? "";
           this.players.delete(nick);
           this.refreshPlayers();
-          this.appendChat(`* ${nick} left the lobby`, "system");
+          this.appendChat("* " + t("LobbyChat_UserLeft", "%1 left the lobby", nick), "system");
           break;
         }
         case "gamelist":
@@ -260,7 +280,7 @@ export class LobbyMultiPanel implements Panel {
           // lobby sayp <senderNick> <text>
           const sender = f[2] ?? "?";
           const text = f[3] ?? "";
-          this.appendChat(`[whisper from ${sender}] ${text}`, "whisper");
+          this.appendChat(t("Port_Chat_WhisperFromFmt", "[whisper from %1] %2", sender, text), "whisper");
           break;
         }
         default:
@@ -278,7 +298,7 @@ export class LobbyMultiPanel implements Panel {
       return;
     }
     if (head === "error" && f[1] === "wrongpassword") {
-      this.appendChat("* Wrong password.", "system");
+      this.appendChat("* " + t("LobbyReal_JoinError3", "Wrong password"), "system");
       return;
     }
   }
@@ -334,54 +354,72 @@ export class LobbyMultiPanel implements Panel {
     wrap.style.fontSize = "12px";
 
     const head = document.createElement("div");
-    head.textContent = "Create game";
+    head.textContent = t("LobbyReal_CreateGame", "Create game");
     head.style.fontWeight = "bold";
     head.style.marginBottom = "4px";
     wrap.appendChild(head);
 
     const grid = document.createElement("div");
     grid.style.display = "grid";
-    grid.style.gridTemplateColumns = "auto 1fr";
+    // `minmax(0, 1fr)` lets the input column shrink below its content's natural
+    // width — without this the 1fr track grows to fit the widest dropdown
+    // option (e.g. Finnish "Takaisin lyöntipaikkaan") and overflows the
+    // panel's 320px right column.
+    grid.style.gridTemplateColumns = "auto minmax(0, 1fr)";
     grid.style.rowGap = "3px";
     grid.style.columnGap = "6px";
     grid.style.alignItems = "center";
 
+    /** Inputs/selects are stretched to fill the grid cell + min-width:0 so
+     *  they may shrink below their intrinsic content width. Reused for every
+     *  form field below. */
+    const fillCell = (el: HTMLElement): void => {
+      el.style.width = "100%";
+      el.style.minWidth = "0";
+    };
+
     const nameInput = document.createElement("input");
     nameInput.type = "text";
-    nameInput.value = "My Game";
+    nameInput.value = t("Port_Lobby_DefaultGameName", "My Game");
     nameInput.maxLength = 24;
-    grid.appendChild(this.label("Name:"));
+    fillCell(nameInput);
+    grid.appendChild(this.label(t("LobbyReal_GameName", "Game name:")));
     grid.appendChild(nameInput);
 
     const passwordInput = document.createElement("input");
     passwordInput.type = "text";
-    passwordInput.placeholder = "(blank = open)";
+    passwordInput.placeholder = t("Port_Lobby_BlankOpenHint", "(blank = open)");
     passwordInput.maxLength = 24;
-    grid.appendChild(this.label("Password:"));
+    fillCell(passwordInput);
+    grid.appendChild(this.label(t("LobbyReal_GamePassword", "Game password:")));
     grid.appendChild(passwordInput);
 
     const numPlayersSel = this.numericSelect([2, 3, 4], "2");
-    grid.appendChild(this.label("Players:"));
+    fillCell(numPlayersSel);
+    grid.appendChild(this.label(t("LobbyReal_PlayerCount", "Number of players:")));
     grid.appendChild(numPlayersSel);
 
     const trackTypeSel = document.createElement("select");
     this.trackTypeSel = trackTypeSel;
     this.populateTrackTypeOptions();
-    grid.appendChild(this.label("Track type:"));
+    fillCell(trackTypeSel);
+    grid.appendChild(this.label(t("LobbyReal_TrackTypes", "Track types:")));
     grid.appendChild(trackTypeSel);
 
     const numTracksSel = this.numericSelect([1, 3, 5, 9, 18], "9");
-    grid.appendChild(this.label("Tracks:"));
+    fillCell(numTracksSel);
+    grid.appendChild(this.label(t("LobbyReal_TrackCount", "Number of tracks:")));
     grid.appendChild(numTracksSel);
 
     const maxStrokesSel = this.numericSelect([5, 10, 15, 20, 25, 30], "10");
-    grid.appendChild(this.label("Max strokes:"));
+    fillCell(maxStrokesSel);
+    grid.appendChild(this.label(t("LobbyReal_MaxStrokes", "Max strokes per track:")));
     grid.appendChild(maxStrokesSel);
 
     const collisionSel = document.createElement("select");
     for (const [v, label] of [
-      ["0", "No collision"],
-      ["1", "Players collide"],
+      ["0", t("LobbyReal_Collision1", "No")],
+      ["1", t("LobbyReal_Collision2", "Yes")],
     ] as const) {
       const o = document.createElement("option");
       o.value = v;
@@ -389,20 +427,22 @@ export class LobbyMultiPanel implements Panel {
       collisionSel.appendChild(o);
     }
     collisionSel.disabled = true;
-    grid.appendChild(this.label("Collision:"));
+    fillCell(collisionSel);
+    grid.appendChild(this.label(t("LobbyReal_Collision", "Ball collisions:")));
     grid.appendChild(collisionSel);
 
     const waterSel = document.createElement("select");
     for (const [v, label] of [
-      ["0", "Back to last hit"],
-      ["1", "Back to shore"],
+      ["0", t("LobbyReal_WaterEvent1", "Back to start")],
+      ["1", t("LobbyReal_WaterEvent2", "Stay on shore")],
     ] as const) {
       const o = document.createElement("option");
       o.value = v;
       o.textContent = label;
       waterSel.appendChild(o);
     }
-    grid.appendChild(this.label("Water:"));
+    fillCell(waterSel);
+    grid.appendChild(this.label(t("LobbyReal_WaterEvent", "When ball goes to water:")));
     grid.appendChild(waterSel);
 
     wrap.appendChild(grid);
@@ -410,7 +450,7 @@ export class LobbyMultiPanel implements Panel {
     const createBtn = document.createElement("button");
     createBtn.type = "button";
     createBtn.className = "btn-green";
-    createBtn.textContent = "Create";
+    createBtn.textContent = t("LobbyReal_CreateGame", "Create game");
     createBtn.style.marginTop = "6px";
     this.bind(createBtn, "click", () => {
       const name = (nameInput.value || "Game").trim();
@@ -486,14 +526,14 @@ export class LobbyMultiPanel implements Panel {
     const input = document.createElement("input");
     input.type = "text";
     input.maxLength = 200;
-    input.placeholder = "Press enter to chat (start with /msg <nick> for a whisper)";
+    input.placeholder = t("Port_Chat_LobbyInputHelp", "Press enter to chat (start with /msg <nick> for a whisper)");
     input.style.flex = "1";
     inputRow.appendChild(input);
     this.chatInputEl = input;
 
     const sendBtn = document.createElement("button");
     sendBtn.type = "submit";
-    sendBtn.textContent = "Send";
+    sendBtn.textContent = t("Port_Chat_Send", "Send");
     inputRow.appendChild(sendBtn);
 
     this.bind(inputRow, "submit", (ev: Event) => {
@@ -509,11 +549,12 @@ export class LobbyMultiPanel implements Panel {
   private populateTrackTypeOptions(): void {
     const sel = this.trackTypeSel;
     if (!sel) return;
-    const prev = sel.value || String(trackTypeToServerId(1));
+    const prev = sel.value || "1";
     while (sel.firstChild) sel.removeChild(sel.firstChild);
 
     const counts = this.tagCounts;
-    const labelFor = (serverId: number, name: string): string => {
+    const labelFor = (serverId: number): string => {
+      const name = trackTypeName(serverId);
       if (!counts) return name;
       const n = counts[serverId] ?? 0;
       return `${name} (${n})`;
@@ -521,13 +562,12 @@ export class LobbyMultiPanel implements Panel {
 
     const mixed = document.createElement("option");
     mixed.value = "0";
-    mixed.textContent = labelFor(0, "Mixed");
+    mixed.textContent = labelFor(0);
     sel.appendChild(mixed);
-    for (let i = 0; i < TRACK_TYPES.length; i++) {
-      const id = trackTypeToServerId(i);
+    for (const id of TRACK_TYPE_SERVER_IDS) {
       const o = document.createElement("option");
       o.value = String(id);
-      o.textContent = labelFor(id, TRACK_TYPES[i]);
+      o.textContent = labelFor(id);
       sel.appendChild(o);
     }
     sel.value = prev;
@@ -579,7 +619,7 @@ export class LobbyMultiPanel implements Panel {
       empty.style.padding = "8px";
       empty.style.color = "#666";
       empty.style.fontStyle = "italic";
-      empty.textContent = "(No games yet — create one to get started)";
+      empty.textContent = t("Port_Lobby_NoGamesYet", "(No games yet — create one to get started)");
       el.appendChild(empty);
       return;
     }
@@ -610,7 +650,7 @@ export class LobbyMultiPanel implements Panel {
     row.appendChild(name);
 
     const meta = document.createElement("span");
-    const ttype = g.trackType === 0 ? "Mixed" : (TRACK_TYPES[serverIdToTrackType(g.trackType)] ?? "?");
+    const ttype = trackTypeName(g.trackType);
     meta.textContent = `${ttype} · ${g.numTracks}t`;
     meta.style.fontSize = "11px";
     meta.style.color = "#406040";
@@ -624,12 +664,12 @@ export class LobbyMultiPanel implements Panel {
     const join = document.createElement("button");
     join.type = "button";
     join.className = "btn-blue";
-    join.textContent = "Join";
+    join.textContent = t("LobbyReal_JoinGame", "Join game");
     join.style.padding = "1px 8px";
     join.style.minHeight = "auto";
     if (g.currentPlayers >= g.numPlayers) {
       join.disabled = true;
-      join.textContent = "Full";
+      join.textContent = t("LobbySelect_Full", "(Full)");
     } else {
       this.bind(join, "click", () => this.joinGame(g));
     }
@@ -643,7 +683,9 @@ export class LobbyMultiPanel implements Panel {
   private joinGame(g: GameInfo): void {
     let password = "-";
     if (g.passworded) {
-      const entered = window.prompt(`Password for "${g.name}":`);
+      const entered = window.prompt(
+        t("LobbyRealPassword_EnterPassword", "Enter game password") + ` "${g.name}":`,
+      );
       if (entered === null) return;
       password = entered.trim() || "-";
     }
@@ -669,7 +711,7 @@ export class LobbyMultiPanel implements Panel {
         const target = rest.substring(0, space);
         const body = rest.substring(space + 1);
         this.app.connection.sendData("lobby", "sayp", target, body);
-        this.appendChat(`[whisper to ${target}] ${body}`, "whisper");
+        this.appendChat(t("Port_Chat_WhisperToFmt", "[whisper to %1] %2", target, body), "whisper");
       }
       return;
     }

--- a/port/web/src/panels/lobby.ts
+++ b/port/web/src/panels/lobby.ts
@@ -1,6 +1,7 @@
 import { PacketType, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
+import { t } from "../i18n.ts";
 
 /**
  * Single-player lobby — visual port of agolf.lobby.LobbySinglePlayerPanel.
@@ -19,15 +20,20 @@ export class LobbyPanel implements Panel {
   private listeners: Array<() => void> = [];
   private tagCounts: number[] | null = null;
 
-  private static readonly TRACK_TYPE_NAMES: Array<[string, string]> = [
-    ["0", "Mixed"],
-    ["1", "Basic"],
-    ["2", "Traditional"],
-    ["3", "Modern"],
-    ["4", "Hole-in-one"],
-    ["5", "Short"],
-    ["6", "Long"],
-  ];
+  /** Indexed by trackType id (0 = mixed, 1..6 = categories). Mirrors
+   *  Java `LobbyReal_TrackTypes<n>` keys. Resolved fresh each call so a
+   *  language change after panel construction picks up the new strings. */
+  private trackTypeNames(): Array<[string, string]> {
+    return [
+      ["0", t("LobbyReal_TrackTypes0", "All kind")],
+      ["1", t("LobbyReal_TrackTypes1", "Basic")],
+      ["2", t("LobbyReal_TrackTypes2", "Traditional")],
+      ["3", t("LobbyReal_TrackTypes3", "Modern")],
+      ["4", t("LobbyReal_TrackTypes4", "Hole-in-one")],
+      ["5", t("LobbyReal_TrackTypes5", "Short")],
+      ["6", t("LobbyReal_TrackTypes6", "Long")],
+    ];
+  }
 
   constructor(app: App) {
     this.app = app;
@@ -39,14 +45,14 @@ export class LobbyPanel implements Panel {
 
     const nameplate = document.createElement("div");
     nameplate.className = "nameplate";
-    nameplate.textContent = "Single player";
+    nameplate.textContent = t("LobbySelect_SinglePlayer", "Single player");
     wrap.appendChild(nameplate);
 
     const controls = document.createElement("div");
     controls.className = "controls";
 
     // Track type — populated lazily once `lobby tagcounts` arrives.
-    const typeGroup = this.makeGroup("Track type");
+    const typeGroup = this.makeGroup(t("LobbyReal_TrackTypes", "Track types:").replace(/:$/, ""));
     const trackType = document.createElement("select");
     typeGroup.appendChild(trackType);
     controls.appendChild(typeGroup);
@@ -55,7 +61,7 @@ export class LobbyPanel implements Panel {
     trackType.value = "2"; // Traditional default
 
     // Number of tracks
-    const numGroup = this.makeGroup("Tracks");
+    const numGroup = this.makeGroup(t("LobbyReal_ListTitleTracks", "Tracks"));
     const num = document.createElement("select");
     for (const n of [1, 3, 5, 9, 18]) {
       const opt = document.createElement("option");
@@ -69,11 +75,11 @@ export class LobbyPanel implements Panel {
     this.numTracksSel = num;
 
     // Water-event
-    const waterGroup = this.makeGroup("Water");
+    const waterGroup = this.makeGroup(t("LobbyReal_WaterEvent", "When ball goes to water:").replace(/:$/, ""));
     const water = document.createElement("select");
     for (const [v, label] of [
-      ["0", "Back to last hit"],
-      ["1", "Back to shore"],
+      ["0", t("LobbyReal_WaterEvent1", "Back to start")],
+      ["1", t("LobbyReal_WaterEvent2", "Stay on shore")],
     ] as const) {
       const opt = document.createElement("option");
       opt.value = v;
@@ -89,7 +95,7 @@ export class LobbyPanel implements Panel {
     const startBtn = document.createElement("button");
     startBtn.type = "button";
     startBtn.className = "btn-green";
-    startBtn.textContent = "Start training";
+    startBtn.textContent = t("LobbyReal_Start", "Start");
     const startHandler = (): void => this.startTraining();
     startBtn.addEventListener("click", startHandler);
     this.listeners.push(() => startBtn.removeEventListener("click", startHandler));
@@ -98,7 +104,7 @@ export class LobbyPanel implements Panel {
     const backBtn = document.createElement("button");
     backBtn.type = "button";
     backBtn.className = "btn-red";
-    backBtn.textContent = "Back";
+    backBtn.textContent = t("LobbyControl_Main", "« Back");
     const backHandler = (): void => {
       // `lobbyselect leave` removes us from this lobby on the server and the
       // server replies with `status lobbyselect 300`, which routes us back.
@@ -155,7 +161,7 @@ export class LobbyPanel implements Panel {
     if (!sel) return;
     const prev = sel.value || "2";
     while (sel.firstChild) sel.removeChild(sel.firstChild);
-    for (const [id, name] of LobbyPanel.TRACK_TYPE_NAMES) {
+    for (const [id, name] of this.trackTypeNames()) {
       const opt = document.createElement("option");
       opt.value = id;
       const n = this.tagCounts ? this.tagCounts[parseInt(id, 10)] : undefined;

--- a/port/web/src/panels/lobbyselect.ts
+++ b/port/web/src/panels/lobbyselect.ts
@@ -2,6 +2,7 @@ import { PacketType, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
 import { todayKey, getDailyResult } from "../daily.ts";
+import { t } from "../i18n.ts";
 
 /**
  * Lobby-select panel — visual port of agolf.LobbySelectPanel, repurposed:
@@ -39,10 +40,15 @@ export class LobbySelectPanel implements Panel {
     const titles = document.createElement("div");
     titles.className = "lobby-titles";
 
+    // Title positions in pixels, matching the bg image's 735px-wide column
+    // thirds (centres at 122.5 / 367.5 / 612.5). Percent positions would
+    // resolve against #app's 733px content area (1px border eats 2px) and
+    // slip a pixel left of the image's divider lines.
     const positions: Array<["1" | "2" | "3", string, string]> = [
-      ["1", "Single player", "16.66%"],
-      ["2", "Daily Cup", "50%"],
-      ["3", "Multiplayer", "83.33%"],
+      ["1", t("LobbySelect_SinglePlayer", "Single player"), "122.5px"],
+      // "Daily Cup" is port-specific (replaces the original DUAL column).
+      ["2", t("Port_LobbySelect_DailyCup", "Daily Cup"), "367.5px"],
+      ["3", t("LobbySelect_MultiPlayer", "Multiplayer"), "612.5px"],
     ];
     const counts: Record<"1" | "2" | "3", HTMLElement> = {
       1: this.makeCount(),
@@ -66,29 +72,46 @@ export class LobbySelectPanel implements Panel {
     wrap.appendChild(titles);
 
     // Three button columns: Single / Daily / Multi.
-    wrap.appendChild(this.makeColumn(1, "Single player", "Quick start", () => this.selectSingle(), () => this.quickSingle()));
+    wrap.appendChild(this.makeColumn(
+      1,
+      t("LobbySelect_SinglePlayer", "Single player"),
+      t("LobbySelect_QuickStart", "Quick start"),
+      () => this.selectSingle(),
+      () => this.quickSingle(),
+    ));
     wrap.appendChild(this.makeDailyColumn());
-    wrap.appendChild(this.makeColumn(3, "Multiplayer", "Quick start", () => this.selectMulti(), () => this.quickMulti()));
+    wrap.appendChild(this.makeColumn(
+      3,
+      t("LobbySelect_MultiPlayer", "Multiplayer"),
+      t("LobbySelect_QuickStart", "Quick start"),
+      () => this.selectMulti(),
+      () => this.quickMulti(),
+    ));
 
     // Footer: graphics / audio / quit
     const footer = document.createElement("div");
     footer.className = "footer";
 
+    const gfxPrefix = t("LobbySelect_Gfx", "Graphics:");
+    const gfxLabels = [
+      t("LobbySelect_Gfx0", "Plain (minimum)"),
+      t("LobbySelect_Gfx1", "Some details (fast)"),
+      t("LobbySelect_Gfx2", "Full details (slower)"),
+      t("LobbySelect_Gfx3", "Full + animations"),
+    ];
     const gfx = document.createElement("select");
-    for (const label of [
-      "Graphics: Low",
-      "Graphics: Medium",
-      "Graphics: High",
-      "Graphics: Maximum",
-    ]) {
+    for (const label of gfxLabels) {
       const opt = document.createElement("option");
-      opt.textContent = label;
+      opt.textContent = `${gfxPrefix} ${label}`;
       gfx.appendChild(opt);
     }
     gfx.selectedIndex = 2;
 
     const audio = document.createElement("select");
-    for (const label of ["Audio: On", "Audio: Off"]) {
+    for (const label of [
+      t("Port_LobbySelect_AudioOn", "Audio: On"),
+      t("Port_LobbySelect_AudioOff", "Audio: Off"),
+    ]) {
       const opt = document.createElement("option");
       opt.textContent = label;
       audio.appendChild(opt);
@@ -97,7 +120,7 @@ export class LobbySelectPanel implements Panel {
     const quit = document.createElement("button");
     quit.type = "button";
     quit.className = "btn-red";
-    quit.textContent = "Quit";
+    quit.textContent = t("LobbySelect_Quit", "Quit");
     const quitHandler = (): void => {
       // Best we can do in a browser tab.
       try { window.close(); } catch { /* noop */ }
@@ -169,16 +192,16 @@ export class LobbySelectPanel implements Panel {
   private makeCount(): HTMLElement {
     const el = document.createElement("div");
     el.className = "lobby-count";
-    el.textContent = "(No players)";
+    el.textContent = t("LobbySelect_Players0", "(No players)");
     return el;
   }
 
   private setCount(el: HTMLElement | null, n: number): void {
     if (!el) return;
     if (!Number.isFinite(n) || n < 0) return;
-    if (n === 0) el.textContent = "(No players)";
-    else if (n === 1) el.textContent = "(1 player)";
-    else el.textContent = `(${n} players)`;
+    if (n === 0) el.textContent = t("LobbySelect_Players0", "(No players)");
+    else if (n === 1) el.textContent = t("LobbySelect_Players1", "(1 player)");
+    else el.textContent = t("LobbySelect_PlayersX", "(%1 players)", n);
   }
 
   private makeColumn(
@@ -233,13 +256,24 @@ export class LobbySelectPanel implements Panel {
     const existing = getDailyResult();
     if (existing) {
       btn.disabled = true;
-      btn.textContent = "Already played today";
-      btn.title =
-        `${todayKey()}: ${existing.forfeited ? "forfeited" : `${existing.strokes} strokes`}` +
-        ` (avg ${existing.average.toFixed(1)}). Come back tomorrow.`;
+      btn.textContent = t("Port_Daily_AlreadyPlayed", "Already played today");
+      const verdict = existing.forfeited
+        ? t("Port_Daily_Forfeited", "forfeited")
+        : t("Port_Daily_Strokes", "%1 strokes", existing.strokes);
+      btn.title = t(
+        "Port_Daily_ButtonTitleDone",
+        "%1: %2 (avg %3). Come back tomorrow.",
+        todayKey(),
+        verdict,
+        existing.average.toFixed(1),
+      );
     } else {
-      btn.textContent = "Daily Cup";
-      btn.title = `${todayKey()} — same track for everyone today.`;
+      btn.textContent = t("Port_LobbySelect_DailyCup", "Daily Cup");
+      btn.title = t(
+        "Port_Daily_ButtonTitle",
+        "%1 — same track for everyone today.",
+        todayKey(),
+      );
       const handler = (): void => this.selectDaily();
       btn.addEventListener("click", handler);
       this.listeners.push(() => btn.removeEventListener("click", handler));

--- a/port/web/src/panels/login.ts
+++ b/port/web/src/panels/login.ts
@@ -1,8 +1,7 @@
 import { PacketType, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
-
-type Lang = "en" | "fi" | "sv";
+import { i18n, saveLang, t, type Lang } from "../i18n.ts";
 
 /**
  * Drives the login handshake:
@@ -21,6 +20,7 @@ export class LoginPanel implements Panel {
   private statusEl: HTMLElement | null = null;
   private submitting = false;
   private submitHandler: ((ev: SubmitEvent) => void) | null = null;
+  private langChangeHandler: ((ev: Event) => void) | null = null;
 
   constructor(app: App) {
     this.app = app;
@@ -40,7 +40,7 @@ export class LoginPanel implements Panel {
     const nameRow = document.createElement("div");
     nameRow.className = "form-row";
     const nameLabel = document.createElement("label");
-    nameLabel.textContent = "Username";
+    nameLabel.textContent = t("Login_EnterNick", "Your nickname:");
     nameLabel.htmlFor = "field-username";
     const nameInput = document.createElement("input");
     nameInput.type = "text";
@@ -54,20 +54,40 @@ export class LoginPanel implements Panel {
     const langRow = document.createElement("div");
     langRow.className = "form-row";
     const langLabel = document.createElement("label");
-    langLabel.textContent = "Language";
+    // No matching key in AGolf.xml — Java surfaces languages via Language_<code>
+    // values but never had a "Language:" label key. Use the port-specific
+    // Port_Login_Language so a translator can add it later if desired.
+    langLabel.textContent = t("Port_Login_Language", "Language");
     langLabel.htmlFor = "field-lang";
     const langSelect = document.createElement("select");
     langSelect.id = "field-lang";
-    for (const [val, label] of [
+    // Render the language names through the same XML so each locale's display
+    // string is the one its own AGolf.xml provides (English: "Finnish",
+    // Finnish: "suomi", etc.). Falls back to the inline defaults if the key
+    // isn't present.
+    for (const [val, fallback] of [
       ["en", "English"],
       ["fi", "Suomi"],
       ["sv", "Svenska"],
     ] as const) {
       const opt = document.createElement("option");
       opt.value = val;
-      opt.textContent = label;
+      opt.textContent = t(`Language_${val}`, fallback);
       langSelect.appendChild(opt);
     }
+    // Default to the saved-language preference (or EN). Triggers below pre-load
+    // the chosen XML so the moment we transition to lobbyselect the strings
+    // are already resolved.
+    langSelect.value = i18n.language;
+    const langChange = (): void => {
+      const lang = (langSelect.value || "en") as Lang;
+      saveLang(lang);
+      void i18n.setLanguage(lang).catch((err) => {
+        console.warn("[login] language load failed", err);
+      });
+    };
+    langSelect.addEventListener("change", langChange);
+    this.langChangeHandler = langChange;
     langRow.appendChild(langLabel);
     langRow.appendChild(langSelect);
     form.appendChild(langRow);
@@ -79,7 +99,7 @@ export class LoginPanel implements Panel {
     const connectBtn = document.createElement("button");
     connectBtn.type = "submit";
     connectBtn.className = "btn-green";
-    connectBtn.textContent = "Connect";
+    connectBtn.textContent = t("Login_Ok", "Connect");
     btnRow.appendChild(spacer);
     btnRow.appendChild(connectBtn);
     form.appendChild(btnRow);
@@ -116,12 +136,16 @@ export class LoginPanel implements Panel {
     if (this.form && this.submitHandler) {
       this.form.removeEventListener("submit", this.submitHandler);
     }
+    if (this.langSelect && this.langChangeHandler) {
+      this.langSelect.removeEventListener("change", this.langChangeHandler);
+    }
     this.form = null;
     this.nameInput = null;
     this.langSelect = null;
     this.connectBtn = null;
     this.statusEl = null;
     this.submitHandler = null;
+    this.langChangeHandler = null;
   }
 
   onPacket(pkt: Packet): void {
@@ -131,17 +155,17 @@ export class LoginPanel implements Panel {
     const head = fields[0];
 
     if (head === "versok") {
-      this.setStatus("Version OK, sending language...");
+      this.setStatus(t("Port_Login_StatusVersOk", "Version OK, sending language..."));
       return;
     }
     if (head === "error" && fields[1] === "vernotok") {
-      this.setStatus("Server rejected client version.");
+      this.setStatus(t("Message_VersionError", "Server rejected client version."));
       this.submitting = false;
       this.setEnabled(true);
       return;
     }
     if (head === "basicinfo") {
-      this.setStatus("Logged in. Awaiting lobby...");
+      this.setStatus(t("Port_Login_StatusBasicInfo", "Logged in. Awaiting lobby..."));
       return;
     }
     if (head === "status" && fields[1] === "lobbyselect") {
@@ -153,13 +177,21 @@ export class LoginPanel implements Panel {
   private submit(): void {
     if (this.submitting) return;
     if (!this.app.connection.isOpen) {
-      this.setStatus("Not connected.");
+      this.setStatus(t("Port_Login_NotConnected", "Not connected."));
       return;
     }
     this.submitting = true;
     this.setEnabled(false);
 
     const lang = (this.langSelect?.value ?? "en") as Lang;
+    // Make sure the chosen locale's XML is loaded before any post-login panel
+    // mounts. Awaited fire-and-forget — the panel transition is server-driven
+    // (waits for `status lobbyselect`), so the round-trip gives `setLanguage`
+    // ample time to finish.
+    saveLang(lang);
+    void i18n.setLanguage(lang).catch((err) => {
+      console.warn("[login] language load failed", err);
+    });
     const rawNick = (this.nameInput?.value ?? "").trim();
     // Server-side sanitiser will accept/reject; we only strip our own framing
     // chars here so we never split the packet on the wire.
@@ -177,7 +209,7 @@ export class LoginPanel implements Panel {
     if (nick) this.app.connection.sendData("nick", nick);
     this.app.connection.sendData("login");
 
-    this.setStatus("Authenticating...");
+    this.setStatus(t("Login_Wait", "Authenticating..."));
   }
 
   private setEnabled(enabled: boolean): void {

--- a/port/web/src/panels/replay.ts
+++ b/port/web/src/panels/replay.ts
@@ -27,6 +27,7 @@ import {
 } from "../game/physics.ts";
 import type { DailyReplay } from "../daily.ts";
 import type { Panel } from "../panel.ts";
+import { t } from "../i18n.ts";
 
 const DEV = Boolean(import.meta.env?.DEV);
 
@@ -77,11 +78,11 @@ export class ReplayPanel implements Panel {
     header.className = "replay-header";
     const title = document.createElement("div");
     title.className = "replay-title";
-    title.textContent = `Daily Cup Replay — ${this.replay.d}`;
+    title.textContent = t("Port_Replay_Title", "Daily Cup Replay — %1", this.replay.d);
     const meta = document.createElement("div");
     meta.className = "replay-meta";
-    const tn = this.replay.n || "(unknown track)";
-    const ta = this.replay.a ? ` by ${this.replay.a}` : "";
+    const tn = this.replay.n || t("Port_Replay_UnknownTrack", "(unknown track)");
+    const ta = this.replay.a ? " " + t("Port_Game_AuthorByFmt", "by %1", this.replay.a) : "";
     meta.textContent = `${tn}${ta}`;
     header.appendChild(title);
     header.appendChild(meta);
@@ -100,21 +101,21 @@ export class ReplayPanel implements Panel {
     this.playBtn = document.createElement("button");
     this.playBtn.type = "button";
     this.playBtn.className = "btn-green";
-    this.playBtn.textContent = "Play";
+    this.playBtn.textContent = t("Port_Replay_Play", "Play");
     this.playBtn.addEventListener("click", () => this.togglePlay());
     controls.appendChild(this.playBtn);
 
     const restartBtn = document.createElement("button");
     restartBtn.type = "button";
     restartBtn.className = "btn-blue";
-    restartBtn.textContent = "Restart";
+    restartBtn.textContent = t("Port_Replay_Restart", "Restart");
     restartBtn.addEventListener("click", () => this.restart());
     controls.appendChild(restartBtn);
 
     const exitBtn = document.createElement("button");
     exitBtn.type = "button";
     exitBtn.className = "btn-blue";
-    exitBtn.textContent = "Exit replay";
+    exitBtn.textContent = t("Port_Replay_Exit", "Exit replay");
     exitBtn.addEventListener("click", () => {
       // Clearing the hash & reloading drops us back into the regular app boot.
       window.location.hash = "";
@@ -130,7 +131,7 @@ export class ReplayPanel implements Panel {
 
     this.statusEl = document.createElement("div");
     this.statusEl.className = "replay-status";
-    this.statusEl.textContent = "Loading sprites…";
+    this.statusEl.textContent = t("Port_Game_LoadingSprites", "Loading sprites…");
     wrap.appendChild(this.statusEl);
 
     this.boot();
@@ -160,13 +161,19 @@ export class ReplayPanel implements Panel {
       this.placeAtFirstStrokeOrigin();
       this.updateStrokeLabel();
       this.setStatus(this.replay.s.length > 0
-        ? `Press Play to watch ${this.replay.s.length} stroke${this.replay.s.length === 1 ? "" : "s"}.`
-        : "No strokes recorded — this run was forfeited before shooting.");
+        ? t(
+            this.replay.s.length === 1 ? "Port_Replay_PressPlay1" : "Port_Replay_PressPlayN",
+            this.replay.s.length === 1
+              ? "Press Play to watch %1 stroke."
+              : "Press Play to watch %1 strokes.",
+            this.replay.s.length,
+          )
+        : t("Port_Replay_NoStrokes", "No strokes recorded — this run was forfeited before shooting."));
       this.draw();
       this.startLoop();
     } catch (err) {
       if (DEV) console.warn("[replay] boot failed", err);
-      this.setStatus("Replay failed to load: " + String(err));
+      this.setStatus(t("Port_Replay_LoadFailed", "Replay failed to load: %1", String(err)));
     }
   }
 
@@ -190,7 +197,11 @@ export class ReplayPanel implements Panel {
       return;
     }
     this.paused = !this.paused;
-    if (this.playBtn) this.playBtn.textContent = this.paused ? "Play" : "Pause";
+    if (this.playBtn) {
+      this.playBtn.textContent = this.paused
+        ? t("Port_Replay_Play", "Play")
+        : t("Port_Replay_Pause", "Pause");
+    }
     if (!this.paused && !this.simulating) {
       this.armNextStroke();
     }
@@ -201,12 +212,18 @@ export class ReplayPanel implements Panel {
     this.simulating = false;
     this.finished = false;
     this.paused = true;
-    if (this.playBtn) this.playBtn.textContent = "Play";
+    if (this.playBtn) this.playBtn.textContent = t("Port_Replay_Play", "Play");
     this.placeAtFirstStrokeOrigin();
     this.updateStrokeLabel();
     this.setStatus(this.replay.s.length > 0
-      ? `Press Play to watch ${this.replay.s.length} stroke${this.replay.s.length === 1 ? "" : "s"}.`
-      : "No strokes recorded.");
+      ? t(
+          this.replay.s.length === 1 ? "Port_Replay_PressPlay1" : "Port_Replay_PressPlayN",
+          this.replay.s.length === 1
+            ? "Press Play to watch %1 stroke."
+            : "Press Play to watch %1 strokes.",
+          this.replay.s.length,
+        )
+      : t("Port_Replay_NoStrokesShort", "No strokes recorded."));
     this.draw();
   }
 
@@ -252,10 +269,15 @@ export class ReplayPanel implements Panel {
     this.finished = true;
     this.paused = true;
     this.simulating = false;
-    if (this.playBtn) this.playBtn.textContent = "Restart";
-    const verb = this.replay.holed ? "Holed in" : "Forfeited at";
+    if (this.playBtn) this.playBtn.textContent = t("Port_Replay_Restart", "Restart");
     const n = this.replay.s.length;
-    this.setStatus(`${verb} ${n} stroke${n === 1 ? "" : "s"}.`);
+    const key = this.replay.holed
+      ? (n === 1 ? "Port_Replay_HoledIn1" : "Port_Replay_HoledInN")
+      : (n === 1 ? "Port_Replay_Forfeited1" : "Port_Replay_ForfeitedN");
+    const fallback = this.replay.holed
+      ? (n === 1 ? "Holed in %1 stroke." : "Holed in %1 strokes.")
+      : (n === 1 ? "Forfeited at %1 stroke." : "Forfeited at %1 strokes.");
+    this.setStatus(t(key, fallback, n));
   }
 
   // ----- physics tick ---------------------------------------------------
@@ -323,6 +345,6 @@ export class ReplayPanel implements Panel {
     // strokeIdx is incremented when a stroke is armed, so it doubles as the
     // 1-based count of strokes already started.
     const cur = Math.min(this.strokeIdx, total);
-    this.strokeEl.textContent = total > 0 ? `Stroke ${cur} / ${total}` : "";
+    this.strokeEl.textContent = total > 0 ? t("Port_Replay_StrokeNOfM", "Stroke %1 / %2", cur, total) : "";
   }
 }


### PR DESCRIPTION
Adds web/src/i18n.ts that fetches /l10n/<lang>/AGolf.xml, parses it with DOMParser, and resolves keys via t(key, defaultEn, ...args) with %1/%2 substitution. EN is loaded eagerly at boot as the fallback overlay; the active locale (saved in localStorage as pmg.lang, default Finnish) is applied before any panel mounts and pre-loaded on the login dropdown's change event so subsequent panels render in the picked locale.

Visible strings in the loading, login, lobby-select, single/multi lobby, in-game and replay panels now flow through t(); Java keys are reused where they exist, and port-specific UI (Daily Cup, replay viewer, share text) lives under a Port_* namespace so a future translator can extend the XMLs cleanly. Docs (README, ARCHITECTURE, KNOWN_ISSUES) updated; the deferred-feature list no longer mentions localisation routing.

Layout fixes that surfaced once Finnish strings replaced the shorter English originals:

  - Lobby-select column buttons (Yksinpeli / Daily Cup / Moninpeli) were percent-positioned, which slipped ~1px left of the bg image dividers because #app's 1px border with box-sizing:border-box leaves 733px of content for a 735px-wide bg. Switched to fixed pixel anchors matching the image grid (0/245/490, width 245).

  - Multi-player lobby form's 280px right column truncated the longest Finnish dropdown options ("Takaisin lyöntipaikkaan"). Bumped to 1fr / 354px so the gap-centre lands exactly on the painted divider in bg-lobby-multi.gif (sampled at image-x=367) and the widest fi/sv option still fits.

  - "Moninpeli" title is now absolutely-positioned at the panel midpoint so it sits above the metallic-plate label baked into bg-lobby-multi.gif regardless of the translated string's width.