### PR TITLE
Port: fix multi-game rejoin slot reuse + Valikko in-game menu

### DIFF
--- a/client/src/main/resources/l10n/en/AGolf.xml
+++ b/client/src/main/resources/l10n/en/AGolf.xml
@@ -1272,6 +1272,24 @@
 	<str key="Tournament_QuitGameButton">
 		<![CDATA[Quit game]]>
 	</str>
+	<str key="Port_Game_Menu">
+		<![CDATA[Menu]]>
+	</str>
+	<str key="Port_Game_Menu_ShowNames">
+		<![CDATA[Show player names]]>
+	</str>
+	<str key="Port_Game_Menu_SendCursor">
+		<![CDATA[Show my aim to other players]]>
+	</str>
+	<str key="Port_Game_Menu_ShowPeerCursors">
+		<![CDATA[Show others' aim lines]]>
+	</str>
+	<str key="Port_Game_Volume">
+		<![CDATA[Volume]]>
+	</str>
+	<str key="Port_Game_VolumeTitle">
+		<![CDATA[Master volume]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Ignore selected user]]>
 	</str>

--- a/client/src/main/resources/l10n/fi/AGolf.xml
+++ b/client/src/main/resources/l10n/fi/AGolf.xml
@@ -1272,6 +1272,24 @@
 	<str key="Tournament_QuitGameButton">
 		<![CDATA[Poistu pelistä]]>
 	</str>
+	<str key="Port_Game_Menu">
+		<![CDATA[Valikko]]>
+	</str>
+	<str key="Port_Game_Menu_ShowNames">
+		<![CDATA[Näytä pelaajien nimet]]>
+	</str>
+	<str key="Port_Game_Menu_SendCursor">
+		<![CDATA[Näytä tähtäin muille pelaajille]]>
+	</str>
+	<str key="Port_Game_Menu_ShowPeerCursors">
+		<![CDATA[Näytä muiden tähtäimet]]>
+	</str>
+	<str key="Port_Game_Volume">
+		<![CDATA[Äänenvoimakkuus]]>
+	</str>
+	<str key="Port_Game_VolumeTitle">
+		<![CDATA[Pää-äänenvoimakkuus]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Mykistä valittu käyttäjä]]>
 	</str>

--- a/client/src/main/resources/l10n/sv/AGolf.xml
+++ b/client/src/main/resources/l10n/sv/AGolf.xml
@@ -1272,6 +1272,24 @@
 	<str key="Tournament_QuitGameButton">
 		<![CDATA[Avsluta spel]]>
 	</str>
+	<str key="Port_Game_Menu">
+		<![CDATA[Meny]]>
+	</str>
+	<str key="Port_Game_Menu_ShowNames">
+		<![CDATA[Visa spelarnamn]]>
+	</str>
+	<str key="Port_Game_Menu_SendCursor">
+		<![CDATA[Visa mitt sikte för andra spelare]]>
+	</str>
+	<str key="Port_Game_Menu_ShowPeerCursors">
+		<![CDATA[Visa andras siktlinjer]]>
+	</str>
+	<str key="Port_Game_Volume">
+		<![CDATA[Volym]]>
+	</str>
+	<str key="Port_Game_VolumeTitle">
+		<![CDATA[Huvudvolym]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Ignorera vald användare]]>
 	</str>

--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -870,11 +870,7 @@ export class MultiGame extends GolfGame {
             }
             return false;
         }
-        // Broadcast `game join` to existing players BEFORE adding the new one.
-        // Ordinal is 1-based (client subtracts 1) — must include the joiner,
-        // so playerCount() + 1. See Game.sendJoinMessages for the matching note.
-        this.broadcast(tabularize("game", "join", this.playerCount() + 1, player.nick, player.clan));
-        this.addPlayer(player);
+        if (!this.addPlayer(player)) return false;
 
         if (lobby && this.players.length > 1) {
             // Update game-list entry (player count changed).
@@ -888,6 +884,71 @@ export class MultiGame extends GolfGame {
             }
             this.startGame();
         }
+        return true;
+    }
+
+    /**
+     * MultiGame join — reuses the lowest unoccupied slot id (0..numPlayers-1)
+     * so a leaver's slot is reclaimed by the next joiner, and broadcasts
+     * `game join` exactly once with that id.
+     *
+     * The base `Game.addPlayer` always assigns the new player `numberIndex`,
+     * which only ever grows — so after any prior leave a fresh joiner takes a
+     * sparse high id while the old slot stays vacant. That breaks two things
+     * for MultiGame:
+     *   1. The per-slot stroke arrays (`playerStrokesThisTrack/Total`) are
+     *      sized to `numPlayers` in the constructor — sparse ids past that
+     *      cap fall off the end.
+     *   2. The base also calls `sendJoinMessages` which broadcasts `game join`
+     *      with `numberIndex + 1`. When the original `MultiGame` layer ALSO
+     *      broadcast a join with `playerCount() + 1`, the two ordinals diverged
+     *      after a leave and existing clients ended up with the joiner appearing
+     *      at TWO scoreboard rows — sometimes overwriting an unrelated active
+     *      player. (See #39 root cause.)
+     *
+     * The override below picks a single dense id and uses it consistently for
+     * the broadcast, the owninfo, and the `playersNumber` push.
+     */
+    override addPlayer(player: Player): boolean {
+        if (this.players.includes(player)) return false;
+
+        // Lowest free slot id within the room's hard cap.
+        let slotId = 0;
+        while (slotId < this.numPlayers && this.playersNumber.includes(slotId)) {
+            slotId++;
+        }
+        if (slotId >= this.numPlayers) return false;
+
+        // Detach from the lobby with the right MULTI-flavoured reason. The
+        // base Game.addPlayer would use STARTED_SP here, which surfaces a
+        // misleading "joined single-player" event in `lobby_leave` analytics.
+        if (player.lobby !== null) {
+            const reason = this.players.length === 0 ? PartReason.CREATED_MP : PartReason.JOINED_MP;
+            player.lobby.removePlayer(player, reason, this.name);
+        }
+
+        // Send join messages BEFORE adding the player so writeAll loops below
+        // don't include the joiner.
+        this.sendGameInfo(player);
+        this.sendPlayerNames(player);
+        const joinBody = tabularize("game", "join", slotId + 1, player.nick, player.clan);
+        for (const p of this.players) {
+            p.connection.sendDataRaw(joinBody);
+        }
+        player.connection.sendData("game", "owninfo", slotId, player.nick, player.clan);
+
+        this.players.push(player);
+        this.playersNumber.push(slotId);
+        if (slotId >= this.numberIndex) this.numberIndex = slotId + 1;
+        player.game = this;
+
+        logEvent("game_join", {
+            game_id: this.gameId,
+            lobby: this.lobbyType,
+            id: player.id,
+            nick: player.nick,
+            players: this.players.length,
+        });
         return true;
     }
 

