### PR TITLE
Port: build :beta image on pushes to beta branch

### DIFF
--- a/.github/workflows/port-docker.yml
+++ b/.github/workflows/port-docker.yml
@@ -2,7 +2,7 @@ name: Port Docker Image
 
 on:
   push:
-    branches: [master]
+    branches: [master, beta]
     tags: ['v*']
   pull_request:
     branches: [master]


### PR DESCRIPTION
Adds beta to the push branches in port-docker.yml. The existing type=ref,event=branch metadata rule tags the image with the branch name automatically, and :latest stays gated to the default branch, so pushes to beta produce ghcr.io/.../playforia-minigolf-browser-port:beta without affecting the prod tag.

Companion kustomize overlay (separate kube-configs repo) deploys this image to beta.minigolf.0m.fi in a minigolf-beta namespace.