### PR TITLE
Port: fix daily count + replay link, log per-player results

### DIFF
--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -666,6 +666,14 @@ export class DailyGame extends GolfGame {
         if (resolvedStatus === "t" || resolvedStatus === "p") {
             // Tell only this player their daily run is over (others keep playing).
             player.connection.sendData("game", "end");
+            logEvent("daily_play_end", {
+                date: this.dateKey,
+                id: player.id,
+                nick: player.nick,
+                strokes: this.playerStrokesThisTrack[id],
+                holed: resolvedStatus === "t",
+                forfeited: resolvedStatus === "p",
+            });
         }
     }
 
@@ -682,6 +690,14 @@ export class DailyGame extends GolfGame {
         this.playStatus = psArr.join("");
         this.writeAll(tabularize("game", "endstroke", id, cap, "p"));
         player.connection.sendData("game", "end");
+        logEvent("daily_play_end", {
+            date: this.dateKey,
+            id: player.id,
+            nick: player.nick,
+            strokes: cap,
+            holed: false,
+            forfeited: true,
+        });
     }
 
     override handlePacket(player: Player, fields: string[]): boolean {

--- a/port/server/src/main.ts
+++ b/port/server/src/main.ts
@@ -248,6 +248,8 @@ function tryServeStatic(req: IncomingMessage, res: ServerResponse, webDist: stri
 
 export interface RunningServer {
     close(): Promise<void>;
+    /** Test hook — peek at lobby state directly. Not used in production. */
+    golfServer: GolfServer;
 }
 
 export async function startServer(args: CliArgs): Promise<RunningServer> {
@@ -376,6 +378,7 @@ export async function startServer(args: CliArgs): Promise<RunningServer> {
     snapshotTimer.unref();
 
     return {
+        golfServer,
         close: async () => {
             clearInterval(snapshotTimer);
             await new Promise<void>((resolve) => {

--- a/port/server/src/server.ts
+++ b/port/server/src/server.ts
@@ -58,10 +58,17 @@ export class GolfServer {
         if (!this.dailyGame) {
             const id = this.getNextGameId();
             this.dailyGame = new DailyGame(id, this.trackManager, today);
-            this.getLobby(LobbyType.DAILY).addGame(this.dailyGame);
         } else {
             this.dailyGame.rotateIfNewDay(today);
         }
+        // Re-register on every access. `fullyRemovePlayer` unregisters the game
+        // when the room empties via mid-game disconnect, but the singleton
+        // itself lives on; without re-adding here, `daily_lobby.gameCount()`,
+        // `inGamePlayerCount()`, and `totalPlayerCount()` perpetually report 0
+        // even when subsequent joiners are sitting in the daily room — breaking
+        // both the analytics snapshot and the lobbyselect "Daily Cup: N players"
+        // display. `addGame` is idempotent (no-op if already registered).
+        this.getLobby(LobbyType.DAILY).addGame(this.dailyGame);
         return this.dailyGame;
     }
 

--- a/port/server/src/test-daily.ts
+++ b/port/server/src/test-daily.ts
@@ -264,9 +264,57 @@ async function main(): Promise<void> {
         await e.waitFor((s) => /^d \d+ game\tend$/.test(s), "E gets personal end (sparse-id finisher)");
         console.log("[OK] sparse-id daily finisher receives personal `game end`");
 
-        c.close();
+        // Regression: mid-game disconnect must not orphan the daily singleton.
+        // Pre-fix: when the last player in the daily room dropped their
+        // socket, `fullyRemovePlayer` called `lobby.removeGame(daily_game)`,
+        // unregistering the singleton from `daily_lobby.games`. The singleton
+        // object lived on in `golfServer.dailyGame`, so subsequent joiners
+        // entered a "ghost" room — `daily_lobby.gameCount()` and
+        // `inGamePlayerCount()` both stayed at 0 for the rest of the server's
+        // lifetime, breaking the analytics snapshot and the lobbyselect
+        // "Daily Cup: N players" display alike.
+        //
+        // Setup: D and E are still in the daily room here. Close them to drop
+        // both sockets — the in-game disconnect path runs synchronously, so
+        // by the time both `close` calls have round-tripped through their
+        // server-side `handleDisconnect`, the daily room has emptied and
+        // (pre-fix) been unregistered.
         d.close();
         e.close();
+        // Yield so the WebSocket close events surface to the server. The
+        // server's in-game disconnect handler is synchronous once it runs,
+        // but the close itself is async — give Windows CI extra slack.
+        await new Promise((r) => setTimeout(r, 250));
+
+        const dailyLobby = server.golfServer.getLobby("d");
+        if (dailyLobby.inGamePlayerCount() !== 0) {
+            throw new Error(
+                `daily lobby in_game count after dropouts = ${dailyLobby.inGamePlayerCount()}; want 0`,
+            );
+        }
+
+        // Fresh joiner re-enters the (still-cached) singleton. Pre-fix:
+        // `gameCount() = 0` here because the singleton was orphaned and
+        // `getDailyGame()` doesn't re-register it. Post-fix: re-add is
+        // idempotent and self-heals.
+        const f = new Client("F");
+        await f.open();
+        await login(f);
+        await enterDaily(f);
+        if (dailyLobby.gameCount() !== 1) {
+            throw new Error(
+                `daily lobby game count after re-entry = ${dailyLobby.gameCount()}; want 1 (singleton must be re-registered)`,
+            );
+        }
+        if (dailyLobby.inGamePlayerCount() !== 1) {
+            throw new Error(
+                `daily lobby in_game count after re-entry = ${dailyLobby.inGamePlayerCount()}; want 1`,
+            );
+        }
+        console.log("[OK] daily singleton stays counted after mid-game dropouts and re-entry");
+
+        c.close();
+        f.close();
         a.close();
         b.close();
         console.log("\nALL DAILY-CHALLENGE PHASES PASSED");

--- a/port/web/src/main.ts
+++ b/port/web/src/main.ts
@@ -41,6 +41,11 @@ function showError(message: string): void {
 
 function mountReplay(replay: DailyReplay): void {
   if (!root) return;
+  // Drop the loading shim before mounting — its `.panel-loading` div is
+  // 100% width/height with a green background, so without this the replay
+  // canvas is rendered underneath an opaque "Loading replay…" cover and
+  // the user sees the loading message forever.
+  root.innerHTML = "";
   new ReplayPanel(replay).mount(root);
 }
 

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -1381,25 +1381,39 @@ export class GamePanel implements Panel {
       const linkBtn = document.createElement("button");
       linkBtn.type = "button";
       linkBtn.className = "btn-blue";
-      linkBtn.textContent = t("Port_Daily_CopyReplayLink", "Copy replay link");
-      // Click handler:
-      //   1. POST the recording to /api/replay → get a short id, copy `?r=<id>`.
-      //   2. If the network or server rejects (offline, 5xx, etc.), fall back
-      //      to the long fragment-embedded link so the user always gets
-      //      *something* shareable rather than a dead button.
+      linkBtn.disabled = true;
+      linkBtn.textContent = t("Port_Daily_SavingReplay", "Saving replay…");
+
+      // Auto-upload as soon as the overlay opens. The previous behaviour was
+      // to defer the POST until the user clicked, which meant a fresh upload
+      // (and possible failure) on every share. Doing it eagerly:
+      //   - Makes the "Copy replay link" click instant once it lands.
+      //   - Surfaces upload failures immediately so the user sees the
+      //     fallback fragment-embedded link without waiting.
+      // Falls back to `replayLink(replay)` (long URL with the run packed into
+      // the URL fragment) on network/server failure so the user always gets
+      // *something* shareable.
+      let cachedUrl: string | null = null;
+      void (async () => {
+        let url: string;
+        try {
+          url = await shortReplayLink(replay);
+        } catch {
+          url = replayLink(replay);
+        }
+        cachedUrl = url;
+        linkBtn.disabled = false;
+        linkBtn.textContent = t("Port_Daily_CopyReplayLink", "Copy replay link");
+      })();
+
       linkBtn.addEventListener("click", () => {
-        linkBtn.disabled = true;
-        linkBtn.textContent = "Saving…";
+        if (!cachedUrl) return;
+        const url = cachedUrl;
         void (async () => {
-          let url: string;
-          try {
-            url = await shortReplayLink(replay);
-          } catch {
-            url = replayLink(replay);
-          }
           const ok = await copyToClipboard(url);
-          linkBtn.disabled = false;
-          linkBtn.textContent = ok ? t("Port_Daily_LinkCopied", "Link copied!") : t("Port_Daily_CopyFailedShort", "Copy failed");
+          linkBtn.textContent = ok
+            ? t("Port_Daily_LinkCopied", "Link copied!")
+            : t("Port_Daily_CopyFailedShort", "Copy failed");
           if (!ok) {
             const ta = document.createElement("textarea");
             ta.value = url;
@@ -1411,7 +1425,9 @@ export class GamePanel implements Panel {
             ov.appendChild(ta);
             ta.select();
           }
-          window.setTimeout(() => { linkBtn.textContent = t("Port_Daily_CopyReplayLink", "Copy replay link"); }, 2000);
+          window.setTimeout(() => {
+            linkBtn.textContent = t("Port_Daily_CopyReplayLink", "Copy replay link");
+          }, 2000);
         })();
       });
       btnRow.appendChild(linkBtn);


### PR DESCRIPTION
Three bugs and one improvement around the daily-cup mode:

- The structured-logging snapshot perpetually reported `daily.in_game = 0` (and the lobbyselect "Daily Cup: N players" display likewise stayed at 0) once the daily room first emptied via a mid-game disconnect. `fullyRemovePlayer` unregisters the empty game from its lobby's `games` map, but the daily singleton lives on in `golfServer.dailyGame` and accepts new joins — those joiners were invisible to `gameCount()` / `inGamePlayerCount()` / `totalPlayerCount()`. Fix: `getDailyGame()` now re-adds the singleton on every access (`addGame` is idempotent).

- `mountReplay` did not clear the loading shim before mounting the replay panel. The shim's `.panel-loading` div is 100% width/height with a green background, so the replay UI was rendered underneath an opaque "Loading replay…" cover and the user saw the loading message forever.

- `daily_play_end` events are emitted on hole-in and forfeit with strokes, holed/forfeited flags, date and player. The pre-existing `game_join` events do log every daily joiner, but under `lobby:"d"` rather than any string containing "daily" — easy to miss in a grep.

- Replay short-link upload now fires automatically when the daily-end overlay opens, so "Copy replay link" is instant once it lands and any network failure surfaces immediately rather than on the user's first click.