### PR TITLE
Port: raise stroke safety-net cap from 1500 to 4000 iterations

### DIFF
--- a/port/docs/ARCHITECTURE.md
+++ b/port/docs/ARCHITECTURE.md
@@ -103,7 +103,9 @@ A simplified-but-faithful port of `GameCanvas.run`'s inner loop, located in
   snapshot taken at `beginstroke` keeps `canMovableBlockMove` in agreement
   across clients during async play.
 - Speed cap at 7.0 units.
-- Stroke-time safety net — force-stop after ~1500 iterations (~9 sec).
+- Stroke-time safety net — force-stop after ~4000 iterations (~24 sec), matching
+  Java's `loopStuckCounter > 4000` threshold; per-ball stuck counters and the
+  bouncy-block decay typically settle strokes well before this cap.
 
 Not implemented: sand/ice surface special handling beyond the friction table,
 breakable block (40–43) visual decay (bounce works; the wall doesn't "break"

--- a/port/web/src/game/physics.ts
+++ b/port/web/src/game/physics.ts
@@ -106,8 +106,14 @@ const DIAG_OFFSET = Math.round(6 * MAGIC_OFFSET); // 4
  */
 export const PHYSICS_STEP_MS = 6;
 
-/** Hard cap on a single stroke. 1500 iterations / 166 Hz ≈ 9 seconds. */
-const MAX_STROKE_ITERATIONS = 1500;
+/** Hard cap on a single stroke. 4000 iterations / 166 Hz ≈ 24 seconds — matches
+ *  Java's `loopStuckCounter > 4000` first-tier safety threshold (GameCanvas.run
+ *  line 445). Java zeroes bounciness at that point and gives the ball another
+ *  3000 iterations to settle; we instead lean on the per-ball stuck counters
+ *  (downhill/magnet/spinning) plus the `bounciness -= 0.01` per tile-18 hit
+ *  decay (which drives super-bouncy back to static 0.84 within ~100 hits) to
+ *  organically settle stuck strokes well before this cap. */
+const MAX_STROKE_ITERATIONS = 4000;
 
 /** Apply stroke impulse with deterministic noise — matches GameCanvas.doStroke.
  *  `shootingMode` mirrors the original right-click cycle: 0=normal, 1=reverse,


### PR DESCRIPTION
Aligns MAX_STROKE_ITERATIONS with Java's loopStuckCounter > 4000 first-tier threshold (GameCanvas.run line 445, ~24s at 166 Hz). The tighter 1500 cap preempted natural settling on the rare tile-18 corner trap; per-ball stuck counters (PR #21) plus the bounciness -= 0.01 per tile-18 hit decay already catch the common cases well before this cap.

Closes #24.