### PR TITLE
Port: handle voteskip / rfng / scoringmulti / cr / part-reason packets

### DIFF
--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -90,13 +90,20 @@ export abstract class Game {
         return true;
     }
 
-    removePlayer(player: Player): boolean {
+    /**
+     * Remove a player from the game and broadcast `game part <id> <reason>` to
+     * the rest. `reason` follows the Java codes consumed by GamePanel:
+     *   4 = USERLEFT (voluntary back / `back` packet)
+     *   5 = CONN_PROBLEM (grace expired after disconnect)
+     *   6 = SWITCHEDLOBBY (silent — client just nulls the name)
+     * Defaults to USERLEFT so the back-button path keeps its existing wire.
+     */
+    removePlayer(player: Player, reason: number = PartReason.USERLEFT): boolean {
         const idx = this.players.indexOf(player);
         if (idx < 0) return false;
-        // game\tpart\t<numberIndex>\t<reason=4>
         const num = this.playersNumber[idx];
         for (const p of this.players) {
-            if (p !== player) p.connection.sendData("game", "part", num, 4);
+            if (p !== player) p.connection.sendData("game", "part", num, reason);
         }
         this.playersNumber.splice(idx, 1);
         this.players.splice(idx, 1);
@@ -891,11 +898,11 @@ export class MultiGame extends GolfGame {
         return true;
     }
 
-    override removePlayer(player: Player): boolean {
+    override removePlayer(player: Player, reason: number = PartReason.USERLEFT): boolean {
         if (!this.players.includes(player)) return false;
         const wasPublic = this.isPublic;
         const playerNum = this.getPlayerId(player);
-        super.removePlayer(player);
+        super.removePlayer(player, reason);
 
         const lobby = player.lobby;
         if (this.players.length > 0) {

--- a/port/server/src/server.ts
+++ b/port/server/src/server.ts
@@ -156,8 +156,12 @@ export class GolfServer {
     private fullyRemovePlayer(player: Player, reason: string): void {
         if (player.game) {
             const lob = player.lobby;
+            // Disconnect-driven removal: peers see "Connection problem or closed
+            // browser" rather than the voluntary-leave phrasing. Voluntary exits
+            // travel through game.handlePacket "back", which calls
+            // game.removePlayer() without an override and stays on reason 4.
             try {
-                player.game.removePlayer(player);
+                player.game.removePlayer(player, PartReason.CONN_PROBLEM);
             } catch {
                 // ignore
             }

--- a/port/server/src/test-vote-rfng.ts
+++ b/port/server/src/test-vote-rfng.ts
@@ -1,0 +1,227 @@
+// Smoke test for issue #30 — confirms the server's wire output for voteskip,
+// rfng, scoringmulti (placeholder), and the part-reason byte on disconnect.
+//
+// Boots a fresh GolfServer on port 4246, drives two clients through a 2-player
+// game, and asserts:
+//   - voteskip from A reaches B as `game voteskip <playerId>` and is NOT echoed
+//     back to A (server uses writeExcluding).
+//   - On the next track the server broadcasts `game resetvoteskip` (so the
+//     client can clear its per-player skip flags).
+//   - newgame from A after game-over reaches B as `game rfng <playerId>` (also
+//     writeExcluding — A doesn't see its own).
+//   - When A's WebSocket drops mid-game, B receives `game part 0 5` (the
+//     CONN_PROBLEM reason). Pre-fix this was always 4 regardless of cause.
+//
+// Usage: node --experimental-strip-types --no-warnings src/test-vote-rfng.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4246;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+class Client {
+    name: string;
+    ws: WebSocket;
+    outSeq = 0;
+    received: string[] = [];
+
+    constructor(name: string) {
+        this.name = name;
+        this.ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+        this.ws.on("message", (m) => this.received.push(m.toString()));
+    }
+    async open(): Promise<void> {
+        await new Promise<void>((r) => this.ws.once("open", () => r()));
+    }
+    send(line: string): void {
+        this.ws.send(line);
+    }
+    sendData(...fields: (string | number)[]): void {
+        this.send(`d ${this.outSeq++} ${fields.join("\t")}`);
+    }
+    sendCommand(verb: string, ...args: string[]): void {
+        this.send(`c ${[verb, ...args].join(" ")}`);
+    }
+    async waitFor(predicate: (s: string) => boolean, label: string, timeoutMs = 4000): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => {
+                console.log(`[${this.name}] timed out waiting for ${label}; queue:`, this.received);
+                reject(new Error(`[${this.name}] timeout: ${label}`));
+            }, timeoutMs);
+            const tick = (): void => {
+                const idx = this.received.findIndex(predicate);
+                if (idx >= 0) {
+                    clearTimeout(t);
+                    const [s] = this.received.splice(idx, 1);
+                    resolve(s);
+                    return;
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+    /** Asserts a packet matching `predicate` does NOT arrive within `windowMs`. */
+    async assertNotReceived(predicate: (s: string) => boolean, label: string, windowMs = 250): Promise<void> {
+        await new Promise((r) => setTimeout(r, windowMs));
+        const found = this.received.find(predicate);
+        if (found) {
+            throw new Error(`[${this.name}] unexpected packet for ${label}: ${found}`);
+        }
+    }
+    close(): void {
+        try { this.ws.close(); } catch { /* */ }
+    }
+    /** Hard-disconnect (no graceful close frame). Forces server to detect EOF. */
+    terminate(): void {
+        try { this.ws.terminate(); } catch { /* */ }
+    }
+}
+
+async function login(c: Client): Promise<void> {
+    await c.waitFor((s) => s === "h 1", "h 1");
+    await c.waitFor((s) => s.startsWith("c crt"), "c crt");
+    await c.waitFor((s) => s === "c ctr", "c ctr");
+    c.sendCommand("new");
+    await c.waitFor((s) => s.startsWith("c id "), "c id");
+    c.sendData("version", 35);
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (v)");
+    c.sendData("language", "en");
+    c.sendData("logintype", "nr");
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (lt)");
+    c.sendData("login");
+    await c.waitFor((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+    await c.waitFor((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+}
+
+async function enterMultiLobby(c: Client): Promise<void> {
+    c.sendData("lobbyselect", "select", "x");
+    await c.waitFor((s) => /^d \d+ status\tlobby\tx/.test(s), "status lobby x");
+    await c.waitFor((s) => /^d \d+ lobby\tusers/.test(s), "lobby users");
+    await c.waitFor((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+    await c.waitFor((s) => /^d \d+ lobby\tgamelist\tfull/.test(s), "gamelist full");
+}
+
+async function main(): Promise<void> {
+    let server: RunningServer | null = null;
+    try {
+        server = await startServer({ host: HOST, port: PORT, tracksDir: tracksDir(), verbose: false });
+        console.log("[server] up");
+
+        const a = new Client("A");
+        const b = new Client("B");
+        await Promise.all([a.open(), b.open()]);
+        await login(a);
+        await login(b);
+        await enterMultiLobby(a);
+        await enterMultiLobby(b);
+        // 2 tracks so we can confirm resetvoteskip fires between holes.
+        a.sendData("lobby", "cmpt", "TestGame", "-", 0, 2, 2, 0, 10, 60, 0, 1, 0, 0);
+        const addLine = await b.waitFor(
+            (s) => /^d \d+ lobby\tgamelist\tadd/.test(s),
+            "B sees gamelist add",
+        );
+        await a.waitFor((s) => /^d \d+ status\tgame/.test(s), "A status game");
+        const gameId = parseInt(addLine.split("\t")[3] ?? "0", 10);
+        b.sendData("lobby", "jmpt", String(gameId));
+        await b.waitFor((s) => /^d \d+ status\tgame/.test(s), "B status game");
+        await a.waitFor((s) => /^d \d+ game\tstart$/.test(s), "A game start");
+        await b.waitFor((s) => /^d \d+ game\tstart$/.test(s), "B game start");
+        await a.waitFor((s) => /^d \d+ game\tresetvoteskip/.test(s), "A initial resetvoteskip");
+        await b.waitFor((s) => /^d \d+ game\tresetvoteskip/.test(s), "B initial resetvoteskip");
+        await a.waitFor((s) => /^d \d+ game\tstarttrack/.test(s), "A starttrack #1");
+        await b.waitFor((s) => /^d \d+ game\tstarttrack/.test(s), "B starttrack #1");
+        console.log("[OK] both joined, game started");
+
+        // ── voteskip ──────────────────────────────────────────────────────
+        // A votes; server should send `game voteskip 0` to B (only). A must
+        // NOT see an echo (Java compensates by setting the flag locally on
+        // the click handler).
+        a.sendData("game", "voteskip");
+        const bGotVote = await b.waitFor(
+            (s) => /^d \d+ game\tvoteskip\t0$/.test(s),
+            "B sees A's voteskip",
+        );
+        console.log("[OK] B received:", bGotVote.split(" ").slice(2).join(" "));
+        await a.assertNotReceived(
+            (s) => /game\tvoteskip/.test(s),
+            "A should not see own voteskip echo",
+        );
+        console.log("[OK] no self-echo for voteskip");
+
+        // B also votes → both have voted → server advances to next track.
+        b.sendData("game", "voteskip");
+        await a.waitFor(
+            (s) => /^d \d+ game\tvoteskip\t1$/.test(s),
+            "A sees B's voteskip",
+        );
+        // Track advance: server broadcasts resetvoteskip + starttrack.
+        await a.waitFor((s) => /^d \d+ game\tresetvoteskip/.test(s), "A resetvoteskip after both voted");
+        await b.waitFor((s) => /^d \d+ game\tresetvoteskip/.test(s), "B resetvoteskip after both voted");
+        await a.waitFor((s) => /^d \d+ game\tstarttrack/.test(s), "A starttrack #2");
+        await b.waitFor((s) => /^d \d+ game\tstarttrack/.test(s), "B starttrack #2");
+        console.log("[OK] both votes accepted, track advanced with resetvoteskip");
+
+        // ── play through the second track and end the game ────────────────
+        // Quickest path to game end: both forfeit the second hole.
+        a.sendData("game", "forfeit");
+        b.sendData("game", "forfeit");
+        await a.waitFor((s) => /^d \d+ game\tend/.test(s), "A game end");
+        await b.waitFor((s) => /^d \d+ game\tend/.test(s), "B game end");
+        console.log("[OK] game ended after both forfeited last track");
+
+        // ── rfng (newgame) ────────────────────────────────────────────────
+        // A clicks play-again; server should send `game rfng 0` to B only.
+        a.sendData("game", "newgame");
+        const bGotRfng = await b.waitFor(
+            (s) => /^d \d+ game\trfng\t0$/.test(s),
+            "B sees A's rfng",
+        );
+        console.log("[OK] B received:", bGotRfng.split(" ").slice(2).join(" "));
+        await a.assertNotReceived(
+            (s) => /game\trfng/.test(s),
+            "A should not see own rfng echo",
+        );
+        console.log("[OK] no self-echo for rfng");
+
+        // ── part-reason on hard disconnect ────────────────────────────────
+        // Drain B's queue first so we're sure the next game-related packet
+        // is the part broadcast (rather than leftover starttrack/etc.).
+        b.received.length = 0;
+        a.terminate();
+        const bGotPart = await b.waitFor(
+            (s) => /^d \d+ game\tpart\t/.test(s),
+            "B sees A's part",
+            6000,
+        );
+        // Format: `d <seq> game\tpart\t<id>\t<reason>` — split on tabs, take
+        // the last field. The reason MUST be "5" (CONN_PROBLEM) post-fix; the
+        // pre-fix server hardcoded "4" for every disconnect path.
+        const parts = bGotPart.split("\t");
+        const reason = parts[parts.length - 1];
+        if (reason !== "5") {
+            throw new Error(`expected part reason "5" (CONN_PROBLEM) on hard disconnect, got "${reason}" (full line: ${bGotPart})`);
+        }
+        console.log("[OK] hard disconnect produced part reason 5 (CONN_PROBLEM)");
+
+        b.close();
+        console.log("\nALL VOTESKIP / RFNG / PART-REASON CHECKS PASSED");
+        process.exit(0);
+    } catch (err) {
+        console.error("FAIL:", err);
+        process.exit(1);
+    } finally {
+        if (server) {
+            try { await server.close(); } catch { /* */ }
+        }
+    }
+}
+
+main();

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -93,6 +93,28 @@ interface PlayerSlot {
   /** This player gave up on the current track. */
   forfeitedThisTrack: boolean;
   /**
+   * Java `playerVotedToSkip[player]`. Set when we receive `game voteskip <id>`
+   * from the server (or locally when *we* press skip — the server doesn't
+   * echo back the sender). Cleared on every `resetvoteskip` and on starttrack.
+   * Drives the "(Vote: skip track)" badge in the scoreboard row.
+   */
+  votedToSkip: boolean;
+  /**
+   * Java `playerReadyForNewGame[player]`. Set when we receive `game rfng <id>`
+   * (or locally when *we* press the play-again button — server doesn't echo).
+   * Drives the "(Wants a new game!)" badge after the game ends.
+   */
+  wantsNewGame: boolean;
+  /**
+   * Java `playerLeaveReasons[player]`. 0 = present, otherwise the part-reason
+   * byte from `game part <id> <reason>`:
+   *   4 = USERLEFT (voluntary back)
+   *   5 = CONN_PROBLEM (network blip / closed tab)
+   *   6 = SWITCHEDLOBBY (silent — name nulled, no badge)
+   * Drives the trailing badge in the scoreboard row for parted players.
+   */
+  partReason: number;
+  /**
    * Spawn for this player on the current track. On multi-spawn tracks each
    * colour-keyed reset marker (shapes 48..51) yields a per-player spawn; the
    * common shape-24 marker is the fallback. Used when constructing the per-
@@ -176,6 +198,24 @@ export class GamePanel implements Panel {
   /** beginstroke packets that arrived before atlases or track were ready. */
   private pendingBeginStrokes: string[][] = [];
   private pendingStartTrack: string[] | null = null;
+  /**
+   * Per-track score multipliers from the `scoringmulti` packet (Java
+   * `playerInfoPanel.trackScoresMultipliers`). The server doesn't currently
+   * emit `scoringmulti`, so this stays empty and every track is treated as 1×.
+   * When populated, `handleStartTrack` posts a chat notice on a new track
+   * whose multiplier is > 1, mirroring Java's `GameChat_ScoreMultiNotify`.
+   */
+  private trackScoresMultipliers: number[] = [];
+  /**
+   * In-game skip / new-game buttons. Recreated on each `setState`-equivalent
+   * transition (track change, end-of-game) so visibility tracks the Java
+   * GameControlPanel's add/remove dance. The `skipButton` is detached from
+   * the DOM after the local player votes (and re-attached on `resetvoteskip`)
+   * so the user can't spam-vote.
+   */
+  private skipButton: HTMLButtonElement | null = null;
+  private skipButtonHost: HTMLElement | null = null;
+  private playAgainButton: HTMLButtonElement | null = null;
 
   private mouseX = 0;
   private mouseY = 0;
@@ -287,16 +327,41 @@ export class GamePanel implements Panel {
     center.appendChild(strokeCountEl);
     center.appendChild(statusEl);
 
+    // Forfeit + Skip live in a row so the existing centered HUD column doesn't
+    // grow taller when both are visible (3-player+ rooms with vote-skip).
+    const buttonRow = document.createElement("div");
+    buttonRow.style.display = "flex";
+    buttonRow.style.gap = "4px";
+    buttonRow.style.justifyContent = "center";
+    buttonRow.style.marginTop = "4px";
+
     const forfeit = document.createElement("button");
     forfeit.type = "button";
     forfeit.className = "btn-yellow";
     forfeit.textContent = t("Port_Game_ForfeitHole", "Forfeit hole");
-    forfeit.style.marginTop = "4px";
     forfeit.style.padding = "1px 10px";
     forfeit.style.minHeight = "auto";
     forfeit.style.fontSize = "11px";
     forfeit.addEventListener("click", () => this.forfeitHole());
-    center.appendChild(forfeit);
+    buttonRow.appendChild(forfeit);
+
+    // Skip-track vote — only meaningful in multiplayer + non-daily rooms; the
+    // visibility logic in `updateSkipButtonVisibility` keeps it hidden in
+    // 1-player and daily modes. Mirrors Java GameControlPanel's `buttonSkip`.
+    const skip = document.createElement("button");
+    skip.type = "button";
+    skip.className = "btn-blue";
+    skip.textContent = t("GameControl_Skip", "Skip track");
+    skip.style.padding = "1px 10px";
+    skip.style.minHeight = "auto";
+    skip.style.fontSize = "11px";
+    skip.style.display = "none";
+    skip.addEventListener("click", () => this.voteSkip());
+    buttonRow.appendChild(skip);
+    this.skipButton = skip;
+    this.skipButtonHost = buttonRow;
+
+    center.appendChild(buttonRow);
 
     const right = document.createElement("div");
     right.className = "right";
@@ -465,10 +530,14 @@ export class GamePanel implements Panel {
     this.chatLogEl = null;
     this.chatInputEl = null;
     this.chatStripEl = null;
+    this.skipButton = null;
+    this.skipButtonHost = null;
+    this.playAgainButton = null;
     this.overlay = null;
     this.root = null;
     this.players = [];
     this.pendingBeginStrokes = [];
+    this.trackScoresMultipliers = [];
   }
 
   // ----- packet routing -------------------------------------------------
@@ -500,6 +569,7 @@ export class GamePanel implements Panel {
         this.ensurePlayerSlots(this.numPlayers);
         this.scoreboardDirty = true;
         this.applyChatVisibility();
+        this.updateSkipButtonVisibility();
         break;
       case "owninfo":
         this.myPlayerId = parseInt(f[2] ?? "0", 10) || 0;
@@ -530,17 +600,117 @@ export class GamePanel implements Panel {
         break;
       case "part":
         {
+          // Java GamePanel.handlePacket "part" reads args[3] as the reason byte
+          // and routes to PlayerInfoPanel.setPlayerPartStatus, which:
+          //   reason 6 → silent name-null (no chat line)
+          //   reason 4 → "Left the game" badge
+          //   reason 5 → "Connection problem" badge
+          // We mirror those branches here.
           const id = parseInt(f[2] ?? "0", 10) || 0;
-          if (this.players[id]) {
-            this.appendChat("* " + t("Chat_Game_PlayerLeft", "Player %1 left the game", this.players[id].nick), "system");
-            this.players[id].active = false;
+          const reason = parseInt(f[3] ?? "4", 10) || 4;
+          const slot = this.players[id];
+          if (slot) {
+            if (reason === 6) {
+              // SWITCHEDLOBBY — silent removal, just clear the slot's name
+              // so the scoreboard row no longer references them.
+              slot.nick = "";
+              slot.active = false;
+              slot.partReason = 0;
+            } else {
+              slot.active = false;
+              slot.partReason = reason;
+              const nick = slot.nick || t("Port_Game_PlayerFmt", "Player %1", id + 1);
+              if (reason === 5) {
+                this.appendChat(
+                  "* " + t("Port_Chat_PlayerConnProblem", "%1 disconnected (connection problem)", nick),
+                  "system",
+                );
+              } else {
+                this.appendChat(
+                  "* " + t("Chat_Game_PlayerLeft", "Player %1 left the game", nick),
+                  "system",
+                );
+              }
+            }
           }
           this.scoreboardDirty = true;
         }
         break;
+      case "voteskip":
+        {
+          // Server broadcasts to OTHER players only; the local clicker sets
+          // the flag in `voteSkip()`. So this branch fires for peers' votes.
+          const id = parseInt(f[2] ?? "0", 10) || 0;
+          const slot = this.players[id];
+          if (slot) {
+            slot.votedToSkip = true;
+            const nick = slot.nick || t("Port_Game_PlayerFmt", "Player %1", id + 1);
+            this.appendChat(
+              "* " + t("Port_Chat_VoteSkip", "%1 voted to skip the track", nick),
+              "system",
+            );
+          }
+          this.scoreboardDirty = true;
+        }
+        break;
+      case "resetvoteskip":
+        // Server broadcasts on every starttrack and on game start. Java's
+        // `voteSkipReset()` clears all flags; we mirror that and re-show the
+        // skip button so the local player can vote again on the new track.
+        for (const slot of this.players) slot.votedToSkip = false;
+        this.updateSkipButtonVisibility();
+        this.scoreboardDirty = true;
+        break;
+      case "rfng":
+        {
+          // "Ready for new game" from a peer (server uses writeExcluding for
+          // this, so the local clicker sets the flag in `requestNewGame()`).
+          const id = parseInt(f[2] ?? "0", 10) || 0;
+          const slot = this.players[id];
+          if (slot) {
+            slot.wantsNewGame = true;
+            const nick = slot.nick || t("Port_Game_PlayerFmt", "Player %1", id + 1);
+            this.appendChat(
+              "* " + t("Port_Chat_WantsNewGame", "%1 wants a new game", nick),
+              "system",
+            );
+          }
+          this.scoreboardDirty = true;
+        }
+        break;
+      case "scoringmulti":
+        {
+          // Per-track score multipliers. Stored once; each starttrack reads
+          // the entry for the new track and posts a chat notice if > 1.
+          const arr: number[] = [];
+          for (let i = 2; i < f.length; i++) {
+            arr.push(parseInt(f[i] ?? "1", 10) || 1);
+          }
+          this.trackScoresMultipliers = arr;
+        }
+        break;
+      case "cr":
+        // Per-track comparison results. Java feeds this into the player-info
+        // panel's results-comparison view, which the port hasn't built yet
+        // (issue #30). Accept and discard so the verb stops appearing in the
+        // unhandled-packet log; the comparison panel is a deferred follow-up.
+        break;
       case "start":
         // Server's "round begins" broadcast (one per game session). Mirrors
         // the Java GamePanel.java:241 trigger for SoundManager.playNotify().
+        // Java's PlayerInfoPanel.reset() also clears voteSkip/readyForNewGame
+        // here so a fresh round doesn't start with stale badges from a
+        // play-again vote that just succeeded.
+        for (const slot of this.players) {
+          slot.votedToSkip = false;
+          slot.wantsNewGame = false;
+        }
+        // Tear down any leftover end-of-game overlay before the new round
+        // starts; otherwise the play-again button stays on screen even though
+        // the new game has begun.
+        this.removeOverlay();
+        this.updateSkipButtonVisibility();
+        this.scoreboardDirty = true;
         audio.playNotify();
         break;
       case "starttrack":
@@ -590,9 +760,13 @@ export class GamePanel implements Panel {
         break;
       case "dailymode":
         // Server tagging this room as the daily challenge. f[2] is the UTC
-        // date key the server picked the track for.
+        // date key the server picked the track for. The packet arrives AFTER
+        // `starttrack` (server.joinDaily ordering), so refresh the skip
+        // button — the prior starttrack would have shown it for a daily
+        // room with two or more occupants because dailyMode was still false.
         this.dailyMode = true;
         this.dailyDateKey = f[2] ?? null;
+        this.updateSkipButtonVisibility();
         break;
       default:
         break;
@@ -680,6 +854,22 @@ export class GamePanel implements Panel {
 
       this.setStatus(t("Port_Game_ClickToShoot", "Click to shoot when you're ready."));
       this.removeOverlay();
+      // Fresh track: vote-skip flags get cleared by the server's
+      // `resetvoteskip` broadcast (which precedes starttrack), but mirror the
+      // reset locally too in case the packets arrive out of order.
+      for (const slot of this.players) slot.votedToSkip = false;
+      // Java GamePanel.starttrack: after `playerInfoPanel.startNextTrack()`
+      // returns the multiplier for the NEW track, post a chat notice if > 1.
+      // currentTrackIdx was just incremented above so the [-1] indexes the
+      // multiplier entry for the freshly-starting track.
+      const trackMul = this.trackScoresMultipliers[this.currentTrackIdx - 1] ?? 1;
+      if (trackMul > 1) {
+        this.appendChat(
+          t("GameChat_ScoreMultiNotify", "* %1x score from this track *", trackMul),
+          "system",
+        );
+      }
+      this.updateSkipButtonVisibility();
       this.scoreboardDirty = true;
       // Replay any beginstrokes that arrived too early.
       const queued = this.pendingBeginStrokes;
@@ -998,9 +1188,27 @@ export class GamePanel implements Panel {
       const total = document.createElement("span");
       total.textContent = "= " + totalSoFar;
       const note = document.createElement("span");
-      if (p.holedThisTrack) note.textContent = t("Port_Game_StatusInHole", "in hole");
-      else if (p.forfeitedThisTrack) note.textContent = t("Port_Game_StatusForfeited", "forfeited");
-      else if (p.simulating) note.textContent = t("Port_Game_StatusShooting", "shooting");
+      // Mirrors Java PlayerInfoPanel's `extraMessage` priority chain:
+      // part-reason badges win over voteSkip/wantsNewGame, which win over
+      // the in-progress play-state notes.
+      if (p.partReason === 5) {
+        note.textContent = t(
+          "GamePlayerInfo_Quit_ConnectionProblem",
+          "(Connection problem or closed browser)",
+        );
+      } else if (p.partReason === 4) {
+        note.textContent = t("GamePlayerInfo_Quit_Part", "(Left the game)");
+      } else if (p.wantsNewGame) {
+        note.textContent = t("GamePlayerInfo_ReadyForNewGame", "(Wants a new game!)");
+      } else if (p.votedToSkip) {
+        note.textContent = t("GamePlayerInfo_VoteSkipTrack", "(Vote: skip track)");
+      } else if (p.holedThisTrack) {
+        note.textContent = t("Port_Game_StatusInHole", "in hole");
+      } else if (p.forfeitedThisTrack) {
+        note.textContent = t("Port_Game_StatusForfeited", "forfeited");
+      } else if (p.simulating) {
+        note.textContent = t("Port_Game_StatusShooting", "shooting");
+      }
       row.appendChild(num);
       row.appendChild(name);
       row.appendChild(tracksCol);
@@ -1259,14 +1467,34 @@ export class GamePanel implements Panel {
       else audio.playGameLoser();
     }
 
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "btn-green";
-    btn.textContent = t("GameControl_Back", "« To menu");
-    btn.addEventListener("click", () => {
+    const btnRow = document.createElement("div");
+    btnRow.style.display = "flex";
+    btnRow.style.gap = "6px";
+    btnRow.style.justifyContent = "center";
+
+    // Play-again — only meaningful in multiplayer (Java's `buttonNewGame`
+    // lives in GameControlPanel and is shown for state==2 game-over). In
+    // single-player there's no peer to vote with us, so the server would
+    // just immediately restart on a single click — surface it the same way.
+    if (this.numPlayers > 1) {
+      const playAgain = document.createElement("button");
+      playAgain.type = "button";
+      playAgain.className = "btn-green";
+      playAgain.textContent = t("GameControl_New", "New Game");
+      playAgain.addEventListener("click", () => this.requestNewGame());
+      btnRow.appendChild(playAgain);
+      this.playAgainButton = playAgain;
+    }
+
+    const back = document.createElement("button");
+    back.type = "button";
+    back.className = this.numPlayers > 1 ? "btn-yellow" : "btn-green";
+    back.textContent = t("GameControl_Back", "« To menu");
+    back.addEventListener("click", () => {
       this.app.connection.sendData("game", "back");
     });
-    ov.appendChild(btn);
+    btnRow.appendChild(back);
+    ov.appendChild(btnRow);
 
     this.root.appendChild(ov);
     this.overlay = ov;
@@ -1482,6 +1710,10 @@ export class GamePanel implements Panel {
       this.overlay.parentNode.removeChild(this.overlay);
     }
     this.overlay = null;
+    // The play-again button is a child of `overlay`; the GC takes it with
+    // the overlay, but null the ref so a stale `disabled = true` write from
+    // a late `requestNewGame` can't blow up.
+    this.playAgainButton = null;
   }
 
   private quit(): void {
@@ -1495,6 +1727,59 @@ export class GamePanel implements Panel {
     if (me.holedThisTrack || me.forfeitedThisTrack) return;
     if (!window.confirm(t("Port_Game_ForfeitConfirm", "Forfeit this hole? You'll be capped at the stroke limit."))) return;
     this.app.connection.sendData("game", "forfeit");
+  }
+
+  /**
+   * Vote-skip click. Server uses writeExcluding so the local player never
+   * sees their own broadcast — we have to mark our own slot here. Hides the
+   * button so the user can't double-vote; re-shown on `resetvoteskip` (fired
+   * by the server on every starttrack).
+   */
+  private voteSkip(): void {
+    const me = this.players[this.myPlayerId];
+    if (!me) return;
+    if (me.votedToSkip) return;
+    me.votedToSkip = true;
+    this.app.connection.sendData("game", "voteskip");
+    this.updateSkipButtonVisibility();
+    this.scoreboardDirty = true;
+  }
+
+  /**
+   * Play-again click on the end overlay. Server uses writeExcluding for the
+   * `rfng` broadcast; mark our own slot, disable the button so we can't
+   * spam-vote, and tell peers via `game newgame`.
+   */
+  private requestNewGame(): void {
+    const me = this.players[this.myPlayerId];
+    if (!me) return;
+    if (me.wantsNewGame) return;
+    me.wantsNewGame = true;
+    this.app.connection.sendData("game", "newgame");
+    if (this.playAgainButton) {
+      this.playAgainButton.disabled = true;
+      this.playAgainButton.textContent = t("Port_Game_WaitingForPeers", "Waiting for others…");
+    }
+    this.scoreboardDirty = true;
+  }
+
+  /**
+   * Show/hide the in-game skip button. Java's GameControlPanel only shows
+   * the skip button in multiplayer rooms (single-player has its own lobby
+   * skip flow); we extend that to also hide it in daily mode (the singleton
+   * room has no concept of voting to skip a deterministic daily track).
+   * Local-player vote also hides until the server's `resetvoteskip` clears.
+   */
+  private updateSkipButtonVisibility(): void {
+    const btn = this.skipButton;
+    if (!btn) return;
+    const me = this.players[this.myPlayerId];
+    const eligible =
+      this.numPlayers > 1 &&
+      !this.dailyMode &&
+      !!me &&
+      !me.votedToSkip;
+    btn.style.display = eligible ? "" : "none";
   }
 
   private applyChatVisibility(): void {
@@ -1523,6 +1808,9 @@ export class GamePanel implements Panel {
         simulating: false,
         holedThisTrack: false,
         forfeitedThisTrack: false,
+        votedToSkip: false,
+        wantsNewGame: false,
+        partReason: 0,
         startX: this.startX,
         startY: this.startY,
         holeScores: [],


### PR DESCRIPTION
Closes #30. Adds the missing inbound packet handlers in the multiplayer game panel and wires the user-facing buttons (Skip track, New Game) so the vote-skip and play-again flows are visible end-to-end.

Server: Game.removePlayer now takes an optional reason; fullyRemovePlayer passes CONN_PROBLEM (5) on disconnect so peers see the right phrasing. MultiGame.removePlayer override forwards the reason — without that, the reason silently fell back to USERLEFT (4) for in-game disconnects.

Test: new test-vote-rfng smoke test covers voteskip echo suppression, resetvoteskip on track advance, rfng echo suppression, and the disconnect → part-reason 5 wire.