### PR TITLE
Port: structured stdout JSON event logging

### DIFF
--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -10,6 +10,7 @@ import {
     type TrackManager,
     type TrackStats,
 } from "./tracks.ts";
+import { logEvent } from "./log.ts";
 
 export const STROKES_UNLIMITED = 0;
 export const STROKETIMEOUT_INFINITE = 0;
@@ -79,6 +80,13 @@ export abstract class Game {
         this.playersNumber.push(this.numberIndex);
         this.numberIndex++;
         player.game = this;
+        logEvent("game_join", {
+            game_id: this.gameId,
+            lobby: this.lobbyType,
+            id: player.id,
+            nick: player.nick,
+            players: this.players.length,
+        });
         return true;
     }
 
@@ -134,6 +142,11 @@ export abstract class Game {
 
     protected endGame(): void {
         this.writeAll(tabularize("game", "end"));
+        logEvent("game_end", {
+            game_id: this.gameId,
+            lobby: this.lobbyType,
+            players: this.players.length,
+        });
     }
 
     abstract sendGameInfo(player: Player): void;
@@ -545,6 +558,11 @@ export class DailyGame extends GolfGame {
         // Initial playStatus for an empty room.
         this.playStatus = "";
         this.isPublic = false;
+        logEvent("game_create", {
+            game_id: gameId,
+            kind: "daily",
+            date: dateKey,
+        });
     }
 
     /** Swap track for the new UTC day if needed; reset per-player counters. */
@@ -731,6 +749,15 @@ export class TrainingGame extends GolfGame {
             trackManager,
         );
 
+        logEvent("game_create", {
+            game_id: gameId,
+            kind: "training",
+            tracks: numberOfTracks,
+            track_type: tracksType,
+            water,
+            creator_id: player.id,
+        });
+
         const lob: Lobby | null = player.lobby;
         if (this.addPlayer(player)) {
             if (lob) lob.addGame(this);
@@ -787,6 +814,18 @@ export class MultiGame extends GolfGame {
             numPlayers,
             trackManager,
         );
+
+        logEvent("game_create", {
+            game_id: gameId,
+            kind: "multi",
+            tracks: numberOfTracks,
+            track_type: tracksType,
+            num_players: numPlayers,
+            max_strokes: maxStrokes,
+            collision,
+            passworded,
+            creator_id: creator.id,
+        });
 
         // Add creator first.
         const lobby = creator.lobby;

--- a/port/server/src/lobby.ts
+++ b/port/server/src/lobby.ts
@@ -2,6 +2,7 @@
 import { tabularize } from "@minigolf/shared";
 import type { Player } from "./player.ts";
 import type { Game } from "./game.ts";
+import { logEvent } from "./log.ts";
 
 export const LobbyType = Object.freeze({
     SINGLE: "1",
@@ -20,6 +21,17 @@ export const PartReason = Object.freeze({
     CONN_PROBLEM: 5,
     SWITCHEDLOBBY: 6,
 } as const);
+
+/** Human-readable names for `PartReason` codes — used by the analytics
+ *  `lobby_leave` event so consumers don't have to remember the numbers. */
+const PART_REASON_NAME: Record<number, string> = {
+    1: "started_sp",
+    2: "created_mp",
+    3: "joined_mp",
+    4: "userleft",
+    5: "conn_problem",
+    6: "switchedlobby",
+};
 
 export const JoinType = Object.freeze({
     NORMAL: 0,
@@ -79,10 +91,19 @@ export class Lobby {
         // Self ownjoin
         player.connection.sendData("lobby", "ownjoin", player.toString());
 
-        if (this.players.indexOf(player) < 0) {
+        const wasPresent = this.players.indexOf(player) >= 0;
+        if (!wasPresent) {
             this.players.push(player);
         }
         player.lobby = this;
+        if (!wasPresent) {
+            logEvent("lobby_join", {
+                id: player.id,
+                nick: player.nick,
+                lobby: this.type,
+                from_game: joinType !== JoinType.NORMAL,
+            });
+        }
 
         // Multi-player lobby: send the public game list to the newcomer.
         if (this.type === LobbyType.MULTI) {
@@ -139,6 +160,12 @@ export class Lobby {
         const idx = this.players.indexOf(player);
         if (idx < 0) return false;
         this.players.splice(idx, 1);
+        logEvent("lobby_leave", {
+            id: player.id,
+            nick: player.nick,
+            lobby: this.type,
+            reason: PART_REASON_NAME[partReason] ?? String(partReason),
+        });
 
         // Broadcast lobby\tpart\t<nick>\t<reason>[\t<gameName>] to remaining players.
         const parts: (string | number)[] = ["lobby", "part", player.nick, partReason];
@@ -174,5 +201,19 @@ export class Lobby {
 
     getGame(id: number): Game | undefined {
         return this.games.get(id);
+    }
+
+    /** Live count of games hosted by this lobby. Used by the periodic
+     *  analytics snapshot in main.ts. */
+    gameCount(): number {
+        return this.games.size;
+    }
+
+    /** Total players across the games hosted by this lobby (excludes players
+     *  still sitting in the lobby itself). Used by the snapshot. */
+    inGamePlayerCount(): number {
+        let n = 0;
+        for (const g of this.games.values()) n += g.playerCount();
+        return n;
     }
 }

--- a/port/server/src/log.ts
+++ b/port/server/src/log.ts
@@ -1,0 +1,24 @@
+// Structured analytics logging — one JSON line per event to stdout.
+//
+// Kubernetes captures container stdout, so this is the cheapest way to ship
+// "how many players, what did they do" data off-server without integrating an
+// analytics service. Every event is a single line of JSON, with at least
+// `t` (ISO timestamp) and `evt` (event name); consumers can `jq -c 'select(.evt=="…")'`.
+//
+// The existing diagnostic console.log lines (`[server]`, `[connection]`, etc.)
+// stay unchanged — they don't start with `{`, so they're trivially separable
+// from this stream.
+//
+// Best-effort: if stdout write throws (EPIPE in tests, broken pipe), swallow
+// silently. Game logic must never block or crash on analytics.
+
+export type LogFields = Record<string, unknown>;
+
+export function logEvent(evt: string, fields: LogFields = {}): void {
+    const payload = { t: new Date().toISOString(), evt, ...fields };
+    try {
+        process.stdout.write(JSON.stringify(payload) + "\n");
+    } catch {
+        /* ignore */
+    }
+}

--- a/port/server/src/main.ts
+++ b/port/server/src/main.ts
@@ -7,6 +7,13 @@ import { GolfServer } from "./server.ts";
 import { Connection } from "./connection.ts";
 import { TrackManager } from "./tracks.ts";
 import { getReplay, saveReplay } from "./replay-store.ts";
+import { LobbyType } from "./lobby.ts";
+import { logEvent } from "./log.ts";
+
+/** Cadence for the analytics `snapshot` event — short enough to give a
+ *  reasonable population time-series, long enough that an idle server
+ *  doesn't spam the logs. */
+const SNAPSHOT_INTERVAL_MS = 60_000;
 
 interface CliArgs {
     host: string;
@@ -335,8 +342,42 @@ export async function startServer(args: CliArgs): Promise<RunningServer> {
     await new Promise<void>((resolve) => http.listen(args.port, args.host, resolve));
     console.log(`[server] listening ws://${args.host}:${args.port}/ws`);
 
+    logEvent("server_start", {
+        host: args.host,
+        port: args.port,
+        chat: chatEnabled,
+        tracks_total: counts[0],
+    });
+
+    // Periodic population snapshot — one structured line per minute summarising
+    // who's connected and where. Lets offline analysis (e.g. via `kubectl logs |
+    // jq 'select(.evt=="snapshot")'`) reconstruct a player-count time-series
+    // even on an idle server. unref() so smoke-tests can exit cleanly without
+    // waiting for the next tick.
+    const snapshotTimer = setInterval(() => {
+        const snap: Record<string, unknown> = {
+            players: golfServer.playerCount(),
+        };
+        for (const [tag, name] of [
+            [LobbyType.SINGLE, "single"],
+            [LobbyType.DUAL, "dual"],
+            [LobbyType.MULTI, "multi"],
+            [LobbyType.DAILY, "daily"],
+        ] as const) {
+            const lob = golfServer.getLobby(tag);
+            snap[name] = {
+                lobby: lob.playerCount(),
+                games: lob.gameCount(),
+                in_game: lob.inGamePlayerCount(),
+            };
+        }
+        logEvent("snapshot", snap);
+    }, SNAPSHOT_INTERVAL_MS);
+    snapshotTimer.unref();
+
     return {
         close: async () => {
+            clearInterval(snapshotTimer);
             await new Promise<void>((resolve) => {
                 wss.close(() => resolve());
             });

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -7,6 +7,7 @@ import type { GolfServer } from "./server.ts";
 import { Player } from "./player.ts";
 import { JoinType, LobbyType, PartReason } from "./lobby.ts";
 import { MultiGame, TrainingGame } from "./game.ts";
+import { logEvent } from "./log.ts";
 
 interface Handler {
     type: typeof PacketType.COMMAND | typeof PacketType.DATA;
@@ -172,6 +173,11 @@ register({
         // basicinfo\t<emailVerified>\t<accessLevel>\tt\tt
         conn.sendData("basicinfo", player.emailVerified, player.accessLevel, "t", "t");
         conn.sendData("status", "lobbyselect", "300");
+        logEvent("player_login", {
+            id: player.id,
+            nick: player.nick,
+            language: player.language ?? "-",
+        });
     },
 });
 

--- a/port/server/src/server.ts
+++ b/port/server/src/server.ts
@@ -6,6 +6,7 @@ import { Lobby, LobbyType, PartReason } from "./lobby.ts";
 import type { TrackManager } from "./tracks.ts";
 import { DailyGame } from "./game.ts";
 import { dispatchPacket } from "./packet-handlers.ts";
+import { logEvent } from "./log.ts";
 
 /** Grace window during which a player can re-attach a fresh WebSocket via
  *  `c old <id>`. Mirrors the value advertised in the connect-handshake banner
@@ -84,6 +85,12 @@ export class GolfServer {
         return this.players.get(id);
     }
 
+    /** Live count of player records held by the server. Used by the periodic
+     *  analytics snapshot in main.ts. */
+    playerCount(): number {
+        return this.players.size;
+    }
+
     getLobby(type: LobbyType): Lobby {
         const l = this.lobbies.get(type);
         if (!l) throw new Error(`unknown lobby type: ${type}`);
@@ -114,7 +121,7 @@ export class GolfServer {
         // cleanup as before. (Reconnect mid-game is a deferred follow-up — see
         // KNOWN_ISSUES.)
         if (player.game) {
-            this.fullyRemovePlayer(player);
+            this.fullyRemovePlayer(player, "in_game");
             return;
         }
 
@@ -130,7 +137,7 @@ export class GolfServer {
             if (this.players.get(player.id) !== player) return;
             if (player.disconnectedAt === null) return;
             console.log(`[reconnect] grace expired for ${player.id}/${player.nick}`);
-            this.fullyRemovePlayer(player);
+            this.fullyRemovePlayer(player, "grace_expired");
         }, RECONNECT_GRACE_MS);
         // Don't keep the event loop alive solely on this timer — the smoke
         // tests close their server cleanly and rely on natural process exit;
@@ -139,7 +146,7 @@ export class GolfServer {
         this.reconnectTimers.set(player.id, timer);
     }
 
-    private fullyRemovePlayer(player: Player): void {
+    private fullyRemovePlayer(player: Player, reason: string): void {
         if (player.game) {
             const lob = player.lobby;
             try {
@@ -160,6 +167,7 @@ export class GolfServer {
         }
         this.removePlayer(player.id);
         player.disconnectedAt = null;
+        logEvent("player_disconnect", { id: player.id, nick: player.nick, reason });
     }
 
     /**
@@ -189,6 +197,7 @@ export class GolfServer {
         // The new Connection's outSeq/inSeq are 0 by construction; no reset
         // needed here. Client mirrors this on receipt of `c rcok`.
         console.log(`[reconnect] reattached ${id}/${player.nick}`);
+        logEvent("player_reconnect", { id, nick: player.nick });
         return true;
     }
 


### PR DESCRIPTION
One JSON line per event (server_start, snapshot, player_login, player_disconnect, player_reconnect, lobby_join/leave, game_create/join/end) emitted to stdout alongside existing `[…]` diagnostic logs, distinguishable by the leading `{`. Snapshot ticks every 60 s with per-lobby player/game counts. Designed to be captured via `kubectl logs` and analysed offline with `jq`; no analytics service involvement.