### PR TITLE
Port: log persistent client id + IP/UA to distinguish unique users fr…

### DIFF
--- a/port/docs/PROTOCOL.md
+++ b/port/docs/PROTOCOL.md
@@ -40,10 +40,13 @@ server → d 0 status<TAB>login
 client → d 1 language<TAB>en   (en|fi|sv — server records, no reply)
 client → d 2 logintype<TAB>nr  (nr = guest; the only one we implement)
 server → d 1 status<TAB>login  (yes, twice — Java oddity)
-client → d 3 nick<TAB>{name}   (PORT EXTENSION — optional; if omitted or
+client → d 3 cid<TAB>{uuid}    (PORT EXTENSION — persistent browser id from
+                                localStorage; analytics only, no protocol
+                                use. Optional; missing = no cid logged.)
+client → d 4 nick<TAB>{name}   (PORT EXTENSION — optional; if omitted or
                                 rejected, server falls back to a random
                                 `~anonym-` placeholder)
-client → d 4 login
+client → d 5 login
 server → d 2 basicinfo<TAB>t<TAB>0<TAB>t<TAB>t
 server → d 3 status<TAB>lobbyselect<TAB>300
 ```

--- a/port/server/src/connection.ts
+++ b/port/server/src/connection.ts
@@ -9,6 +9,7 @@ import type { WebSocket } from "ws";
 import { decode, type Packet, PacketType, buildCommand, buildData } from "@minigolf/shared";
 import type { Player } from "./player.ts";
 import type { GolfServer } from "./server.ts";
+import { logEvent } from "./log.ts";
 
 // Browsers throttle JS in background tabs (Chrome down to ~1Hz, sometimes
 // even less). The original Java applet didn't have that problem, but our
@@ -38,11 +39,42 @@ export class Connection {
     public readonly ws: WebSocket;
     public readonly server: GolfServer;
     public readonly verbose: boolean;
+    /** Short random per-connection id (e.g. `c-x3k9q1mt`). Stamped on every
+     *  analytics event involving this socket so a downstream consumer can
+     *  group `client_connect` / `player_login` / `player_disconnect` lines
+     *  for the same WS, even if the player record is reused via reconnect. */
+    public readonly connId: string;
+    /** Remote address from the HTTP upgrade socket. May be IPv4-mapped IPv6
+     *  (`::ffff:1.2.3.4`) — left as-is so it round-trips back to the same
+     *  bucket that `main.ts` uses for per-IP rate limiting. */
+    public readonly remoteAddress: string;
+    /** User-Agent header from the WS upgrade. Non-browser clients (smoke
+     *  tests, server-to-server tooling) typically send `undefined` — we
+     *  store the empty string so the field is always present in logs. */
+    public readonly userAgent: string;
+    /** Persistent browser-side UUID (from `localStorage["mg.clientId"]`) sent
+     *  by the web client during the login handshake via the `cid` packet.
+     *  Survives page refresh; lets analytics distinguish "same browser
+     *  reloading" from "two unrelated guests". Null until the packet lands
+     *  (or for non-browser clients that don't send one). Lives on Connection
+     *  rather than Player so the `client_connect`/`client_disconnect` events
+     *  — which fire pre-login and post-player-removal respectively — can
+     *  still surface it. */
+    public clientId: string | null = null;
 
-    constructor(ws: WebSocket, server: GolfServer, verbose: boolean) {
+    constructor(
+        ws: WebSocket,
+        server: GolfServer,
+        verbose: boolean,
+        remoteAddress: string,
+        userAgent: string,
+    ) {
         this.ws = ws;
         this.server = server;
         this.verbose = verbose;
+        this.remoteAddress = remoteAddress;
+        this.userAgent = userAgent;
+        this.connId = "c-" + Math.random().toString(36).slice(2, 10);
         ws.on("message", (data) => {
             const text = typeof data === "string" ? data : data.toString("utf-8");
             this.lastActivity = Date.now();
@@ -55,6 +87,16 @@ export class Connection {
         });
 
         this.heartbeatTimer = setInterval(() => this.checkHeartbeat(), 1_000);
+
+        // Connection-level analytics ping. Fires for every WS upgrade, even
+        // ones that abort before login — so we see "browser opened a socket"
+        // separately from "player completed handshake". `conn` ties it to
+        // the eventual `player_login`/`player_disconnect` lines.
+        logEvent("client_connect", {
+            conn: this.connId,
+            ip: this.remoteAddress,
+            ua: this.userAgent,
+        });
 
         // Send the initial handshake — this is what Java sends in ClientConnectedEvent.
         this.sendRaw("h 1");
@@ -131,6 +173,15 @@ export class Connection {
             clearInterval(this.heartbeatTimer);
             this.heartbeatTimer = null;
         }
+        // Connection-level disconnect — pairs with `client_connect`. The
+        // higher-level `player_disconnect` (emitted from server.ts) fires
+        // only when the socket carried a logged-in player; this one fires
+        // even for sockets that never got past the handshake. `cid` is
+        // included if the client got far enough to send it.
+        logEvent("client_disconnect", {
+            conn: this.connId,
+            cid: this.clientId,
+        });
         this.server.handleDisconnect(this);
     }
 

--- a/port/server/src/main.ts
+++ b/port/server/src/main.ts
@@ -329,8 +329,14 @@ export async function startServer(args: CliArgs): Promise<RunningServer> {
             ipConnCount.set(remote, cur + 1);
         }
 
+        // User-Agent for analytics. Most browsers send one; non-browser
+        // clients (test harnesses, server-to-server tooling) often don't.
+        // Stored verbatim — we don't strip or normalise here; consumer-side
+        // jq queries are fine with the raw header.
+        const ua = String(req.headers["user-agent"] ?? "");
+
         wss.handleUpgrade(req, sock, head, (ws) => {
-            new Connection(ws, golfServer, args.verbose);
+            new Connection(ws, golfServer, args.verbose, remote, ua);
             ws.on("close", () => {
                 if (maxConnsPerIp > 0) {
                     const cur = ipConnCount.get(remote) ?? 0;

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -125,6 +125,24 @@ register({
 });
 
 /**
+ * Browser-port extension: persistent per-browser client id. The web client
+ * keeps a UUID in `localStorage["mg.clientId"]` and forwards it during the
+ * login handshake. Server-side it's only used for analytics — every
+ * `player_login` / `player_disconnect` / `player_reconnect` event carries
+ * the cid so an offline log scan can distinguish "same browser refreshing"
+ * from "two unrelated guests on shared NAT". Length-capped and
+ * character-restricted because it ends up in stdout JSON.
+ */
+register({
+    type: PacketType.DATA,
+    pattern: /^cid\t(.+)$/,
+    handle: (_server, conn, match) => {
+        const cleaned = match[1].replace(/[^A-Za-z0-9._-]/g, "").slice(0, 64);
+        if (cleaned) conn.clientId = cleaned;
+    },
+});
+
+/**
  * Browser-port extension: client sends `nick <name>` between `logintype` and
  * `login` so the player's chosen display name flows through to other clients
  * (scoreboards, chat, daily-mode ghost labels). Without this the server would
@@ -177,6 +195,10 @@ register({
             id: player.id,
             nick: player.nick,
             language: player.language ?? "-",
+            cid: conn.clientId,
+            conn: conn.connId,
+            ip: conn.remoteAddress,
+            ua: conn.userAgent,
         });
     },
 });

--- a/port/server/src/server.ts
+++ b/port/server/src/server.ts
@@ -174,7 +174,13 @@ export class GolfServer {
         }
         this.removePlayer(player.id);
         player.disconnectedAt = null;
-        logEvent("player_disconnect", { id: player.id, nick: player.nick, reason });
+        logEvent("player_disconnect", {
+            id: player.id,
+            nick: player.nick,
+            reason,
+            cid: player.connection.clientId,
+            conn: player.connection.connId,
+        });
     }
 
     /**
@@ -199,12 +205,31 @@ export class GolfServer {
             this.reconnectTimers.delete(id);
         }
         player.disconnectedAt = null;
+        // Carry the persistent client id forward onto the new socket. The
+        // transparent reconnect protocol (`c old <id>`) doesn't re-send the
+        // `cid` packet, so without this the post-reattach socket's
+        // `clientId` would stay null and analytics on the same browser
+        // would look like two distinct identities across a network blip.
+        if (conn.clientId === null && player.connection.clientId !== null) {
+            conn.clientId = player.connection.clientId;
+        }
         player.connection = conn;
         conn.player = player;
         // The new Connection's outSeq/inSeq are 0 by construction; no reset
         // needed here. Client mirrors this on receipt of `c rcok`.
         console.log(`[reconnect] reattached ${id}/${player.nick}`);
-        logEvent("player_reconnect", { id, nick: player.nick });
+        // The reattached socket carries its own cid (the client re-sent it on
+        // the new connection's `cid` packet — or, for a same-tab transparent
+        // reconnect that happens before login, the new conn has a fresh cid
+        // that will be filled later). Either way, log against `conn.clientId`
+        // (the new socket) and `conn.connId` (the new socket id) so the trail
+        // shows the post-reattach identity.
+        logEvent("player_reconnect", {
+            id,
+            nick: player.nick,
+            cid: conn.clientId,
+            conn: conn.connId,
+        });
         return true;
     }
 

--- a/port/web/src/panels/login.ts
+++ b/port/web/src/panels/login.ts
@@ -3,6 +3,50 @@ import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
 import { i18n, saveLang, t, type Lang } from "../i18n.ts";
 
+const CLIENT_ID_STORAGE_KEY = "mg.clientId";
+
+/**
+ * Persistent per-browser identifier kept in localStorage. Survives page
+ * refreshes (and even browser restarts) but resets on cleared site data,
+ * private windows, or a different browser/profile. Format is the platform
+ * `crypto.randomUUID()` (RFC 4122 v4) when available, falling back to a
+ * compact random string for execution contexts that don't expose it
+ * (very old test runners, mostly).
+ *
+ * The server only consumes this for analytics — it's logged in
+ * player_login / player_disconnect / player_reconnect, never used for
+ * authentication or session takeover, so a forged or shared id only
+ * confuses our own dashboards.
+ */
+function getOrCreateClientId(): string {
+  try {
+    const existing = localStorage.getItem(CLIENT_ID_STORAGE_KEY);
+    if (existing && existing.length > 0) return existing;
+  } catch {
+    // localStorage unavailable (private mode quota, sandbox). Fall through
+    // and mint a transient id — it'll change on every refresh, which makes
+    // the analytics weaker but still better than nothing.
+  }
+  const fresh = mintClientId();
+  try {
+    localStorage.setItem(CLIENT_ID_STORAGE_KEY, fresh);
+  } catch {
+    /* ignore */
+  }
+  return fresh;
+}
+
+function mintClientId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c && typeof c.randomUUID === "function") return c.randomUUID();
+  // Fallback: 16 bytes of Math.random in hex. Not cryptographically secure,
+  // but the cid only labels analytics rows — collision risk is what matters,
+  // and 128 bits is plenty for that.
+  let s = "";
+  for (let i = 0; i < 32; i++) s += Math.floor(Math.random() * 16).toString(16);
+  return s;
+}
+
 /**
  * Drives the login handshake:
  *   c new (already sent during loading)
@@ -203,9 +247,14 @@ export class LoginPanel implements Panel {
     // uses it as the player's display name instead of the random `~anonym-`
     // placeholder, so other players (and ghost labels in daily mode) see the
     // name the user chose at the login screen.
+    // `cid` is the port's persistent browser id (localStorage UUID). The
+    // server logs it in player_login/disconnect/reconnect events so an
+    // operator scanning the analytics log can tell "same browser refreshing"
+    // apart from "two unrelated guests on the same NAT".
     this.app.connection.sendData("version", 35);
     this.app.connection.sendData("language", lang);
     this.app.connection.sendData("logintype", "nr");
+    this.app.connection.sendData("cid", getOrCreateClientId());
     if (nick) this.app.connection.sendData("nick", nick);
     this.app.connection.sendData("login");
 


### PR DESCRIPTION
…om refreshes

Adds per-connection identity to the structured analytics log so an offline log scan can tell "same browser refreshing" apart from "two unrelated guests". Introduces three new signals:

- `client_connect` / `client_disconnect` events with a short per-socket `conn` id, remote IP, and User-Agent — fire for every WS upgrade, even pre-login.
- `cid` field on `player_login` / `player_disconnect` / `player_reconnect`, sourced from the new `cid` data packet (PORT EXTENSION). The web client generates a UUID via `crypto.randomUUID()`, persists it in `localStorage["mg.clientId"]`, and forwards it during the login handshake. Survives page refresh, distinct across browsers/profiles.
- Carry-forward of `clientId` across transparent reconnects (`c old <id>`) so a network blip doesn't fork the cid trail.

Server-only impact: cid is analytics-only, never used for auth or session takeover. End-to-end verified — two sessions with the same cid but different player ids produce the expected fingerprint of a refresh.