### PR TITLE
Port: fix Seed.next() returning 2^31 instead of 0 for MIN_VALUE branch

### DIFF
--- a/port/shared/src/seed.test.ts
+++ b/port/shared/src/seed.test.ts
@@ -42,6 +42,14 @@ for (const [seedStr, expected] of Object.entries(REFERENCE)) {
   });
 }
 
+test("Integer.MIN_VALUE branch returns 0 (Java overflow quirk)", () => {
+  // top32 == 0x80000000 makes Java compute -MIN_VALUE -> MIN_VALUE -> pinned to 0.
+  // Pre-image of post-LCG state 0x800000000000 (computed via modular inverse of MULT mod 2^48).
+  const s = new Seed(0n);
+  (s as unknown as { rnd: bigint }).rnd = 0xe15c0e462aa9n;
+  assert.equal(s.next(), 0);
+});
+
 test("clone forks state", () => {
   const a = new Seed(42n);
   a.next();

--- a/port/shared/src/seed.ts
+++ b/port/shared/src/seed.ts
@@ -22,11 +22,10 @@ export class Seed {
 
     // Java's quirk:
     //   if (v < 0) { v = -v; if (v < 0) v = 0; }
-    // -Integer.MIN_VALUE overflows back to itself in Java; the second check pins it to 0.
-    if (v < 0) {
-      v = -v;
-      if (v < 0) v = 0; // would only fire for v === Integer.MIN_VALUE, which after -v is still negative in 32-bit Java
-    }
+    // In Java's 32-bit int arithmetic, -Integer.MIN_VALUE overflows back to itself,
+    // and the inner check pins it to 0. JS Numbers don't overflow, so -(-2^31) yields
+    // 2^31 and would skip the pin — handle MIN_VALUE explicitly.
+    if (v < 0) v = v === -0x80000000 ? 0 : -v;
     return v;
   }
 


### PR DESCRIPTION
Java's `-Integer.MIN_VALUE` overflows back to itself, and the inner `if (v < 0) v = 0` check then pins it to zero. JS Numbers don't overflow, so `-(-2^31)` yields `2^31`, skipping the pin and returning a value that no Java client would ever produce. The window is rare (~1 in 2^31 calls) but eventually surfaces as a single divergent stroke across many sessions.

Closes #23