### PR TITLE
Port: honour track 'S' settings flags during rendering

### DIFF
--- a/port/docs/KNOWN_ISSUES.md
+++ b/port/docs/KNOWN_ISSUES.md
@@ -99,9 +99,13 @@ A few non-obvious pitfalls when modifying things:
   watch out.
 - **`networkSerialize` has a port-specific addition.** It now includes a
   `C <categories>` line that Java's `FileSystemTrackStats.networkSerialize`
-  doesn't emit. Clients use it for the in-game tag chips. If you ever
-  cross-test against a real Java client, expect the Java client to ignore
-  this line (it scans for known prefixes only).
+  doesn't emit, plus an `S <settings>` line that the Java server also
+  omitted (the Java client never honored these flags because of a parser
+  typo on the receiving side — see `parseSettingsFlags` in
+  `shared/src/track.ts`). Clients use C for the in-game tag chips and S
+  for tile-visibility / illusion-shadow rendering. If you ever cross-test
+  against a real Java client, expect it to ignore both lines (it scans
+  for known prefixes only).
 - **The shooter waits for the server broadcast.** Don't optimize the
   click→impulse path by applying locally — it would desync everyone.
 - **HMR delivers physics changes instantly.** The Vite dev server hot-reloads

--- a/port/docs/PROTOCOL.md
+++ b/port/docs/PROTOCOL.md
@@ -134,12 +134,16 @@ server → d K+6 game<TAB>starttrack<TAB>{playStatus}<TAB>{gameId}<TAB>{trackDat
 
 `{trackData}` is the V1 networkSerialize body. Tab-separated lines:
 ```
-V 1<TAB>A {author}<TAB>N {name}<TAB>T {map}<TAB>C {categories}
+V 1<TAB>A {author}<TAB>N {name}<TAB>T {map}<TAB>C {categories}<TAB>S {settings}
 <TAB>I {plays},{strokes},{bestPar},{numBestPar}<TAB>B {bestPlayer},{bestEpochMs}
 <TAB>R {r0},{r1},...,{r10}
 ```
-The `B` line is omitted if `bestPar < 0`. The `C` line is OUR port extension —
-Java doesn't include it. Use `extractField(fields, "C ")` on the client.
+The `B` line is omitted if `bestPar < 0`. The `C` and `S` lines are OUR port
+extensions — Java doesn't include them. `S` carries the four-flag visibility
+string (`mines/magnets/teleports/illusion-shadows`, plus the legacy 2-digit
+player-range suffix); use `parseSettingsFlags` from `@minigolf/shared` to
+decode the first four chars. Use `extractField(fields, "C ")` /
+`extractField(fields, "S ")` on the client.
 
 ## Game info packet (15 fields)
 

--- a/port/server/src/test-s-line.ts
+++ b/port/server/src/test-s-line.ts
@@ -1,0 +1,90 @@
+// Smoke check for issue #27 — confirms `S <settings>` rides along in the
+// `game starttrack` payload so the client renderer can apply mine/magnet/
+// teleport visibility + illusion-shadow flags. Reuses the test-fullflow
+// handshake up to starttrack and asserts on the new field.
+//
+// Usage: WS_URL=ws://localhost:4274/ws node --experimental-strip-types
+//        --no-warnings src/test-s-line.ts
+import { WebSocket } from "ws";
+
+const URL = process.env.WS_URL ?? "ws://localhost:4274/ws";
+
+const ws = new WebSocket(URL);
+const recv: string[] = [];
+let outSeq = 0;
+
+function sendData(...fields: (string | number)[]): void {
+    ws.send(`d ${outSeq++} ${fields.join("\t")}`);
+}
+function sendCommand(verb: string, ...args: string[]): void {
+    ws.send(`c ${[verb, ...args].join(" ")}`);
+}
+
+function awaitFrame(predicate: (s: string) => boolean, label: string, timeoutMs = 5000): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error(`timeout waiting for ${label}`)), timeoutMs);
+        const tick = (): void => {
+            const idx = recv.findIndex(predicate);
+            if (idx >= 0) {
+                clearTimeout(t);
+                const [s] = recv.splice(idx, 1);
+                resolve(s);
+                return;
+            }
+            setTimeout(tick, 25);
+        };
+        tick();
+    });
+}
+
+ws.on("message", (raw) => recv.push(raw.toString()));
+ws.on("error", (e) => {
+    console.error("ws error:", e);
+    process.exit(2);
+});
+
+await new Promise<void>((r) => ws.once("open", () => r()));
+
+// Handshake (mirrors test-fullflow phases 1–7).
+await awaitFrame((s) => s === "h 1", "h 1");
+await awaitFrame((s) => s.startsWith("c crt"), "c crt");
+await awaitFrame((s) => s === "c ctr", "c ctr");
+sendCommand("new");
+await awaitFrame((s) => s.startsWith("c id "), "c id");
+sendData("version", 35);
+await awaitFrame((s) => /^d \d+ status\tlogin$/.test(s), "status login (post-version)");
+sendData("language", "en");
+sendData("logintype", "nr");
+await awaitFrame((s) => /^d \d+ status\tlogin$/.test(s), "status login (post-logintype)");
+sendData("login");
+await awaitFrame((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+await awaitFrame((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+sendData("lobbyselect", "select", 1);
+await awaitFrame((s) => /^d \d+ status\tlobby\t1/.test(s), "status lobby 1");
+await awaitFrame((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+sendData("lobby", "cspt", 1, 0, 0);
+const startFrame = await awaitFrame((s) => /^d \d+ game\tstarttrack\t/.test(s), "starttrack", 8000);
+
+const fields = startFrame.split("\t");
+const sField = fields.find((f) => f.startsWith("S "));
+const tField = fields.find((f) => f.startsWith("T "));
+const cField = fields.find((f) => f.startsWith("C "));
+
+if (!tField) {
+    console.error("FAIL: no T line");
+    process.exit(1);
+}
+if (!sField) {
+    console.error("FAIL: no S line in starttrack frame — issue #27 fix incomplete");
+    process.exit(1);
+}
+const sBody = sField.substring(2);
+// The body itself is "ffff" for the ~93% of stock tracks without an explicit
+// S declaration and "<flags><minPlayers><maxPlayers>" (e.g. "tttt14") for the
+// ones that do. We just assert the line IS shipped — `parseTrack` /
+// `parseSettingsFlags` are unit-tested against real track files in
+// shared/src/track.test.ts so the value side is covered there.
+console.log("starttrack:", { hasT: true, hasC: !!cField, hasS: true, sBody, sBodyLen: sBody.length });
+console.log(`OK: S line shipped (body=${JSON.stringify(sBody)}, len=${sBody.length})`);
+ws.close();
+process.exit(0);

--- a/port/server/src/tracks.ts
+++ b/port/server/src/tracks.ts
@@ -90,15 +90,22 @@ export function networkSerialize(stats: TrackStats): string {
     // Java's networkSerialize doesn't include this; we add it as a port extension
     // because the client UI surfaces tags now.
     const cLine = "C " + (t.categories.length > 0 ? t.categories.join(",") : "");
+    // Special-settings flags (mines/magnets/teleports visibility + illusion-wall
+    // shadow). Java's networkSerialize omits this — combined with the buggy
+    // `length() != 6` skip in VersionedTrackFileParser the original client
+    // never honored S at all. The port forwards the raw S body so the renderer
+    // can apply it. Empty string when the track file has no S line; the client
+    // treats that as all-false (Java parser default).
+    const sLine = "S " + (t.settings ?? "");
 
     if (stats.bestPar < 0) {
-        return tabularize("V 1", "A " + t.author, "N " + t.name, "T " + t.map, cLine, iLine, rLine);
+        return tabularize("V 1", "A " + t.author, "N " + t.name, "T " + t.map, cLine, sLine, iLine, rLine);
     }
 
     const bestPlayer = stats.bestPlayer ?? "";
     const bestEpoch = stats.bestParEpoch ?? 0;
     const bLine = "B " + commaize(bestPlayer, bestEpoch);
-    return tabularize("V 1", "A " + t.author, "N " + t.name, "T " + t.map, cLine, iLine, bLine, rLine);
+    return tabularize("V 1", "A " + t.author, "N " + t.name, "T " + t.map, cLine, sLine, iLine, bLine, rLine);
 }
 
 /**

--- a/port/shared/src/index.ts
+++ b/port/shared/src/index.ts
@@ -26,8 +26,12 @@ export {
     type Track,
     type TrackSet,
     type TrackSetDifficulty,
+    type SettingsFlags,
+    NO_SETTINGS_FLAGS,
     parseTrack,
     parseTrackset,
+    parseSettingsFlags,
+    applySettingsToTileCode,
 } from "./track.ts";
 
 export {

--- a/port/shared/src/track.test.ts
+++ b/port/shared/src/track.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
-import { parseTrack, parseTrackset } from "./track.ts";
+import { applySettingsToTileCode, parseSettingsFlags, parseTrack, parseTrackset } from "./track.ts";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -46,6 +46,104 @@ describe("parseTrack — defaults for missing optional lines", () => {
         assert.deepEqual(track.categories, []);
         assert.deepEqual(track.ratings, []);
         assert.equal(track.bestPlayer, undefined);
+    });
+});
+
+describe("parseSettingsFlags", () => {
+    it("decodes the four-char form ('t'==true, anything else==false)", () => {
+        assert.deepEqual(parseSettingsFlags("ttff"), [true, true, false, false]);
+        assert.deepEqual(parseSettingsFlags("tttt"), [true, true, true, true]);
+        assert.deepEqual(parseSettingsFlags("ffff"), [false, false, false, false]);
+        assert.deepEqual(parseSettingsFlags("ftft"), [false, true, false, true]);
+    });
+
+    it("ignores the trailing 2-digit min/max-player suffix on real S lines", () => {
+        // VersionedTrackFileParser has a `length() != 6` typo that drops these
+        // entirely; we deliberately diverge — the first four chars are the
+        // flag bits regardless of how many trailing chars follow.
+        assert.deepEqual(parseSettingsFlags("tttt14"), [true, true, true, true]);
+        assert.deepEqual(parseSettingsFlags("ftft14"), [false, true, false, true]);
+        assert.deepEqual(parseSettingsFlags("ffff14"), [false, false, false, false]);
+    });
+
+    it("returns all-false for empty / null / undefined / too-short input", () => {
+        assert.deepEqual(parseSettingsFlags(""), [false, false, false, false]);
+        assert.deepEqual(parseSettingsFlags(null), [false, false, false, false]);
+        assert.deepEqual(parseSettingsFlags(undefined), [false, false, false, false]);
+        assert.deepEqual(parseSettingsFlags("tt"), [true, true, false, false]);
+    });
+});
+
+describe("applySettingsToTileCode", () => {
+    // Helper to build a 32-bit tile code: special<<24 | shape<<16 | bg<<8 | fg.
+    const tile = (special: number, shape: number, bg: number, fg = 0) =>
+        (special << 24) | (shape << 16) | (bg << 8) | fg;
+    const allOn: ReturnType<typeof parseSettingsFlags> = [true, true, true, true];
+    const allOff: ReturnType<typeof parseSettingsFlags> = [false, false, false, false];
+
+    it("returns the input unchanged for non-special tiles (special != 2)", () => {
+        const elemTile = tile(1, 0, 5, 7);
+        assert.equal(applySettingsToTileCode(elemTile, allOff), elemTile);
+        assert.equal(applySettingsToTileCode(elemTile, allOn), elemTile);
+        const empty = 0;
+        assert.equal(applySettingsToTileCode(empty, allOff), empty);
+    });
+
+    it("returns the input unchanged when all flags are on", () => {
+        // Mine, magnet, every teleport variant — flags=tttt means "show all".
+        for (const shape of [4, 6, 20, 21, 10, 11, 12, 13, 14, 15]) {
+            const code = tile(2, shape, 1, 0);
+            assert.equal(applySettingsToTileCode(code, allOn), code, `shape=${shape}`);
+        }
+    });
+
+    it("hides mines when flag[0]=false (shape 28/30 in Java, raw 4/6)", () => {
+        // Mine on dirt (bg=1). Substitute = 0x01000000 + 1*256 = 16777472.
+        const mine = tile(2, 4, 1, 0);
+        const bigmine = tile(2, 6, 1, 0);
+        const want = 16777216 + 1 * 256;
+        assert.equal(applySettingsToTileCode(mine, allOff), want);
+        assert.equal(applySettingsToTileCode(bigmine, allOff), want);
+        // ...but only when flag[0] is off.
+        assert.equal(applySettingsToTileCode(mine, [true, false, false, false]), mine);
+    });
+
+    it("hides magnets when flag[1]=false (raw 20/21)", () => {
+        const attract = tile(2, 20, 2, 0);
+        const repel = tile(2, 21, 2, 0);
+        const want = 16777216 + 2 * 256;
+        assert.equal(applySettingsToTileCode(attract, allOff), want);
+        assert.equal(applySettingsToTileCode(repel, allOff), want);
+        assert.equal(applySettingsToTileCode(attract, [false, true, false, false]), attract);
+    });
+
+    it("strips teleport colour when flag[2]=false (raw 10/12/14 → blue start, 11/13/15 → blue exit)", () => {
+        const bg = 0;
+        // Sources collapse to blue start (34078720 = 0x02080000).
+        for (const raw of [10, 12, 14]) {
+            assert.equal(applySettingsToTileCode(tile(2, raw, bg, 0), allOff), 34078720 + bg * 256);
+        }
+        // Exits collapse to blue exit (34144256 = 0x02090000).
+        for (const raw of [11, 13, 15]) {
+            assert.equal(applySettingsToTileCode(tile(2, raw, bg, 0), allOff), 34144256 + bg * 256);
+        }
+        // Blue itself (raw 8 source, raw 9 exit) is already generic — no change.
+        const blueStart = tile(2, 8, bg, 0);
+        const blueExit = tile(2, 9, bg, 0);
+        assert.equal(applySettingsToTileCode(blueStart, allOff), blueStart);
+        assert.equal(applySettingsToTileCode(blueExit, allOff), blueExit);
+    });
+
+    it("doesn't react to flag[3] (illusion shadows are gated in the shadow pass, not the tile pass)", () => {
+        const wallishCode = tile(2, 19 - 24 + 24, 0, 0); // any non-mine/magnet/tele special
+        assert.equal(applySettingsToTileCode(wallishCode, [true, true, true, false]), wallishCode);
+        assert.equal(applySettingsToTileCode(wallishCode, [true, true, true, true]), wallishCode);
+    });
+
+    it("preserves the under-tile bg in the substitute (mine-on-dirt becomes plain dirt)", () => {
+        // bg=2 (mud); substitute should be 16777216 + 2*256 = 16777728.
+        const mineOnMud = tile(2, 4, 2, 0);
+        assert.equal(applySettingsToTileCode(mineOnMud, allOff), 16777216 + 2 * 256);
     });
 });
 

--- a/port/shared/src/track.ts
+++ b/port/shared/src/track.ts
@@ -34,6 +34,83 @@ export interface TrackSet {
 const DEFAULT_SETTINGS = "ffff";
 
 /**
+ * Four boolean flags decoded from a track's `S` line. Indexes mirror Java's
+ * `Track.specialSettings`:
+ *   [0] mines visible       (false = mines render as plain bg / "invisible")
+ *   [1] magnets visible     (false = magnets render as plain bg)
+ *   [2] teleports coloured  (false = colour-keyed start/exit reduce to blue)
+ *   [3] illusion shadows    (false = collision-id 19 doesn't cast a shadow)
+ */
+export type SettingsFlags = readonly [boolean, boolean, boolean, boolean];
+
+export const NO_SETTINGS_FLAGS: SettingsFlags = [false, false, false, false];
+
+/**
+ * Decode the first 4 chars of an S-line body into the boolean flag array.
+ * Real-world tracks store six chars — four flags plus a 2-digit min/max
+ * player range — but the Java client only consults the first four. We do the
+ * same and tolerate strings shorter than 4 by leaving the missing flags false
+ * (matching `new boolean[4]` in `VersionedTrackFileParser.constructTrack`).
+ *
+ * Note: the upstream Java parser has a long-standing typo (`length() != 6`)
+ * that drops the flags entirely whenever the string is exactly 6 chars long
+ * — i.e. for nearly every real track. The dev-comment "should throw error"
+ * in the `else` branch shows the original intent was to parse the first 4
+ * chars regardless of total length, which is what we do here.
+ */
+export function parseSettingsFlags(settings: string | null | undefined): SettingsFlags {
+    if (!settings) return NO_SETTINGS_FLAGS;
+    return [
+        settings.charAt(0) === "t",
+        settings.charAt(1) === "t",
+        settings.charAt(2) === "t",
+        settings.charAt(3) === "t",
+    ];
+}
+
+/**
+ * Mirror of Java `Tile.getSpecialsettingCode(boolean[])`. Substitutes a raw
+ * 32-bit tile code based on visibility flags so the substituted code unpacks
+ * into the "hidden" / "colourless" form. Pure function — no dependencies on
+ * canvas / sprites — so the renderer just calls this on each tile before
+ * unpacking.
+ *
+ * Shape values here are the RAW byte (Java's `tile.shape` is `raw + 24`):
+ *   raw 4 / 6  → mine / BIGmine                   (Java shape 28 / 30)
+ *   raw 20 / 21 → magnet attract / repel           (Java shape 44 / 45)
+ *   raw 10 / 12 / 14 → red/yellow/green T-source  (Java shape 34 / 36 / 38)
+ *   raw 11 / 13 / 15 → red/yellow/green T-exit    (Java shape 35 / 37 / 39)
+ *
+ * Substitute encodings (Java verbatim, before adding `bg*256`):
+ *   16777216 = 0x01000000 → special=1, shape=0   ⇒ plain bg element
+ *   34078720 = 0x02080000 → special=2, shape=8   ⇒ blue T-source (generic start)
+ *   34144256 = 0x02090000 → special=2, shape=9   ⇒ blue T-exit (generic exit)
+ * `bg*256` restores the original under-tile element (e.g. mine on dirt becomes
+ * plain dirt, not plain grass).
+ *
+ * IMPORTANT: only the visual layer should call this. Java `Map.collisionMap()`
+ * does NOT consult specialSettings — the collision/physics layer keeps the
+ * unmodified tile semantics so a hidden mine still detonates, a hidden magnet
+ * still pulls, etc. That's the whole point of the flags as a puzzle knob.
+ */
+export function applySettingsToTileCode(code: number, flags: SettingsFlags): number {
+    const special = (code >>> 24) & 0xff;
+    if (special !== 2) return code;
+    const shape = (code >>> 16) & 0xff;
+    const bg = (code >>> 8) & 0xff;
+    // [0] mines invisible — Java shape 28/30 (raw 4/6).
+    if (!flags[0] && (shape === 4 || shape === 6)) return 16777216 + bg * 256;
+    // [1] magnets invisible — Java shape 44/45 (raw 20/21).
+    if (!flags[1] && (shape === 20 || shape === 21)) return 16777216 + bg * 256;
+    // [2] teleports colourless — colour-keyed starts/exits collapse to blue.
+    if (!flags[2]) {
+        if (shape === 10 || shape === 12 || shape === 14) return 34078720 + bg * 256;
+        if (shape === 11 || shape === 13 || shape === 15) return 34144256 + bg * 256;
+    }
+    return code;
+}
+
+/**
  * Parse a versioned (.track) file. Tolerates missing optional lines.
  *
  * Format (per VersionedTrackFileParser javadoc):

--- a/port/web/src/game/render.ts
+++ b/port/web/src/game/render.ts
@@ -13,6 +13,9 @@ import {
   PIXEL_PER_TILE,
   MAP_PIXEL_WIDTH,
   MAP_PIXEL_HEIGHT,
+  NO_SETTINGS_FLAGS,
+  applySettingsToTileCode,
+  type SettingsFlags,
   unpackTile,
 } from "@minigolf/shared";
 import type { ParsedMap } from "./map.ts";
@@ -123,12 +126,35 @@ export class TrackRenderer {
   private bgCanvas: HTMLCanvasElement;
   private parsedMap: ParsedMap;
   private atlases: Atlases;
-  constructor(parsedMap: ParsedMap, atlases: Atlases) {
+  /**
+   * Track 'S'-line flags (see `parseSettingsFlags` in @minigolf/shared).
+   *   [0] mines visible / hidden as plain bg
+   *   [1] magnets visible / hidden as plain bg
+   *   [2] teleports coloured / reduced to colourless blue start+exit
+   *   [3] illusion-wall (collision id 19) casts shadow / not
+   * Java applies these only at draw time (via `Tile.getSpecialsettingCode` and
+   * `Map.castShadow`); collision/physics keeps the original tile semantics so
+   * "hidden" mines/magnets/teleports still trigger normally — that's the whole
+   * point of the flags as a puzzle-design knob.
+   */
+  private settingsFlags: SettingsFlags;
+  constructor(parsedMap: ParsedMap, atlases: Atlases, settingsFlags: SettingsFlags = NO_SETTINGS_FLAGS) {
     this.parsedMap = parsedMap;
     this.atlases = atlases;
+    this.settingsFlags = settingsFlags;
     this.bgCanvas = document.createElement("canvas");
     this.bgCanvas.width = MAP_PIXEL_WIDTH;
     this.bgCanvas.height = MAP_PIXEL_HEIGHT;
+    this.buildBackground();
+  }
+
+  /**
+   * Replace the active settings flags and rebuild the cached background. Used
+   * if the S line ever arrives after `TrackRenderer` was constructed (the
+   * panel currently passes flags up-front, but this keeps the door open).
+   */
+  setSettingsFlags(flags: SettingsFlags): void {
+    this.settingsFlags = flags;
     this.buildBackground();
   }
 
@@ -147,6 +173,10 @@ export class TrackRenderer {
     ty: number,
     code: number,
   ): void {
+    // Visibility / colour-key remap per the track's S-line flags. Done here
+    // (visual layer) only — collision/physics keeps the unmodified code so
+    // hidden mines still detonate, hidden magnets still pull, etc.
+    code = applySettingsToTileCode(code, this.settingsFlags);
     const u = unpackTile(code);
     const special = u.isNoSpecial;
     if (special === 0) {
@@ -251,12 +281,15 @@ export class TrackRenderer {
     const data = img.data;
     const collision = this.parsedMap.collision;
 
+    // Java `Map.castShadow`: solid pixels are collision id 16..23, with id 19
+    // (illusion wall) gated by `specialSettings[3]` — when the flag is on,
+    // illusion walls cast shadows like normal walls; when off, they don't.
+    const illusionShadow = this.settingsFlags[3];
     const isSolid = (x: number, y: number): boolean => {
       if (x < 0 || x >= W || y < 0 || y >= H) return false;
       const c = collision[y * W + x];
-      // Java: c >= 16 && c <= 23 && c != 19  (specialSettings[3]==false; the
-      // illusion-wall block doesn't cast shadows in the default ruleset).
-      return c >= 16 && c <= 23 && c !== 19;
+      if (c < 16 || c > 23) return false;
+      return c !== 19 || illusionShadow;
     };
     const isTeleStart = (x: number, y: number): boolean => {
       if (x < 0 || x >= W || y < 0 || y >= H) return false;

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -1,4 +1,4 @@
-import { PacketType, Seed, type Packet } from "@minigolf/shared";
+import { PacketType, Seed, parseSettingsFlags, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
 import { loadAtlases, type Atlases } from "../game/sprites.ts";
@@ -620,7 +620,12 @@ export class GamePanel implements Panel {
     try {
       const parsed = buildMap(tLine, this.atlases);
       this.parsedMap = parsed;
-      this.renderer = new TrackRenderer(parsed, this.atlases);
+      // S line: 4 visibility/shadow flags + legacy 2-digit player range. Server
+      // forwards the raw body; we decode the first four chars. Missing/short
+      // S → all-false, mirroring `new boolean[4]` in Java's track parser.
+      const settingsBody = extractField(f, "S ") ?? "";
+      const settingsFlags = parseSettingsFlags(settingsBody);
+      this.renderer = new TrackRenderer(parsed, this.atlases, settingsFlags);
       // Pick the common (shape-24) start, deterministic from gameId.
       const commonStart: [number, number] | null =
         parsed.startPositions.length > 0

--- a/port/web/src/panels/replay.ts
+++ b/port/web/src/panels/replay.ts
@@ -157,6 +157,10 @@ export class ReplayPanel implements Panel {
     try {
       this.atlases = await loadAtlases();
       this.parsedMap = buildMap(this.replay.t, this.atlases);
+      // DailyReplay doesn't carry the track's S-line body (yet) so the
+      // renderer defaults to all-false flags — mines/magnets/teleports hide,
+      // illusion walls don't cast shadows. Matches Java's "no S" default and
+      // is acceptable since replay physics doesn't depend on visibility.
       this.renderer = new TrackRenderer(this.parsedMap, this.atlases);
       this.placeAtFirstStrokeOrigin();
       this.updateStrokeLabel();


### PR DESCRIPTION
The track file's `S <flags><minPlayers><maxPlayers>` line carries four boolean flags (mines visible, magnets visible, teleports coloured, illusion-wall shadows) that the port stored on `track.settings` but never consulted while rendering. Java's reference does the substitution in `Tile.getSpecialsettingCode` + `Map.castShadow`; this matches that path, applying flags only at the visual layer so collision/physics keep the original tile semantics — hidden mines still detonate, hidden magnets still pull, hidden teleports still teleport.

Server now ships `S <body>` after the `C` line in `networkSerialize` (Java omits it; combined with the upstream parser's `length() != 6` typo this means original Playforia probably never honored these flags either). Renderer threads `SettingsFlags` through `TrackRenderer` and the game panel parses the body off the starttrack packet. Replay panel keeps the all-false default since `DailyReplay` doesn't carry the body yet — old replay links of mine/magnet/teleport tracks may render those elements hidden where they used to be visible; physics is unchanged.

Closes #27