--- a/port/server/src/test-multi-rejoin.ts
+++ b/port/server/src/test-multi-rejoin.ts
@@ -1,0 +1,237 @@
+// Regression test for multi-game leave-and-rejoin.
+//
+// Boots a fresh GolfServer on port 4249 and walks through the broken-before
+// scenario: A creates a 4-player game, B joins, then B leaves. The MultiGame
+// scoreboard must reuse B's slot id when a fresh joiner D arrives — previously
+// the server emitted two divergent `game join` ordinals (one at
+// `playerCount()+1`, one at `numberIndex+1` from the base `sendJoinMessages`),
+// which made existing clients render the joiner at TWO scoreboard rows and
+// kept growing the visible player count beyond `numPlayers` over each rejoin.
+//
+// Asserts:
+//   - Each `game join` broadcast carries exactly one ordinal (no doubles).
+//   - A new joiner reclaims the lowest free slot id, not a fresh sparse index.
+//   - The same slot can be filled by a different player without breaking the
+//     id space.
+//
+// Invoke: node --experimental-strip-types --no-warnings src/test-multi-rejoin.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4249;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+class Client {
+    name: string;
+    ws: WebSocket;
+    outSeq = 0;
+    received: string[] = [];
+
+    constructor(name: string) {
+        this.name = name;
+        this.ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+        this.ws.on("message", (m) => this.received.push(m.toString()));
+    }
+    async open(): Promise<void> {
+        await new Promise<void>((r) => this.ws.once("open", () => r()));
+    }
+    send(line: string): void {
+        this.ws.send(line);
+    }
+    sendData(...fields: (string | number)[]): void {
+        this.send(`d ${this.outSeq++} ${fields.join("\t")}`);
+    }
+    sendCommand(verb: string, ...args: string[]): void {
+        this.send(`c ${[verb, ...args].join(" ")}`);
+    }
+    async waitFor(predicate: (s: string) => boolean, label: string, timeoutMs = 4000): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => {
+                console.log(`[${this.name}] timed out waiting for ${label}; queue:`, this.received);
+                reject(new Error(`[${this.name}] timeout: ${label}`));
+            }, timeoutMs);
+            const tick = (): void => {
+                const idx = this.received.findIndex(predicate);
+                if (idx >= 0) {
+                    clearTimeout(t);
+                    const [s] = this.received.splice(idx, 1);
+                    resolve(s);
+                    return;
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+    /** Return all currently buffered frames matching predicate without blocking. */
+    drain(predicate: (s: string) => boolean): string[] {
+        const out: string[] = [];
+        const keep: string[] = [];
+        for (const s of this.received) {
+            if (predicate(s)) out.push(s);
+            else keep.push(s);
+        }
+        this.received = keep;
+        return out;
+    }
+    async settle(ms = 80): Promise<void> {
+        await new Promise<void>((r) => setTimeout(r, ms));
+    }
+    close(): void {
+        try { this.ws.close(); } catch { /* */ }
+    }
+}
+
+async function login(c: Client): Promise<void> {
+    await c.waitFor((s) => s === "h 1", "h 1");
+    await c.waitFor((s) => s.startsWith("c crt"), "c crt");
+    await c.waitFor((s) => s === "c ctr", "c ctr");
+    c.sendCommand("new");
+    await c.waitFor((s) => s.startsWith("c id "), "c id");
+    c.sendData("version", 35);
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (v)");
+    c.sendData("language", "en");
+    c.sendData("logintype", "nr");
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (lt)");
+    c.sendData("login");
+    await c.waitFor((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+    await c.waitFor((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+}
+
+async function enterMultiLobby(c: Client): Promise<void> {
+    c.sendData("lobbyselect", "select", "x");
+    await c.waitFor((s) => /^d \d+ status\tlobby\tx/.test(s), "status lobby x");
+    await c.waitFor((s) => /^d \d+ lobby\tusers/.test(s), "lobby users");
+    await c.waitFor((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+    await c.waitFor((s) => /^d \d+ lobby\tgamelist\tfull/.test(s), "gamelist full");
+}
+
+/** Parse the player-id (1-based ordinal in the wire packet → 0-based slot). */
+function ownInfoSlot(line: string): number {
+    // d <seq> game\towninfo\t<id>\t<nick>\t<clan>
+    const m = line.match(/game\towninfo\t(-?\d+)/);
+    if (!m) throw new Error(`not an owninfo: ${line}`);
+    return parseInt(m[1], 10);
+}
+
+function joinSlot(line: string): number {
+    // d <seq> game\tjoin\t<ordinal>\t<nick>\t<clan>  (1-based; subtract 1 for slot)
+    const m = line.match(/game\tjoin\t(-?\d+)/);
+    if (!m) throw new Error(`not a join: ${line}`);
+    return parseInt(m[1], 10) - 1;
+}
+
+async function main(): Promise<void> {
+    let server: RunningServer | null = null;
+    try {
+        server = await startServer({ host: HOST, port: PORT, tracksDir: tracksDir(), verbose: false });
+        console.log("[server] up");
+
+        const a = new Client("A");
+        const b = new Client("B");
+        await Promise.all([a.open(), b.open()]);
+
+        await login(a);
+        await login(b);
+        await enterMultiLobby(a);
+        await enterMultiLobby(b);
+        console.log("[OK] A and B in multi lobby");
+
+        // A creates a 4-player game (room for B + two more).
+        a.sendData("lobby", "cmpt", "RejoinTest", "-", 0, 4, 1, 0, 10, 60, 0, 1, 0, 0);
+        const addLine = await b.waitFor(
+            (s) => /^d \d+ lobby\tgamelist\tadd/.test(s),
+            "B sees gamelist add",
+        );
+        const gameId = parseInt(addLine.split("\t")[3] ?? "0", 10);
+        await a.waitFor((s) => /^d \d+ status\tgame/.test(s), "A status game");
+        const aOwn = await a.waitFor((s) => /game\towninfo/.test(s), "A owninfo");
+        if (ownInfoSlot(aOwn) !== 0) {
+            throw new Error(`A's slot id should be 0, got ${ownInfoSlot(aOwn)}`);
+        }
+        console.log("[OK] A created game id", gameId, "and got slot 0");
+
+        // B joins → A receives ONE join broadcast for B at slot 1, B receives owninfo 1.
+        b.sendData("lobby", "jmpt", String(gameId));
+        await b.waitFor((s) => /^d \d+ status\tgame/.test(s), "B status game");
+        const bOwn = await b.waitFor((s) => /game\towninfo/.test(s), "B owninfo");
+        if (ownInfoSlot(bOwn) !== 1) {
+            throw new Error(`B's slot id should be 1, got ${ownInfoSlot(bOwn)}`);
+        }
+        await b.settle();
+        const aJoinB = a.drain((s) => /game\tjoin\t/.test(s));
+        if (aJoinB.length !== 1) {
+            throw new Error(`A should see exactly 1 join broadcast for B, got ${aJoinB.length}: ${JSON.stringify(aJoinB)}`);
+        }
+        if (joinSlot(aJoinB[0]) !== 1) {
+            throw new Error(`A's join broadcast for B should target slot 1, got ${joinSlot(aJoinB[0])}`);
+        }
+        console.log("[OK] B joined at slot 1 with a single broadcast");
+
+        // B leaves the game (back to multi lobby). A must see `game part 1 4`.
+        b.sendData("game", "back");
+        await a.waitFor((s) => /game\tpart\t1\t4/.test(s), "A sees B part");
+        await b.waitFor((s) => /^d \d+ status\tlobby\tx/.test(s), "B back in lobby");
+        console.log("[OK] B left, A saw part for slot 1");
+
+        // C joins (a fresh client) and MUST take slot 1 (B's old slot) — not 2.
+        const c = new Client("C");
+        await c.open();
+        await login(c);
+        await enterMultiLobby(c);
+        c.sendData("lobby", "jmpt", String(gameId));
+        await c.waitFor((s) => /^d \d+ status\tgame/.test(s), "C status game");
+        const cOwn = await c.waitFor((s) => /game\towninfo/.test(s), "C owninfo");
+        if (ownInfoSlot(cOwn) !== 1) {
+            throw new Error(`C should reuse B's freed slot 1, got ${ownInfoSlot(cOwn)} — sparse-id regression`);
+        }
+        await c.settle();
+        const aJoinC = a.drain((s) => /game\tjoin\t/.test(s));
+        if (aJoinC.length !== 1) {
+            throw new Error(`A should see exactly 1 join broadcast for C, got ${aJoinC.length}: ${JSON.stringify(aJoinC)}`);
+        }
+        if (joinSlot(aJoinC[0]) !== 1) {
+            throw new Error(`A's join broadcast for C should target slot 1, got ${joinSlot(aJoinC[0])}`);
+        }
+        console.log("[OK] C reclaimed slot 1 with a single broadcast (no scoreboard bloat)");
+
+        // B rejoins — they should be assigned slot 2 (next free), again single broadcast.
+        b.sendData("lobby", "jmpt", String(gameId));
+        await b.waitFor((s) => /^d \d+ status\tgame/.test(s), "B status game (rejoin)");
+        const bRejoinOwn = await b.waitFor((s) => /game\towninfo/.test(s), "B owninfo (rejoin)");
+        if (ownInfoSlot(bRejoinOwn) !== 2) {
+            throw new Error(`B's rejoin slot should be 2, got ${ownInfoSlot(bRejoinOwn)}`);
+        }
+        await c.settle();
+        const cJoinB = c.drain((s) => /game\tjoin\t/.test(s));
+        if (cJoinB.length !== 1) {
+            throw new Error(`C should see exactly 1 join broadcast for B's rejoin, got ${cJoinB.length}: ${JSON.stringify(cJoinB)}`);
+        }
+        if (joinSlot(cJoinB[0]) !== 2) {
+            throw new Error(`C's join broadcast for B should target slot 2, got ${joinSlot(cJoinB[0])}`);
+        }
+        console.log("[OK] B rejoined at slot 2 with a single broadcast");
+
+        a.close();
+        b.close();
+        c.close();
+        console.log("\nALL MULTI-REJOIN PHASES PASSED");
+        process.exit(0);
+    } catch (err) {
+        console.error("FAIL:", err);
+        process.exit(1);
+    } finally {
+        if (server) {
+            try { await server.close(); } catch { /* */ }
+        }
+    }
+}
+
+main();

--- a/port/web/public/style.css
+++ b/port/web/public/style.css
@@ -496,3 +496,104 @@ button.btn-blue   { background: #9090e0; border-color: #9090e0; }
   color: #444;
   text-align: center;
 }
+
+/* Valikko button — visual pressed state mirrors a sunken Win98 toolbar
+ * toggle. `is-active` is added while the popover is open so the button
+ * shows it's the source of the current menu. */
+.panel-game .btn-yellow.is-active {
+  background: #c8a020;
+  box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.4);
+  transform: translateY(1px);
+}
+
+/* -----------------------------------------------------------------------
+ * Win98/XP-style range input. Used by the in-game Valikko's volume slider.
+ * The track is a thin sunken groove; the thumb is a tall narrow gray
+ * rectangle with a 3D raised border and three horizontal grip lines on its
+ * face. Cross-browser styling needs separate -webkit and -moz pseudo-element
+ * blocks because each engine ships its own slider primitives.
+ * --------------------------------------------------------------------- */
+input[type="range"].win98-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  height: 18px;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+input[type="range"].win98-slider:focus {
+  outline: none;
+}
+
+/* WebKit / Blink */
+input[type="range"].win98-slider::-webkit-slider-runnable-track {
+  height: 4px;
+  background: #c0c0c0;
+  /* Inset 3D groove: dark on top/left, light on bottom/right. */
+  border-top: 1px solid #808080;
+  border-left: 1px solid #808080;
+  border-right: 1px solid #ffffff;
+  border-bottom: 1px solid #ffffff;
+  box-shadow: inset 1px 1px 0 #404040;
+}
+
+input[type="range"].win98-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 10px;
+  height: 18px;
+  margin-top: -8px; /* center thumb on the 4px track */
+  background-color: #c0c0c0;
+  /* Three horizontal grip lines (#808080) at y=6/8/10 within the 18px-tall
+   * thumb, rendered with stacked linear-gradients so we don't need a sprite. */
+  background-image:
+    linear-gradient(#808080, #808080),
+    linear-gradient(#808080, #808080),
+    linear-gradient(#808080, #808080);
+  background-size: 6px 1px, 6px 1px, 6px 1px;
+  background-position: 2px 6px, 2px 9px, 2px 12px;
+  background-repeat: no-repeat;
+  /* Raised 3D bevel: white top/left, dark gray bottom/right. */
+  border-top: 1px solid #ffffff;
+  border-left: 1px solid #ffffff;
+  border-right: 1px solid #404040;
+  border-bottom: 1px solid #404040;
+  box-shadow: inset -1px -1px 0 #808080;
+  border-radius: 0;
+}
+
+input[type="range"].win98-slider::-webkit-slider-thumb:active {
+  background-color: #b0b0b0;
+}
+
+/* Firefox */
+input[type="range"].win98-slider::-moz-range-track {
+  height: 4px;
+  background: #c0c0c0;
+  border-top: 1px solid #808080;
+  border-left: 1px solid #808080;
+  border-right: 1px solid #ffffff;
+  border-bottom: 1px solid #ffffff;
+  box-shadow: inset 1px 1px 0 #404040;
+}
+
+input[type="range"].win98-slider::-moz-range-thumb {
+  width: 10px;
+  height: 18px;
+  background-color: #c0c0c0;
+  background-image:
+    linear-gradient(#808080, #808080),
+    linear-gradient(#808080, #808080),
+    linear-gradient(#808080, #808080);
+  background-size: 6px 1px, 6px 1px, 6px 1px;
+  background-position: 2px 6px, 2px 9px, 2px 12px;
+  background-repeat: no-repeat;
+  border-top: 1px solid #ffffff;
+  border-left: 1px solid #ffffff;
+  border-right: 1px solid #404040;
+  border-bottom: 1px solid #404040;
+  box-shadow: inset -1px -1px 0 #808080;
+  border-radius: 0;
+}

--- a/port/web/src/game/render.ts
+++ b/port/web/src/game/render.ts
@@ -62,6 +62,26 @@ const PEER_AIM_COLOURS = [
 ];
 
 /**
+ * Solid hex colour matched to the ball palette, used by the scoreboard nick
+ * span so each player's name visibly matches their ball+cursor on the canvas.
+ * Slot 0's "white" maps to a mid grey for readability against the panel
+ * background — pure white text would be invisible. Indexed by `playerIdx % 4`.
+ */
+const SLOT_NICK_COLOURS = [
+  "#5a5a5a", // 0 — neutral grey (white ball reads as a colourless circle)
+  "#b32020", // 1 — red
+  "#2050cc", // 2 — blue
+  "#a07000", // 3 — gold (yellow tones don't read well on the off-white scoreboard)
+];
+
+/** Public lookup for the scoreboard / chat / overlays. Cycles past slot 3 like
+ *  the ball atlas does, so daily-room high sparse ids still resolve. */
+export function slotNickColor(playerIdx: number): string {
+  const i = ((playerIdx % SLOT_NICK_COLOURS.length) + SLOT_NICK_COLOURS.length) % SLOT_NICK_COLOURS.length;
+  return SLOT_NICK_COLOURS[i];
+}
+
+/**
  * Power-scaled delta from ball to a point at length `power*200/6.5`. Mirrors
  * Java GameCanvas.update():
  *   x2 = ball + power[0] * 200 / 6.5
@@ -119,15 +139,17 @@ export interface BallSprite {
    *   2 = full name beside the ball, outlined, edge-aware horizontal alignment
    *   3 = name + "[clan]" stacked beside the ball; falls back to mode-2 layout
    *       when clan is empty
-   * Java draws self in white and others in black; the port deliberately omits
-   * self entirely (issue #26 spec) since the user already knows which ball is
-   * theirs, so the colour split is moot here and labels just render in a
-   * single readable colour.
+   * Java draws self in white and others in black, both with a green
+   * (rgb(19,167,19) — the panel background) 1px orthogonal outline; the port
+   * matches that exactly so labels look identical to the original.
    */
   nameDisplay?: {
     mode: 1 | 2 | 3;
     name: string;
     clan?: string;
+    /** True if this is the local player's ball — flips the fill colour from
+     *  black (other players, Java GameCanvas:116) to white (self, GameCanvas:125). */
+    isSelf: boolean;
   };
   /**
    * Death/sink animation. Mirrors Java GameCanvas.drawPlayer's `shrinkAmount`
@@ -445,12 +467,19 @@ export class TrackRenderer {
     });
     for (const b of balls) {
       if (b.hidden) continue;
-      // balls.gif: 8 sprites total, 4 per row → playerIdx*2 + (moving?1:0).
-      // Daily rooms can hold 100 players (vs the 4-player Java cap), so cycle
-      // colours past index 3 — without the modulo the sprite source falls
-      // outside the atlas and the ball renders as nothing.
+      // balls.gif layout (matches Java's `ballSprites[playerid + offset]` at
+      // GameCanvas.java:1753 / 1789):
+      //   row 0 (idx 0..3): players 0..3 frame A (idle)
+      //   row 1 (idx 4..7): players 0..3 frame B (Java's dithered alternate
+      //                      driven by `(x/5 + y/5) % 2 * 4`)
+      // The previous `colour * 2 + moving` formula assumed each player's two
+      // frames were horizontally adjacent (cols 2k, 2k+1) — they aren't, which
+      // made slot 1 render as P2's sprite, slot 2 as P0 frame B, and slot 3 as
+      // P2 frame B. End result: only two distinct ball colours visible across
+      // four players. Daily rooms can hold 100 players (vs Java's 4-cap), so
+      // cycle colours past index 3 to stay in-atlas.
       const colour = ((b.playerIdx % 4) + 4) % 4;
-      const idx = colour * 2 + (b.moving ? 1 : 0);
+      const idx = (b.moving ? 4 : 0) + colour;
       const { sx, sy } = spriteSrc13(idx, 4);
       const baseDx = Math.round(b.x - 6.5);
       const baseDy = Math.round(b.y - 6.5);
@@ -480,27 +509,38 @@ export class TrackRenderer {
         ctx.drawImage(this.atlases.balls, sx, sy, 13, 13, dx, dy, size, size);
         const nd = b.nameDisplay;
         if (nd) {
-          // Java GameCanvas.drawPlayer:1754. The Java client uses
-          // backgroundColour (rgb(19,167,19)) as the outline colour, but that
-          // bright green doesn't read well across all tiles when labels render
-          // continuously (Java only drew them during simulation). Use a dark
-          // semi-transparent outline instead — matches the daily-mode ghost
-          // label treatment a few lines up.
+          // Java GameCanvas.drawPlayer:1754. Outline = panel background green
+          // rgb(19,167,19) (Java's `backgroundColour`); fill = white for self,
+          // black for others (set in GameCanvas:116/125 before drawPlayer is
+          // called, then preserved by StringDraw.drawOutlinedString).
           ctx.save();
           ctx.font = '10px "Dialog", Verdana, sans-serif';
           ctx.textBaseline = "alphabetic";
+          const fillColour = nd.isSelf ? "#fff" : "#000";
           if (nd.mode === 1) {
-            // Initial: centered above ball, no outline (matches Java's
-            // drawString call which has no outline).
+            // Initial: centered above ball, NO outline (Java calls plain
+            // drawString here, not drawOutlinedString).
             const initial = nd.name.charAt(0);
             ctx.textAlign = "center";
-            ctx.fillStyle = "#000";
+            ctx.fillStyle = fillColour;
             ctx.fillText(initial, baseDx + 6, baseDy + 13 - 3);
           } else {
-            ctx.lineWidth = 2;
+            // Java draws the outline by 4 offset fillText copies of the same
+            // string (StringDraw.drawOutlinedString:53-63). Replicating that
+            // pixel-for-pixel in canvas leaves a green halo that's washed out
+            // against the canvas's anti-aliased glyph edges — so use canvas
+            // strokeText instead, which produces a single solid 1.5px outline
+            // that reads clearly while still using Java's exact colour choices
+            // (green outline, white-self / black-others fill).
+            ctx.lineWidth = 1.5;
             ctx.lineJoin = "round";
-            ctx.strokeStyle = "rgba(0,0,0,0.7)";
-            ctx.fillStyle = "#fff";
+            ctx.miterLimit = 2;
+            ctx.strokeStyle = "rgb(19,167,19)";
+            ctx.fillStyle = fillColour;
+            const drawOutlined = (text: string, tx: number, ty: number): void => {
+              ctx.strokeText(text, tx, ty);
+              ctx.fillText(text, tx, ty);
+            };
             const clan =
               nd.mode === 3 && nd.clan && nd.clan.length > 0
                 ? `[${nd.clan}]`
@@ -518,17 +558,13 @@ export class TrackRenderer {
                 // Java: alignment flips to RIGHT, textX = x - 2 (text ends at x-2).
                 ctx.textAlign = "right";
                 const tx = baseDx - 2;
-                ctx.strokeText(nd.name, tx, yName);
-                ctx.fillText(nd.name, tx, yName);
-                ctx.strokeText(clan, tx, yClan);
-                ctx.fillText(clan, tx, yClan);
+                drawOutlined(nd.name, tx, yName);
+                drawOutlined(clan, tx, yClan);
               } else {
                 ctx.textAlign = "left";
                 const tx = baseDx + 13 + 2;
-                ctx.strokeText(nd.name, tx, yName);
-                ctx.fillText(nd.name, tx, yName);
-                ctx.strokeText(clan, tx, yClan);
-                ctx.fillText(clan, tx, yClan);
+                drawOutlined(nd.name, tx, yName);
+                drawOutlined(clan, tx, yClan);
               }
             } else {
               // Mode 2 (or mode 3 with no clan): single name line beside ball.
@@ -539,8 +575,7 @@ export class TrackRenderer {
               const tx = overflow
                 ? baseDx - 2 - nameWidth
                 : baseDx + 13 + 2;
-              ctx.strokeText(nd.name, tx, yLine);
-              ctx.fillText(nd.name, tx, yLine);
+              drawOutlined(nd.name, tx, yLine);
             }
           }
           ctx.restore();

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -3,7 +3,7 @@ import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
 import { loadAtlases, type Atlases } from "../game/sprites.ts";
 import { buildMap, type ParsedMap } from "../game/map.ts";
-import { TrackRenderer, type AimLine, type BallSprite, type PeerAim } from "../game/render.ts";
+import { TrackRenderer, slotNickColor, type AimLine, type BallSprite, type PeerAim } from "../game/render.ts";
 import {
   applyStrokeImpulse,
   newBall,
@@ -51,6 +51,64 @@ function extractField(fields: string[], prefix: string): string | null {
     if (f.startsWith(prefix)) return f.substring(prefix.length);
   }
   return null;
+}
+
+/**
+ * Wire convention: server sends `"-"` to mean "no clan" (Player.clan defaults
+ * to "-" on the Java side). Java's GamePanel.java:187,194 maps that sentinel
+ * to null before storing it; we collapse it to the empty string so the
+ * existing `clan && clan.length > 0` checks across render and scoreboard skip
+ * the `[clan]` row instead of rendering a literal `[-]`.
+ */
+function normalizeClan(raw: string | undefined): string {
+  if (!raw || raw === "-") return "";
+  return raw;
+}
+
+/**
+ * Per-user game-panel preferences, persisted across sessions in localStorage.
+ * Exposed through the in-game "Valikko" button so the player can toggle
+ * cosmetic + bandwidth knobs without leaving the match. Volume lives on the
+ * audio singleton (which has its own persistence key); the rest live here.
+ */
+interface GameSettings {
+  /** Render in-game name labels above other players' balls. */
+  showNames: boolean;
+  /** Broadcast my cursor at ~15 Hz so peers see my live aim line. */
+  sendCursor: boolean;
+  /** Render peers' aim lines from their broadcast cursor positions. */
+  showPeerCursors: boolean;
+}
+
+const SETTINGS_KEY = "minigolf.game.settings";
+const DEFAULT_SETTINGS: GameSettings = {
+  showNames: true,
+  sendCursor: true,
+  showPeerCursors: true,
+};
+
+function loadSettings(): GameSettings {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return { ...DEFAULT_SETTINGS };
+    const parsed = JSON.parse(raw);
+    return {
+      showNames: typeof parsed.showNames === "boolean" ? parsed.showNames : DEFAULT_SETTINGS.showNames,
+      sendCursor: typeof parsed.sendCursor === "boolean" ? parsed.sendCursor : DEFAULT_SETTINGS.sendCursor,
+      showPeerCursors:
+        typeof parsed.showPeerCursors === "boolean" ? parsed.showPeerCursors : DEFAULT_SETTINGS.showPeerCursors,
+    };
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+function saveSettings(s: GameSettings): void {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
+  } catch {
+    // localStorage unavailable (private mode, quota) — accept the loss.
+  }
 }
 
 interface TrackInfoLine {
@@ -200,6 +258,11 @@ export class GamePanel implements Panel {
   private mouseMoveHandler: ((ev: MouseEvent) => void) | null = null;
   private clickHandler: ((ev: MouseEvent) => void) | null = null;
   private contextMenuHandler: ((ev: MouseEvent) => void) | null = null;
+  /** Toggleable user prefs (names, cursor send/recv) — persisted via localStorage. */
+  private settings: GameSettings = loadSettings();
+  private settingsMenuEl: HTMLElement | null = null;
+  private menuButtonEl: HTMLButtonElement | null = null;
+  private menuOutsideClickHandler: ((ev: MouseEvent) => void) | null = null;
 
   /**
    * Daily-mode state. Set when the server sends `game dailymode <dateKey>`.
@@ -305,32 +368,31 @@ export class GamePanel implements Panel {
     right.appendChild(avgPar);
     right.appendChild(bestPar);
 
-    // Master volume slider — drives audio.masterGain. Lives in the right
-    // column so it shares trackinfo's vertical budget rather than carving a
-    // new row out of the already-tight bottom band.
-    const volRow = document.createElement("div");
-    volRow.style.display = "flex";
-    volRow.style.alignItems = "center";
-    volRow.style.gap = "4px";
-    volRow.style.justifyContent = "flex-end";
-    volRow.style.marginTop = "2px";
-    const volLabel = document.createElement("span");
-    volLabel.textContent = t("Port_Game_Volume", "Volume");
-    volLabel.style.fontSize = "10px";
-    const volSlider = document.createElement("input");
-    volSlider.type = "range";
-    volSlider.min = "0";
-    volSlider.max = "100";
-    volSlider.step = "1";
-    volSlider.value = String(Math.round(audio.volume * 100));
-    volSlider.style.width = "90px";
-    volSlider.title = t("Port_Game_VolumeTitle", "Master volume");
-    volSlider.addEventListener("input", () => {
-      audio.setVolume(volSlider.valueAsNumber / 100);
+    // "Valikko" — opens a popover with name/cursor toggles, volume slider,
+    // and quit. Replaces the bottom-strip volume row from earlier so this
+    // tight band only carries one control. Also opened via ESC.
+    const menuRow = document.createElement("div");
+    menuRow.style.display = "flex";
+    menuRow.style.alignItems = "center";
+    menuRow.style.justifyContent = "flex-end";
+    menuRow.style.marginTop = "2px";
+    menuRow.style.position = "relative";
+    const menuBtn = document.createElement("button");
+    menuBtn.type = "button";
+    menuBtn.className = "btn-yellow";
+    menuBtn.textContent = t("Port_Game_Menu", "Menu");
+    menuBtn.style.padding = "1px 12px";
+    menuBtn.style.minHeight = "auto";
+    menuBtn.style.fontSize = "11px";
+    menuBtn.setAttribute("aria-haspopup", "true");
+    menuBtn.setAttribute("aria-pressed", "false");
+    menuBtn.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      this.toggleSettingsMenu();
     });
-    volRow.appendChild(volLabel);
-    volRow.appendChild(volSlider);
-    right.appendChild(volRow);
+    menuRow.appendChild(menuBtn);
+    right.appendChild(menuRow);
+    this.menuButtonEl = menuBtn;
 
     trackinfo.appendChild(left);
     trackinfo.appendChild(center);
@@ -362,8 +424,12 @@ export class GamePanel implements Panel {
 
     const keyHandler = (ev: KeyboardEvent) => {
       if (ev.key === "Escape") {
+        // Avoid swallowing ESC while a chat input/textarea has focus — the
+        // user is probably trying to clear a draft, not pop the menu.
+        const focused = ev.target as HTMLElement | null;
+        if (focused && (focused.tagName === "INPUT" || focused.tagName === "TEXTAREA")) return;
         ev.preventDefault();
-        this.quit();
+        this.toggleSettingsMenu();
       }
     };
     window.addEventListener("keydown", keyHandler);
@@ -443,6 +509,8 @@ export class GamePanel implements Panel {
   unmount(): void {
     if (this.rafHandle) cancelAnimationFrame(this.rafHandle);
     this.rafHandle = 0;
+    this.closeSettingsMenu();
+    this.menuButtonEl = null;
     if (this.keyHandler) window.removeEventListener("keydown", this.keyHandler);
     if (this.canvas) {
       if (this.mouseMoveHandler) this.canvas.removeEventListener("mousemove", this.mouseMoveHandler);
@@ -506,7 +574,7 @@ export class GamePanel implements Panel {
         this.myNick = f[3] ?? "You";
         this.ensurePlayerSlots(this.myPlayerId + 1);
         this.players[this.myPlayerId].nick = this.myNick;
-        this.players[this.myPlayerId].clan = f[4] ?? "";
+        this.players[this.myPlayerId].clan = normalizeClan(f[4]);
         this.scoreboardDirty = true;
         break;
       case "players":
@@ -514,7 +582,7 @@ export class GamePanel implements Panel {
           const id = parseInt(f[i] ?? "0", 10);
           this.ensurePlayerSlots(id + 1);
           this.players[id].nick = f[i + 1] ?? "";
-          this.players[id].clan = f[i + 2] ?? "";
+          this.players[id].clan = normalizeClan(f[i + 2]);
         }
         this.scoreboardDirty = true;
         break;
@@ -522,9 +590,31 @@ export class GamePanel implements Panel {
         {
           const id = (parseInt(f[2] ?? "1", 10) || 1) - 1;
           this.ensurePlayerSlots(id + 1);
-          this.players[id].nick = f[3] ?? "";
-          this.players[id].clan = f[4] ?? "";
-          this.appendChat("* " + t("Chat_Game_PlayerJoined", "%1 joined the game", this.players[id].nick), "system");
+          // Slot may have been left inactive by an earlier `part`. Reset
+          // every per-player field a previous occupant could have dirtied
+          // before populating the new identity — otherwise the joiner
+          // inherits stale `active=false`, prior strokes, holed/forfeit
+          // flags, ball position, hole-score history, etc. The spawn falls
+          // back to `slot.startX/Y` which is the panel default for fresh
+          // slots; this is correct because today MultiGame join is gated
+          // pre-start (game.ts:887-889 removes started games from the
+          // lobby gamelist), so `slot.startX/Y` hasn't been re-pointed at a
+          // previous occupant's per-track spawn yet.
+          const slot = this.players[id];
+          slot.nick = f[3] ?? "";
+          slot.clan = normalizeClan(f[4]);
+          slot.active = true;
+          slot.simulating = false;
+          slot.holedThisTrack = false;
+          slot.forfeitedThisTrack = false;
+          slot.strokesThisTrack = 0;
+          slot.holeScores = [];
+          slot.ball = newBall(slot.startX, slot.startY);
+          slot.ctx = null;
+          slot.cursorX = null;
+          slot.cursorY = null;
+          slot.cursorMode = 0;
+          this.appendChat("* " + t("Chat_Game_PlayerJoined", "%1 joined the game", slot.nick), "system");
           this.scoreboardDirty = true;
         }
         break;
@@ -821,6 +911,7 @@ export class GamePanel implements Panel {
    */
   private maybeSendCursor(nowMs: number): void {
     if (!this.app.connection.isOpen) return;
+    if (!this.settings.sendCursor) return;
     const me = this.players[this.myPlayerId];
     if (!me) return;
     if (me.simulating || me.ball.inHole || me.holedThisTrack || me.forfeitedThisTrack) return;
@@ -984,6 +1075,9 @@ export class GamePanel implements Panel {
       num.textContent = `${i + 1}.`;
       const name = document.createElement("span");
       name.textContent = p.nick || t("Port_Game_PlayerFmt", "Player %1", i + 1);
+      // Match the ball+cursor palette — same `playerIdx` used by render.ts.
+      // The inline style overrides `.row.you` / `.row.them` colour rules.
+      name.style.color = slotNickColor(i);
       const tracksCol = document.createElement("span");
       const cells: string[] = [];
       let totalSoFar = 0;
@@ -1163,16 +1257,16 @@ export class GamePanel implements Panel {
       // Daily mode: render every other player as a translucent ghost with a
       // name label above. Self renders normally.
       const ghost = this.dailyMode && !isMine;
-      // Multiplayer name labels (issue #26). Mirrors Java GameCanvas
-      // playerNamesDisplayMode default (`playerCount <= 2 ? 0 : 3`): off in
-      // 1- and 2-player games, name+clan otherwise. Self is intentionally
-      // skipped — the user already knows which ball is theirs and Java's
-      // white-self / black-other colour split is moot in the port's continuous
-      // render model where every ball is potentially "current". Ghosts
-      // short-circuit since they already render their own centered label.
+      // Multiplayer name labels — match Java GameCanvas.drawPlayer:1754
+      // (white-self / black-others, green outline). Java's
+      // `playerNamesDisplayMode` defaults to `playerCount <= 2 ? 0 : 3`, so
+      // labels only appear in 3+ player games (the AI / 2-player matches
+      // showed nothing). The Valikko toggle still lets the user hide them
+      // in larger games. Ghosts short-circuit since they already render
+      // their own centered label.
       const showName =
         !ghost &&
-        !isMine &&
+        this.settings.showNames &&
         this.numPlayers >= 3 &&
         p.active &&
         !p.holedThisTrack &&
@@ -1196,7 +1290,7 @@ export class GamePanel implements Panel {
         ghost,
         label: ghost ? (p.nick || `Player ${i + 1}`) : undefined,
         nameDisplay: showName
-          ? { mode: 3, name: p.nick, clan: p.clan }
+          ? { mode: 3, name: p.nick, clan: p.clan, isSelf: isMine }
           : undefined,
         shrink: isSinking ? p.ball.liquidTimer : 0,
       });
@@ -1206,6 +1300,7 @@ export class GamePanel implements Panel {
       // daily mode: the ghost rendering treats other players as non-interactive
       // shadows of past plays; live aim lines would clash with that framing.
       if (
+        this.settings.showPeerCursors &&
         !isMine &&
         !ghost &&
         !p.ball.inHole &&
@@ -1497,6 +1592,170 @@ export class GamePanel implements Panel {
 
   private quit(): void {
     this.app.connection.sendData("game", "back");
+  }
+
+  /** Toggle the in-game settings menu. Closes if already open. */
+  private toggleSettingsMenu(): void {
+    if (this.settingsMenuEl) {
+      this.closeSettingsMenu();
+    } else {
+      this.openSettingsMenu();
+    }
+  }
+
+  private closeSettingsMenu(): void {
+    if (this.settingsMenuEl) {
+      this.settingsMenuEl.remove();
+      this.settingsMenuEl = null;
+    }
+    if (this.menuOutsideClickHandler) {
+      document.removeEventListener("click", this.menuOutsideClickHandler, true);
+      this.menuOutsideClickHandler = null;
+    }
+    if (this.menuButtonEl) {
+      this.menuButtonEl.classList.remove("is-active");
+      this.menuButtonEl.setAttribute("aria-pressed", "false");
+    }
+  }
+
+  private openSettingsMenu(): void {
+    const anchor = this.menuButtonEl;
+    if (!anchor) return;
+    const parent = anchor.parentElement;
+    if (!parent) return;
+
+    const menu = document.createElement("div");
+    menu.className = "game-settings-menu";
+    // Anchor above the button: parent is `position: relative`, so absolute
+    // bottom positioning floats the popover up from the bottom strip.
+    menu.style.position = "absolute";
+    menu.style.right = "0";
+    menu.style.bottom = `${anchor.offsetHeight + 4}px`;
+    menu.style.minWidth = "210px";
+    menu.style.padding = "6px 8px";
+    menu.style.background = "#fff";
+    menu.style.border = "1px solid #555";
+    menu.style.borderRadius = "3px";
+    menu.style.boxShadow = "0 2px 6px rgba(0,0,0,0.25)";
+    menu.style.fontSize = "11px";
+    menu.style.fontFamily = '"Dialog", Verdana, sans-serif';
+    menu.style.color = "#000";
+    menu.style.zIndex = "20";
+    // Block clicks inside the menu from bubbling to the outside-click handler.
+    menu.addEventListener("click", (ev) => ev.stopPropagation());
+
+    const addCheckbox = (
+      label: string,
+      checked: boolean,
+      onChange: (next: boolean) => void,
+    ): void => {
+      const row = document.createElement("label");
+      row.style.display = "flex";
+      row.style.alignItems = "center";
+      row.style.gap = "6px";
+      row.style.padding = "2px 0";
+      row.style.cursor = "pointer";
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.checked = checked;
+      cb.style.margin = "0";
+      cb.addEventListener("change", () => onChange(cb.checked));
+      const text = document.createElement("span");
+      text.textContent = label;
+      row.appendChild(cb);
+      row.appendChild(text);
+      menu.appendChild(row);
+    };
+
+    addCheckbox(
+      t("Port_Game_Menu_ShowNames", "Show player names"),
+      this.settings.showNames,
+      (v) => {
+        this.settings.showNames = v;
+        saveSettings(this.settings);
+      },
+    );
+    addCheckbox(
+      t("Port_Game_Menu_SendCursor", "Share my aim with others"),
+      this.settings.sendCursor,
+      (v) => {
+        this.settings.sendCursor = v;
+        saveSettings(this.settings);
+      },
+    );
+    addCheckbox(
+      t("Port_Game_Menu_ShowPeerCursors", "Show others' aim lines"),
+      this.settings.showPeerCursors,
+      (v) => {
+        this.settings.showPeerCursors = v;
+        saveSettings(this.settings);
+      },
+    );
+
+    // Volume slider — moved here from the bottom strip.
+    const volRow = document.createElement("div");
+    volRow.style.display = "flex";
+    volRow.style.alignItems = "center";
+    volRow.style.gap = "6px";
+    volRow.style.padding = "4px 0 2px";
+    volRow.style.borderTop = "1px solid #ddd";
+    volRow.style.marginTop = "4px";
+    const volLabel = document.createElement("span");
+    volLabel.textContent = t("Port_Game_Volume", "Volume");
+    const volSlider = document.createElement("input");
+    volSlider.type = "range";
+    volSlider.className = "win98-slider";
+    volSlider.min = "0";
+    volSlider.max = "100";
+    volSlider.step = "1";
+    volSlider.value = String(Math.round(audio.volume * 100));
+    volSlider.style.flex = "1";
+    volSlider.title = t("Port_Game_VolumeTitle", "Master volume");
+    volSlider.addEventListener("input", () => {
+      audio.setVolume(volSlider.valueAsNumber / 100);
+    });
+    volRow.appendChild(volLabel);
+    volRow.appendChild(volSlider);
+    menu.appendChild(volRow);
+
+    // Quit button — pull-up of the bottom-strip ESC behaviour.
+    const quitBtn = document.createElement("button");
+    quitBtn.type = "button";
+    quitBtn.className = "btn-red";
+    quitBtn.textContent = t("Tournament_QuitGameButton", "Quit game");
+    quitBtn.style.marginTop = "6px";
+    quitBtn.style.width = "100%";
+    quitBtn.style.padding = "2px 8px";
+    quitBtn.style.minHeight = "auto";
+    quitBtn.style.fontSize = "11px";
+    quitBtn.addEventListener("click", () => {
+      this.closeSettingsMenu();
+      this.quit();
+    });
+    menu.appendChild(quitBtn);
+
+    parent.appendChild(menu);
+    this.settingsMenuEl = menu;
+    anchor.classList.add("is-active");
+    anchor.setAttribute("aria-pressed", "true");
+
+    // Close on click anywhere outside the popover. Capture phase so we see
+    // it before any panel handler can swallow the event.
+    const onOutside = (ev: MouseEvent): void => {
+      const target = ev.target as Node | null;
+      if (!target) return;
+      if (menu.contains(target)) return;
+      if (anchor.contains(target)) return;
+      this.closeSettingsMenu();
+    };
+    this.menuOutsideClickHandler = onOutside;
+    // Defer registration so the click that opened the menu doesn't immediately
+    // close it.
+    setTimeout(() => {
+      if (this.menuOutsideClickHandler === onOutside) {
+        document.addEventListener("click", onOutside, true);
+      }
+    }, 0);
   }
 
   /** Give up on the current hole — server caps strokes & marks DNF. */


### PR DESCRIPTION
Server (game.ts): MultiGame now overrides addPlayer to find the lowest free slot id and broadcast `game join` exactly once with that id. Removes the previous double-broadcast (`playerCount()+1` + sendJoinMessages' `numberIndex+1`) whose ordinals diverged after any prior leave, which had been creating duplicate scoreboard rows on rejoin and overwriting unrelated active slots once the room saw a few cycles. Slot ids stay dense within numPlayers so a leaver's slot is reclaimed by the next joiner. Daily-room sparse-id semantics are untouched.

Client (panels/game.ts): full slot reset on `case "join"` so a reused slot doesn't inherit the previous occupant's stale active/strokes/holed state. Empty-clan `"-"` sentinel collapses to `""` at packet ingress, matching Java GamePanel.java:187,194 — fixes the `[-]` line under unclanned nicks.

Render (render.ts): ball atlas indexing now uses
`(moving ? 4 : 0) + colour` to match Java's
`ballSprites[playerid + offset]` layout (row-major: idle then dithered alternate). The old `colour*2 + moving` formula assumed each player's two frames were horizontally adjacent, which collapsed four players to two visible colours. In-game name labels now match Java's drawPlayer:1754 exactly: rgb(19,167,19) outline, white-self / black-others fill, rendered via canvas strokeText for browser-friendly readability. Scoreboard nick colours follow the same per-slot palette via new `slotNickColor()` helper.

Valikko menu (panels/game.ts, style.css, l10n/*): replaces the bottom-strip volume row with a "Valikko" / "Menu" toggle button that opens a popover with toggles for player names, share-my-aim, show-others'-aim, plus the volume slider (now styled in Win98/XP look — sunken 4px track, raised gray thumb with grip lines) and a red Quit button reusing Tournament_QuitGameButton. ESC opens / closes the menu (deferred to text inputs so chat drafts aren't clobbered). Toggles persist via localStorage. Translations added to en/fi/sv AGolf.xml.

Regression test: port/server/src/test-multi-rejoin.ts walks A creates → B joins → B leaves → C joins (must take slot 1) → B rejoins (slot 2) and asserts a single broadcast with the dense id at each step.