### PR TITLE
Port: fix daily-room sparse-player-id breaks for late joiners

### DIFF
--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -100,13 +100,16 @@ export abstract class Game {
         this.sendPlayerNames(player);
         // Broadcast join to existing players (none for single-player on first add).
         // Wire: `game join <newPlayerOrdinal> <nick> <clan>`. The client treats
-        // the ordinal as 1-based and subtracts 1 to get its slot index. We are
-        // about to push the new player to `this.players`, so playerCount() + 1
-        // is the correct ordinal to send (otherwise the existing players' first
-        // slot is overwritten with the newcomer's nick on every join).
+        // the ordinal as 1-based and subtracts 1 to get its slot index. The new
+        // player's actual id will be `numberIndex` (assigned right after this
+        // by `addPlayer`), so the correct 1-based ordinal is `numberIndex + 1`.
+        // In the daily room sparse ids accumulate (a finisher who left still
+        // owns a slot in playStatus), so `playerCount() + 1` would target a
+        // lower index than the joiner's real id and overwrite an existing
+        // player's nick on the recipients' scoreboards.
         for (const p of this.players) {
             if (p !== player) {
-                p.connection.sendData("game", "join", this.playerCount() + 1, player.nick, player.clan);
+                p.connection.sendData("game", "join", this.numberIndex + 1, player.nick, player.clan);
             }
         }
         // Self owninfo — Java sends `numberIndex` BEFORE incrementing, so first player sees 0.

--- a/port/server/src/test-daily.ts
+++ b/port/server/src/test-daily.ts
@@ -196,8 +196,77 @@ async function main(): Promise<void> {
         c.sendData("game", "beginstroke", ball, mouseA);
         await c.waitFor((s) => /^d \d+ game\tbeginstroke\t0\t/.test(s), "C sees own stroke after re-entry");
         console.log("[OK] daily re-entry into empty room: C can shoot with id=0");
-        c.close();
 
+        // Regression: sparse-id join into a non-empty daily room.
+        // Scenario from a user playtest report: after several players have
+        // played and most left, a fresh joiner gets a high sparse `numberIndex`
+        // because the room was never empty long enough to reset. Pre-fix the
+        // client iterated up to `numPlayers` (= broadcast `playStatus` length)
+        // when building its outgoing playStatus and ball-sprite list, omitted
+        // its own slot at the high sparse id, and the server's `endStroke`
+        // resolved `charAt(myId) === ""` to `"f"` — the daily run never ended.
+        // Also: existing players received `game join` with ordinal
+        // `playerCount() + 1`, smaller than the joiner's real id, so their
+        // scoreboards overwrote an existing player's slot with the joiner.
+        //
+        // Setup: C is still in the daily room from the previous block (id=0).
+        // D joins (id=1, numberIndex grows to 2). C leaves. Room now has just
+        // D, but numberIndex is 2 → next joiner will be sparse.
+        const d = new Client("D");
+        await d.open();
+        await login(d);
+        await enterDaily(d);
+        const dOwn = await d.waitFor((s) => /^d \d+ game\towninfo\t/.test(s), "D owninfo");
+        const did = parseInt(dOwn.split("\t")[2] ?? "-1", 10);
+        if (did !== 1) throw new Error(`D entered with id=${did}; want 1`);
+
+        // C leaves. Room has only D, but numberIndex stayed 2 — sparse setup.
+        c.sendData("game", "back");
+        await c.waitFor((s) => /^d \d+ status\tlobbyselect\t/.test(s), "C back to lobbyselect");
+
+        // E joins. numberIndex=2 → E.id = 2 (sparse: no occupant has id=0).
+        const e = new Client("E");
+        await e.open();
+        await login(e);
+        await enterDaily(e);
+        const eOwn = await e.waitFor((s) => /^d \d+ game\towninfo\t/.test(s), "E owninfo");
+        const eid = parseInt(eOwn.split("\t")[2] ?? "-1", 10);
+        if (eid !== 2) throw new Error(`E entered with id=${eid}; want 2 (sparse — C's slot still owned)`);
+
+        // D should see E's join with ordinal = eid + 1 = 3, not players.length+1=2.
+        // Pre-fix: ordinal would have been 2, overwriting D's own slot 1 with E's nick.
+        const eJoinOnD = await d.waitFor((s) => /^d \d+ game\tjoin\t/.test(s), "D sees E join");
+        const eOrdinal = parseInt(eJoinOnD.split("\t")[2] ?? "0", 10);
+        if (eOrdinal !== eid + 1) {
+            throw new Error(`D saw E join with ordinal=${eOrdinal}; want ${eid + 1} — pre-fix bug overwrites existing slot`);
+        }
+        console.log(`[OK] sparse-id join into non-empty room: E's join carries ordinal=${eOrdinal}`);
+
+        // E shoots. The shot must succeed despite E's id (2) being past the
+        // pre-fix numPlayers cap.
+        e.sendData("game", "beginstroke", ball, mouseA);
+        await e.waitFor(
+            (s) => new RegExp(`^d \\d+ game\\tbeginstroke\\t${eid}\\t`).test(s),
+            "E sees own stroke",
+        );
+
+        // E holes in. Pre-fix the client would build a too-short playStatus
+        // (length=numPlayers=players.length=2) and the server's endStroke
+        // would resolve charAt(eid)="" to "f", so no `game end` would arrive.
+        // Post-fix the playStatus is padded to myPlayerId+1 and the personal
+        // end fires.
+        const eStatus = "f".repeat(eid) + "t";
+        e.sendData("game", "endstroke", eid, eStatus);
+        await e.waitFor(
+            (s) => new RegExp(`^d \\d+ game\\tendstroke\\t${eid}\\t1\\tt$`).test(s),
+            "E sees own holed",
+        );
+        await e.waitFor((s) => /^d \d+ game\tend$/.test(s), "E gets personal end (sparse-id finisher)");
+        console.log("[OK] sparse-id daily finisher receives personal `game end`");
+
+        c.close();
+        d.close();
+        e.close();
         a.close();
         b.close();
         console.log("\nALL DAILY-CHALLENGE PHASES PASSED");

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -856,8 +856,15 @@ export class GamePanel implements Panel {
 
   /** Build a status string for OUR ball (we're authoritative for ourselves). */
   private myPlayStatus(): string {
+    // Daily rooms have sparse player ids (a finisher who later leaves still
+    // owns a slot in the server's playStatus, so a fresh joiner's myPlayerId
+    // can exceed the broadcast playStatus length / numPlayers). Iterate up to
+    // myPlayerId+1 so the produced string always includes our own char —
+    // otherwise the server reads `charAt(myPlayerId) === ""`, resolves it to
+    // "f", and never marks us as holed.
+    const len = Math.max(this.numPlayers, this.myPlayerId + 1);
     let s = "";
-    for (let i = 0; i < this.numPlayers; i++) {
+    for (let i = 0; i < len; i++) {
       if (i === this.myPlayerId) {
         s += this.players[i]?.ball.inHole ? "t" : "f";
       } else {
@@ -931,7 +938,9 @@ export class GamePanel implements Panel {
     const sb = this.scoreboardEl;
     if (!sb) return;
     while (sb.firstChild) sb.removeChild(sb.firstChild);
-    for (let i = 0; i < this.numPlayers; i++) {
+    // Iterate `players.length` so a high-sparse-id self-row in a daily room
+    // still renders (numPlayers can be smaller than myPlayerId+1).
+    for (let i = 0; i < this.players.length; i++) {
       const p = this.players[i];
       if (!p) continue;
       // Daily mode: only the local player's score is shown — other ghosts in
@@ -1106,10 +1115,19 @@ export class GamePanel implements Panel {
     const peerAims = this.drawPeerAims;
     sprites.length = 0;
     peerAims.length = 0;
-    for (let i = 0; i < this.numPlayers; i++) {
+    // Iterate `players.length` (not `numPlayers`): in daily rooms our own
+    // myPlayerId can exceed numPlayers because of sparse server-side ids
+    // accumulated from finishers who later left. ensurePlayerSlots already
+    // grew the array to cover myPlayerId+1, so this loop reaches our slot.
+    for (let i = 0; i < this.players.length; i++) {
       const p = this.players[i];
       if (!p) continue;
       const isMine = i === this.myPlayerId;
+      // Skip empty placeholder slots from sparse-id gaps in daily rooms — a
+      // joiner with a high sparse id leaves untouched lower indices that
+      // never received `players` or `join`. Without this they would render
+      // as ghosts at spawn labelled "Player N".
+      if (this.dailyMode && !isMine && p.nick === "") continue;
       // Daily mode: render every other player as a translucent ghost with a
       // name label above. Self renders normally.
       const ghost = this.dailyMode && !isMine;


### PR DESCRIPTION
Repro: more than 4 players cycle through the daily room; an early finisher leaves, a fresh player joins. The fresh joiner sees an invisible ball (still hittable) and never receives the share screen after holing in.

Cause: the daily room keeps `numberIndex` growing as players come and go, so a late joiner's `myPlayerId` can exceed the server-reported `numPlayers` (= live `players.length`). The client's draw loop and outgoing-playStatus builder were both bounded by `numPlayers`, so the local slot at the high sparse id was skipped — the ball never rendered, and the server's `endStroke` read `charAt(myPlayerId) === ""`, resolved to "f", and never fired the personal `game end`. Separately, the `game join` broadcast carried `playerCount() + 1` as the 1-based ordinal, smaller than the joiner's real id, so existing players' scoreboards overwrote a current slot with the joiner's nick.

Client fix (panels/game.ts):
- myPlayStatus now iterates Math.max(numPlayers, myPlayerId + 1) so the local slot is always present in the outgoing string.
- draw() and renderScoreboard() iterate players.length (grown by ensurePlayerSlots to cover myPlayerId+1) instead of numPlayers.
- Daily ghost rendering skips empty-nick non-self slots so sparse-id gaps don't draw phantom ghosts at spawn.

Server fix (server/game.ts):
- `game join` broadcast ordinal is numberIndex + 1, matching the joiner's actual sparse id.

Regression test (test-daily.ts): D joins non-empty room → C leaves → E joins as sparse id 2 → asserts D sees E's join with ordinal 3 AND E receives the personal `game end` after holing.