### PR TITLE
Port: multiplayer practice mode + drop-in for in-progress rooms

### DIFF
--- a/client/src/main/resources/l10n/en/AGolf.xml
+++ b/client/src/main/resources/l10n/en/AGolf.xml
@@ -1290,6 +1290,21 @@
 	<str key="Port_Game_VolumeTitle">
 		<![CDATA[Master volume]]>
 	</str>
+	<str key="Port_Game_Practice">
+		<![CDATA[Practice]]>
+	</str>
+	<str key="Port_Game_PracticeHint">
+		<![CDATA[Play random maps while waiting — multiplayer enabled]]>
+	</str>
+	<str key="Port_Game_PracticeProgress">
+		<![CDATA[Practice]]>
+	</str>
+	<str key="Port_Lobby_InProgress">
+		<![CDATA[(In progress)]]>
+	</str>
+	<str key="Port_Lobby_JoinInProgress">
+		<![CDATA[Drop in]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Ignore selected user]]>
 	</str>

--- a/client/src/main/resources/l10n/fi/AGolf.xml
+++ b/client/src/main/resources/l10n/fi/AGolf.xml
@@ -1290,6 +1290,21 @@
 	<str key="Port_Game_VolumeTitle">
 		<![CDATA[Pää-äänenvoimakkuus]]>
 	</str>
+	<str key="Port_Game_Practice">
+		<![CDATA[Harjoittele]]>
+	</str>
+	<str key="Port_Game_PracticeHint">
+		<![CDATA[Pelaa satunnaisia ratoja odottaessa — moninpelinä]]>
+	</str>
+	<str key="Port_Game_PracticeProgress">
+		<![CDATA[Harjoitus]]>
+	</str>
+	<str key="Port_Lobby_InProgress">
+		<![CDATA[(Käynnissä)]]>
+	</str>
+	<str key="Port_Lobby_JoinInProgress">
+		<![CDATA[Liity peliin]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Mykistä valittu käyttäjä]]>
 	</str>

--- a/client/src/main/resources/l10n/sv/AGolf.xml
+++ b/client/src/main/resources/l10n/sv/AGolf.xml
@@ -1290,6 +1290,21 @@
 	<str key="Port_Game_VolumeTitle">
 		<![CDATA[Huvudvolym]]>
 	</str>
+	<str key="Port_Game_Practice">
+		<![CDATA[Träna]]>
+	</str>
+	<str key="Port_Game_PracticeHint">
+		<![CDATA[Spela slumpmässiga banor under väntan — flerspelarläge]]>
+	</str>
+	<str key="Port_Game_PracticeProgress">
+		<![CDATA[Träning]]>
+	</str>
+	<str key="Port_Lobby_InProgress">
+		<![CDATA[(Pågår)]]>
+	</str>
+	<str key="Port_Lobby_JoinInProgress">
+		<![CDATA[Hoppa in]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Ignorera vald användare]]>
 	</str>

--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -507,7 +507,15 @@ export class GolfGame extends Game {
         this.tracks = this.initTracks();
     }
 
-    /** 15-field game string used in lobby gamelist packets. Mirrors Java GolfGame.getGameString. */
+    /**
+     * 15-field game string used in lobby gamelist packets. Mirrors Java
+     * GolfGame.getGameString.
+     *
+     * Field 5 (formerly the always-`-1` legacy slot) is repurposed as an
+     * "in-progress" flag: `1` once the game has started (`!isPublic`),
+     * `0` while it is still waiting / practicing. Old clients that ignored
+     * the field keep working; new clients use it to badge running rooms.
+     */
     override getGameString(): string {
         return tabularize(
             this.gameId,
@@ -515,7 +523,7 @@ export class GolfGame extends Game {
             this.passworded,
             this.perms,
             this.numPlayers,
-            -1,
+            this.isPublic ? 0 : 1,
             this.tracks.length,
             this.tracksType,
             this.maxStrokes,
@@ -842,8 +850,19 @@ export class TrainingGame extends GolfGame {
  *      `lobby gamelist remove <gameId>` and game broadcasts `game start`.
  *   4. Players left during play continue with each other; the game ends when
  *      all tracks are complete or all players leave.
+ *
+ * Browser-port extension: **practice mode**. While the room is still waiting
+ * for players to fill, anyone in the room can press the Practice button to
+ * start a shared run of random tracks that auto-cycle on each hole-in. Late
+ * joiners drop into the current practice track. When the last player joins,
+ * practice ends and the configured tracks list is played from track 1 — the
+ * existing `startGame()` flow runs untouched.
  */
 export class MultiGame extends GolfGame {
+    /** True between `game practice` request and the real-game `startGame()`. */
+    public practiceActive = false;
+    /** The map currently in play during practice. Replaced on every hole-in. */
+    private practiceTrack: Track | null = null;
     constructor(
         creator: Player,
         gameId: number,
@@ -923,15 +942,223 @@ export class MultiGame extends GolfGame {
             // Update game-list entry (player count changed).
             lobby.writeAll(tabularize("lobby", "gamelist", "change", this.getGameString()));
         }
-        if (this.players.length === this.numPlayers) {
-            // Game just filled — kick it off.
+
+        if (this.isPublic && this.players.length === this.numPlayers) {
+            // Room just filled for the first time — kick the real game off.
+            // `startGame()` clears any active practice state so the configured
+            // track list is what plays. Re-broadcast `gamelist change` so the
+            // inProgress flag flips for everyone in the lobby (the room stays
+            // visible — we no longer drop it from the list on fill so vacated
+            // slots can be refilled later).
             this.isPublic = false;
             if (lobby) {
-                lobby.writeAll(tabularize("lobby", "gamelist", "remove", String(this.gameId)));
+                lobby.writeAll(tabularize("lobby", "gamelist", "change", this.getGameString()));
             }
             this.startGame();
+        } else if (!this.isPublic) {
+            // Game already running — catch the late joiner up to the current
+            // track. `addPlayer` already broadcast `game join` to the rest;
+            // they keep playing untouched.
+            this.sendCurrentTrackTo(player);
+        } else if (this.practiceActive) {
+            // Late joiner during practice — drop them into the current track.
+            this.sendPracticeTrackTo(player);
         }
         return true;
+    }
+
+    /**
+     * Catch-up packet sequence for a player who joined a started game with a
+     * free slot. Walks them through the same `start` / `resetvoteskip` /
+     * `starttrack` trio existing players saw at the start of this track,
+     * stamps `gametrack` so their HUD reads "Track N/M" matching the room,
+     * and replays per-slot `endstroke` packets so peers who already finished
+     * the current track render correctly on the joiner's scoreboard.
+     *
+     * Per-track stroke counts for prior tracks aren't recoverable — the
+     * server doesn't keep per-track history per slot, only the rolling
+     * `playerStrokesTotal`. The joiner's scoreboard renders prior columns
+     * as "—" via the client's `holeScores[t] === undefined` branch.
+     */
+    private sendCurrentTrackTo(player: Player): void {
+        const slotId = this.getPlayerId(player);
+
+        // Pad / overwrite the joiner's slot to fresh.
+        const psArr = this.playStatus.split("");
+        while (psArr.length <= slotId) psArr.push("f");
+        psArr[slotId] = "f";
+        this.playStatus = psArr.join("");
+
+        const track = this.tracks[this.currentTrack];
+        if (!track) return;
+        const stats = this.trackManager.getStats(track);
+        const buff = "f".repeat(this.playStatus.length);
+
+        player.connection.sendDataRaw(tabularize("game", "start"));
+        player.connection.sendDataRaw(tabularize("game", "resetvoteskip"));
+        player.connection.sendDataRaw(
+            tabularize("game", "starttrack", buff, this.gameId, networkSerialize(stats)),
+        );
+        // Tell the joiner which configured track this is so their HUD reads
+        // "Track N/M" matching the room rather than "Track 1/M".
+        player.connection.sendDataRaw(
+            tabularize("game", "gametrack", this.currentTrack + 1),
+        );
+
+        // Replay completion state for peers who already finished this track.
+        for (let i = 0; i < this.playStatus.length; i++) {
+            if (i === slotId) continue;
+            const status = this.playStatus.charAt(i);
+            if (status === "t" || status === "p") {
+                const strokes = this.playerStrokesThisTrack[i] ?? 0;
+                player.connection.sendDataRaw(
+                    tabularize("game", "endstroke", i, strokes, status),
+                );
+            }
+        }
+    }
+
+    /**
+     * Begin (or ignore if already running) shared practice mode. Picks a
+     * random track from the room's configured category and broadcasts a
+     * `game start`/`starttrack` pair to everyone currently in the room. New
+     * joiners get a personal version of the same broadcast via
+     * `sendPracticeTrackTo`. The configured `this.tracks` list is left
+     * untouched — `sendGameInfo`'s `numTracks` and the eventual real-game
+     * track sequence both keep working.
+     *
+     * No-op if the real game has already started (`!this.isPublic`).
+     */
+    startPractice(): void {
+        if (this.practiceActive) return;
+        if (!this.isPublic) return;
+
+        const cat: TrackCategoryId = trackCategoryByTypeId(this.tracksType);
+        const picked = this.trackManager.getRandomTracks(1, cat);
+        if (picked.length === 0) return;
+
+        this.practiceActive = true;
+        this.practiceTrack = picked[0];
+        this.strokeCounter = 0;
+        this.strokeSeedCounter = 0;
+        for (let i = 0; i < this.playerStrokesThisTrack.length; i++) {
+            this.playerStrokesThisTrack[i] = 0;
+            this.playerStrokesTotal[i] = 0;
+        }
+        for (const p of this.players) p.hasSkipped = false;
+
+        const buff = "f".repeat(this.players.length);
+        this.playStatus = buff;
+        const stats = this.trackManager.getStats(this.practiceTrack);
+        this.writeAll(tabularize("game", "start"));
+        this.writeAll(tabularize("game", "resetvoteskip"));
+        this.writeAll(
+            tabularize("game", "starttrack", buff, this.gameId, networkSerialize(stats)),
+        );
+        // Tell clients to render this as practice (HUD shows "Practice", no
+        // per-hole columns). Sent after `starttrack` so the panel has the
+        // track loaded by the time it flips into practice mode.
+        this.writeAll(tabularize("game", "practicemode", "t"));
+        logEvent("practice_start", {
+            game_id: this.gameId,
+            players: this.players.length,
+            track: this.practiceTrack.name,
+        });
+    }
+
+    /**
+     * Drop a single player into the currently-running practice track. Pads
+     * `playStatus` to cover their slot, sends them the same `start` /
+     * `resetvoteskip` / `starttrack` / `practicemode` sequence existing
+     * players already saw, and replays per-slot `endstroke` packets so any
+     * peers who already finished the current track render correctly on the
+     * joiner's scoreboard.
+     */
+    private sendPracticeTrackTo(player: Player): void {
+        if (!this.practiceTrack) return;
+
+        const slotId = this.getPlayerId(player);
+        const psArr = this.playStatus.split("");
+        while (psArr.length <= slotId) psArr.push("f");
+        // Joiner is fresh on the current track regardless of what was there.
+        psArr[slotId] = "f";
+        this.playStatus = psArr.join("");
+
+        const buff = "f".repeat(this.playStatus.length);
+        const stats = this.trackManager.getStats(this.practiceTrack);
+        player.connection.sendDataRaw(tabularize("game", "start"));
+        player.connection.sendDataRaw(tabularize("game", "resetvoteskip"));
+        player.connection.sendDataRaw(
+            tabularize("game", "starttrack", buff, this.gameId, networkSerialize(stats)),
+        );
+        player.connection.sendDataRaw(tabularize("game", "practicemode", "t"));
+
+        // Replay completion state for peers who already finished this track.
+        for (let i = 0; i < this.playStatus.length; i++) {
+            if (i === slotId) continue;
+            const status = this.playStatus.charAt(i);
+            if (status === "t" || status === "p") {
+                const strokes = this.playerStrokesThisTrack[i] ?? 0;
+                player.connection.sendDataRaw(
+                    tabularize("game", "endstroke", i, strokes, status),
+                );
+            }
+        }
+    }
+
+    /** During practice each hole-in / forfeit-all advances to a fresh random
+     *  track instead of walking through `this.tracks`. */
+    protected override nextTrack(): void {
+        if (!this.practiceActive) {
+            super.nextTrack();
+            return;
+        }
+        const cat: TrackCategoryId = trackCategoryByTypeId(this.tracksType);
+        const picked = this.trackManager.getRandomTracks(1, cat);
+        if (picked.length === 0) return;
+        this.practiceTrack = picked[0];
+        this.strokeCounter = 0;
+        this.strokeSeedCounter = 0;
+        for (let i = 0; i < this.players.length; i++) {
+            const slot = this.playersNumber[i];
+            this.playerStrokesThisTrack[slot] = 0;
+            this.players[i].hasSkipped = false;
+        }
+        const buff = "f".repeat(this.playStatus.length);
+        this.playStatus = buff;
+        const stats = this.trackManager.getStats(this.practiceTrack);
+        this.writeAll(tabularize("game", "resetvoteskip"));
+        this.writeAll(
+            tabularize("game", "starttrack", buff, this.gameId, networkSerialize(stats)),
+        );
+    }
+
+    /** Real-game start. Wipes any practice residue (track ref + per-player
+     *  stroke counters incremented during practice) before delegating to the
+     *  base `GolfGame.startGame`. The base broadcasts `game start`, which the
+     *  client uses to drop back into normal-mode rendering. */
+    override startGame(): void {
+        if (this.practiceActive) {
+            this.practiceActive = false;
+            this.practiceTrack = null;
+            for (let i = 0; i < this.playerStrokesThisTrack.length; i++) {
+                this.playerStrokesThisTrack[i] = 0;
+                this.playerStrokesTotal[i] = 0;
+            }
+            this.strokeCounter = 0;
+        }
+        super.startGame();
+    }
+
+    /** Inject the `practice` verb before falling through to the standard
+     *  GolfGame handler. Practice can only start while the room is still
+     *  open (`isPublic`) — the request is ignored otherwise. */
+    override handlePacket(player: Player, fields: string[]): boolean {
+        if (fields.length >= 2 && fields[1] === "practice") {
+            this.startPractice();
+            return true;
+        }
+        return super.handlePacket(player, fields);
     }
 
     /**
@@ -1002,24 +1229,56 @@ export class MultiGame extends GolfGame {
     override removePlayer(player: Player, reason: number = PartReason.USERLEFT): boolean {
         if (!this.players.includes(player)) return false;
         const wasPublic = this.isPublic;
+        const wasPracticing = this.practiceActive;
         const playerNum = this.getPlayerId(player);
         super.removePlayer(player, reason);
+
+        if (this.playStatus.length > playerNum) {
+            // Don't let the leaver's `'f'` slot trap survivors waiting on a
+            // ball that's never going to roll. Stamp the slot 'p' (passed)
+            // so `allDoneOnCurrentTrack` sees only still-present players
+            // as needing to finish; advance the track if they all did.
+            // Applies to both practice and real games — a vacated slot
+            // should never block progression for whoever's still here.
+            const cur = this.playStatus.charAt(playerNum);
+            if (cur === "f") {
+                const psArr = this.playStatus.split("");
+                psArr[playerNum] = "p";
+                this.playStatus = psArr.join("");
+                if (this.players.length > 0) {
+                    let allDone = true;
+                    for (const c of this.playStatus) {
+                        if (c === "f") { allDone = false; break; }
+                    }
+                    if (allDone) this.nextTrack();
+                }
+            }
+        }
+
+        if (wasPracticing && this.players.length === 0) {
+            // Room emptied mid-practice — drop the practice ref so a future
+            // re-use of this object (none today, defensive) doesn't leak.
+            this.practiceActive = false;
+            this.practiceTrack = null;
+        }
 
         const lobby = player.lobby;
         if (this.players.length > 0) {
             if (!wasPublic) {
                 // Game was in progress — pick the first remaining player to shoot.
                 this.broadcast(tabularize("game", "startturn", this.playersNumber[0] ?? 0));
-            } else if (lobby) {
-                // Still in the lobby phase — update the visible player count.
+            }
+            if (lobby) {
+                // Always update the gamelist row so the freed slot is visible
+                // to lobby-side joiners (covers both waiting and in-progress
+                // games — full rooms now stay in the list and shrink back to
+                // joinable when someone leaves).
                 lobby.writeAll(tabularize("lobby", "gamelist", "change", this.getGameString()));
             }
         } else if (lobby) {
             lobby.writeAll(tabularize("lobby", "gamelist", "remove", String(this.gameId)));
             lobby.removeGame(this);
         }
-        // Touch playerNum so TS doesn't whine.
-        void playerNum;
         return true;
     }
 }

--- a/port/server/src/lobby.ts
+++ b/port/server/src/lobby.ts
@@ -132,20 +132,23 @@ export class Lobby {
         for (const p of this.players) p.connection.sendDataRaw(body);
     }
 
-    /** Send the current public-game list to one player. Mirrors Java Lobby.sendGameList. */
+    /**
+     * Send the multiplayer game list to one player. Mirrors Java
+     * Lobby.sendGameList. Today this is only called for `LobbyType.MULTI`,
+     * which contains exclusively MultiGame rooms — full and ongoing rooms
+     * are included so the player can see what's happening across the lobby
+     * (and join any room with a free slot, including ones that filled
+     * earlier and have since freed a seat).
+     */
     sendGameList(player: Player): void {
         const fields: (string | number)[] = ["lobby", "gamelist", "full"];
         let count = 0;
         const flat: string[] = [];
         for (const g of this.games.values()) {
-            if (g.isPublic) {
-                // Each game contributes its 15 game-string fields, then a trailing tab
-                // (the Java code appends gameString + "\t" then runs that whole buffer
-                // through tabularize as a single arg, which preserves the embedded tabs).
-                flat.push(g.getGameString());
-            } else {
-                continue;
-            }
+            // Each game contributes its 15 game-string fields. The
+            // `inProgress` flag in field 5 lets the client decide whether
+            // to render a "(In progress)" badge / disable Join.
+            flat.push(g.getGameString());
             count++;
         }
         fields.push(count);

--- a/port/server/src/test-late-join.ts
+++ b/port/server/src/test-late-join.ts
@@ -1,0 +1,203 @@
+// Late-join-into-started-game smoke test.
+//
+// Boots a fresh server, has A and B fill a 2-player game so it starts. C is
+// in the lobby and observes:
+//   1. Initial gamelist (carries A's room).
+//   2. A `gamelist change` flipping the `inProgress` flag to '1' once the
+//      room fills (room stays in the list — no `gamelist remove`).
+//   3. A `gamelist change` shrinking the room back to 1/2 when B leaves
+//      mid-game.
+// Then C joins the now-1/2 room and verifies the catch-up sequence:
+//   - personal `start` / `resetvoteskip` / `starttrack` / `gametrack 1` — no
+//     full-room `start` broadcast (A is mid-game and shouldn't be reset).
+//
+// Usage: node --experimental-strip-types --no-warnings src/test-late-join.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4249;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+class Client {
+    name: string;
+    ws: WebSocket;
+    outSeq = 0;
+    received: string[] = [];
+
+    constructor(name: string) {
+        this.name = name;
+        this.ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+        this.ws.on("message", (m) => this.received.push(m.toString()));
+    }
+    async open(): Promise<void> {
+        await new Promise<void>((r) => this.ws.once("open", () => r()));
+    }
+    send(line: string): void { this.ws.send(line); }
+    sendData(...fields: (string | number)[]): void {
+        this.send(`d ${this.outSeq++} ${fields.join("\t")}`);
+    }
+    sendCommand(verb: string, ...args: string[]): void {
+        this.send(`c ${[verb, ...args].join(" ")}`);
+    }
+    async waitFor(predicate: (s: string) => boolean, label: string, timeoutMs = 4000): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => {
+                console.log(`[${this.name}] timeout ${label}; queue:`, this.received);
+                reject(new Error(`[${this.name}] timeout: ${label}`));
+            }, timeoutMs);
+            const tick = (): void => {
+                const idx = this.received.findIndex(predicate);
+                if (idx >= 0) {
+                    clearTimeout(t);
+                    const [s] = this.received.splice(idx, 1);
+                    resolve(s);
+                    return;
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+    async assertNotReceived(predicate: (s: string) => boolean, label: string, timeoutMs = 200): Promise<void> {
+        await new Promise((r) => setTimeout(r, timeoutMs));
+        const hit = this.received.find(predicate);
+        if (hit) throw new Error(`[${this.name}] unexpected packet (${label}): ${hit}`);
+    }
+    drain(): void { this.received.length = 0; }
+    close(): void { try { this.ws.close(); } catch { /* */ } }
+}
+
+async function login(c: Client): Promise<void> {
+    await c.waitFor((s) => s === "h 1", "h 1");
+    await c.waitFor((s) => s.startsWith("c crt"), "c crt");
+    await c.waitFor((s) => s === "c ctr", "c ctr");
+    c.sendCommand("new");
+    await c.waitFor((s) => s.startsWith("c id "), "c id");
+    c.sendData("version", 35);
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (v)");
+    c.sendData("language", "en");
+    c.sendData("logintype", "nr");
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (lt)");
+    c.sendData("login");
+    await c.waitFor((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+    await c.waitFor((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+}
+
+async function enterMultiLobby(c: Client): Promise<void> {
+    c.sendData("lobbyselect", "select", "x");
+    await c.waitFor((s) => /^d \d+ status\tlobby\tx/.test(s), "status lobby x");
+    await c.waitFor((s) => /^d \d+ lobby\tusers/.test(s), "lobby users");
+    await c.waitFor((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+    await c.waitFor((s) => /^d \d+ lobby\tgamelist\tfull/.test(s), "gamelist full");
+}
+
+async function main(): Promise<void> {
+    let server: RunningServer | null = null;
+    try {
+        server = await startServer({ host: HOST, port: PORT, tracksDir: tracksDir(), verbose: false });
+        console.log("[server] up");
+
+        const a = new Client("A");
+        const b = new Client("B");
+        const c = new Client("C");
+        await Promise.all([a.open(), b.open(), c.open()]);
+        for (const x of [a, b, c]) await login(x);
+        for (const x of [a, b, c]) await enterMultiLobby(x);
+        console.log("[OK] A, B, C in multi lobby");
+
+        // A creates a 2-player game with maxStrokes=10 and 3 tracks. After
+        // B joins, the room is full and starts.
+        a.sendData("lobby", "cmpt", "DropInTest", "-", 0, 2, 3, 0, 10, 60, 0, 1, 0, 0);
+        const addLine = await c.waitFor(
+            (s) => /^d \d+ lobby\tgamelist\tadd/.test(s),
+            "C sees gamelist add",
+        );
+        const gameId = parseInt(addLine.split("\t")[3] ?? "0", 10);
+        // gameString field 5 is at addLine index 7 (after `d N lobby gamelist add <gameId> <name> <pwd> <perms> <numPlayers>` ...).
+        // Easier check: just look for `0` as field 5 right after numPlayers=2.
+        if (!/\tDropInTest\tf\t0\t2\t0\t/.test(addLine)) {
+            throw new Error("expected inProgress=0 in initial add: " + addLine);
+        }
+        console.log("[OK] C sees room added with inProgress=0 (waiting)");
+        await a.waitFor((s) => /^d \d+ status\tgame/.test(s), "A status game");
+
+        // B joins → room fills → game starts. C should see a `gamelist change`
+        // with inProgress=1, AND no `gamelist remove`.
+        c.drain();
+        b.sendData("lobby", "jmpt", String(gameId));
+        await b.waitFor((s) => /^d \d+ status\tgame/.test(s), "B status game");
+        await a.waitFor((s) => /^d \d+ game\tstart$/.test(s), "A real start");
+        await b.waitFor((s) => /^d \d+ game\tstart$/.test(s), "B real start");
+
+        // The change packet flipping inProgress to "1" should be the LAST
+        // gamelist event C sees once the dust settles.
+        await c.waitFor(
+            (s) => /^d \d+ lobby\tgamelist\tchange\t\d+\tDropInTest\tf\t0\t2\t1\t/.test(s),
+            "C sees inProgress=1 change",
+        );
+        await c.assertNotReceived(
+            (s) => /^d \d+ lobby\tgamelist\tremove\t/.test(s),
+            "no remove after fill",
+            200,
+        );
+        console.log("[OK] room stays in gamelist after fill, inProgress flipped to 1");
+
+        // A and B play one stroke each, A holes-in.
+        const ball = (200 * 1500 + 200 * 4 + 0).toString(36).padStart(4, "0");
+        const mouseA = (300 * 1500 + 250 * 4 + 0).toString(36).padStart(4, "0");
+        a.sendData("game", "beginstroke", ball, mouseA);
+        await a.waitFor((s) => /^d \d+ game\tbeginstroke\t0\t/.test(s), "A own beginstroke");
+        a.sendData("game", "endstroke", 0, "tf");
+        await a.waitFor((s) => /^d \d+ game\tendstroke\t0\t1\tt$/.test(s), "A holed");
+        // B leaves voluntarily — `removePlayer` should mark slot 1 'p' so
+        // allDone passes and the track advances; we'll only assert on the
+        // gamelist side here.
+        c.drain();
+        b.sendData("game", "back");
+
+        // C should see a gamelist change shrinking the room to 1/2,
+        // inProgress still '1' (game still in progress).
+        await c.waitFor(
+            (s) => /^d \d+ lobby\tgamelist\tchange\t\d+\tDropInTest\tf\t0\t2\t1\t.*\t1$/.test(s),
+            "C sees 1/2 update with inProgress=1",
+        );
+        console.log("[OK] B left mid-game → gamelist shrinks back to 1/2 (inProgress=1)");
+
+        // C joins the 1/2 in-progress room. Expect personal start / resetvoteskip /
+        // starttrack / gametrack — but NO `lobby gamelist remove`.
+        c.drain();
+        c.sendData("lobby", "jmpt", String(gameId));
+        await c.waitFor((s) => /^d \d+ status\tgame/.test(s), "C status game");
+        await c.waitFor((s) => /^d \d+ game\tstart$/.test(s), "C personal start");
+        await c.waitFor((s) => /^d \d+ game\tresetvoteskip$/.test(s), "C resetvoteskip");
+        const stt = await c.waitFor((s) => /^d \d+ game\tstarttrack\t/.test(s), "C personal starttrack");
+        await c.waitFor((s) => /^d \d+ game\tgametrack\t\d+$/.test(s), "C gametrack");
+        // playStatus length should be 2 (slots 0..1 — A's slot 0 and C's slot 1).
+        // Specifically: server padded playStatus for C's slot to 'f', and the
+        // wire buff is "f".repeat(playStatus.length) = "ff".
+        if (!/game\tstarttrack\tff\t/.test(stt)) {
+            throw new Error("expected playStatus length 2 (\"ff\") in C's starttrack: " + stt);
+        }
+        console.log("[OK] C dropped into in-progress game with personal catch-up sequence");
+
+        a.close(); b.close(); c.close();
+        console.log("\nALL LATE-JOIN PHASES PASSED");
+        process.exit(0);
+    } catch (err) {
+        console.error("FAIL:", err);
+        process.exit(1);
+    } finally {
+        if (server) {
+            try { await server.close(); } catch { /* */ }
+        }
+    }
+}
+
+main();

--- a/port/server/src/test-practice.ts
+++ b/port/server/src/test-practice.ts
@@ -1,0 +1,215 @@
+// Practice-mode smoke test.
+//
+// Boots a fresh server, has two clients enter the multi lobby and create a
+// 4-player room (so the room never auto-fills during the test). Then:
+//   1. A presses Practice → both A and B receive game start + starttrack +
+//      practicemode t.
+//   2. A holes in 1 stroke → server picks a fresh random track and rebroadcasts
+//      starttrack with a clean playStatus.
+//   3. C joins → C sees a personal start/starttrack/practicemode t.
+//   4. The 4th player D joins → the room fills and the configured tracks
+//      (numTracks=3) start playing. No `practicemode` packet on this start.
+//
+// Usage: node --experimental-strip-types --no-warnings src/test-practice.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4248;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+class Client {
+    name: string;
+    ws: WebSocket;
+    outSeq = 0;
+    received: string[] = [];
+
+    constructor(name: string) {
+        this.name = name;
+        this.ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+        this.ws.on("message", (m) => this.received.push(m.toString()));
+    }
+    async open(): Promise<void> {
+        await new Promise<void>((r) => this.ws.once("open", () => r()));
+    }
+    send(line: string): void { this.ws.send(line); }
+    sendData(...fields: (string | number)[]): void {
+        this.send(`d ${this.outSeq++} ${fields.join("\t")}`);
+    }
+    sendCommand(verb: string, ...args: string[]): void {
+        this.send(`c ${[verb, ...args].join(" ")}`);
+    }
+    async waitFor(predicate: (s: string) => boolean, label: string, timeoutMs = 4000): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => {
+                console.log(`[${this.name}] timed out waiting for ${label}; queue:`, this.received);
+                reject(new Error(`[${this.name}] timeout: ${label}`));
+            }, timeoutMs);
+            const tick = (): void => {
+                const idx = this.received.findIndex(predicate);
+                if (idx >= 0) {
+                    clearTimeout(t);
+                    const [s] = this.received.splice(idx, 1);
+                    resolve(s);
+                    return;
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+    /** Confirm a packet matching `predicate` does NOT arrive within `timeoutMs`. */
+    async assertNotReceived(predicate: (s: string) => boolean, label: string, timeoutMs = 200): Promise<void> {
+        await new Promise((r) => setTimeout(r, timeoutMs));
+        const hit = this.received.find(predicate);
+        if (hit) throw new Error(`[${this.name}] unexpected packet (${label}): ${hit}`);
+    }
+    drain(): void {
+        this.received.length = 0;
+    }
+    close(): void {
+        try { this.ws.close(); } catch { /* */ }
+    }
+}
+
+async function login(c: Client): Promise<void> {
+    await c.waitFor((s) => s === "h 1", "h 1");
+    await c.waitFor((s) => s.startsWith("c crt"), "c crt");
+    await c.waitFor((s) => s === "c ctr", "c ctr");
+    c.sendCommand("new");
+    await c.waitFor((s) => s.startsWith("c id "), "c id");
+    c.sendData("version", 35);
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (v)");
+    c.sendData("language", "en");
+    c.sendData("logintype", "nr");
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (lt)");
+    c.sendData("login");
+    await c.waitFor((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+    await c.waitFor((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+}
+
+async function enterMultiLobby(c: Client): Promise<void> {
+    c.sendData("lobbyselect", "select", "x");
+    await c.waitFor((s) => /^d \d+ status\tlobby\tx/.test(s), "status lobby x");
+    await c.waitFor((s) => /^d \d+ lobby\tusers/.test(s), "lobby users");
+    await c.waitFor((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+    await c.waitFor((s) => /^d \d+ lobby\tgamelist\tfull/.test(s), "gamelist full");
+}
+
+async function main(): Promise<void> {
+    let server: RunningServer | null = null;
+    try {
+        server = await startServer({ host: HOST, port: PORT, tracksDir: tracksDir(), verbose: false });
+        console.log("[server] up");
+
+        const a = new Client("A");
+        const b = new Client("B");
+        const c = new Client("C");
+        const d = new Client("D");
+        await Promise.all([a.open(), b.open(), c.open(), d.open()]);
+        for (const x of [a, b, c, d]) await login(x);
+        for (const x of [a, b, c, d]) await enterMultiLobby(x);
+        console.log("[OK] all four logged in and in multi lobby");
+
+        // A creates a 4-player game with 3 configured tracks. No password.
+        a.sendData("lobby", "cmpt", "PracticeRoom", "-", 0, 4, 3, 0, 10, 60, 0, 1, 0, 0);
+        const addLine = await b.waitFor(
+            (s) => /^d \d+ lobby\tgamelist\tadd/.test(s),
+            "B sees gamelist add",
+        );
+        await a.waitFor((s) => /^d \d+ status\tgame/.test(s), "A status game");
+        const gameId = parseInt(addLine.split("\t")[3] ?? "0", 10);
+        console.log("[OK] game created with id", gameId, "(4 players, 3 tracks)");
+
+        // B joins (now 2/4). No `game start` should fire — room not full.
+        b.sendData("lobby", "jmpt", String(gameId));
+        await b.waitFor((s) => /^d \d+ status\tgame/.test(s), "B status game");
+        await a.waitFor((s) => /^d \d+ game\tjoin\t2\t/.test(s), "A sees B join");
+        await a.assertNotReceived((s) => /^d \d+ game\tstart$/.test(s), "no start before practice");
+        console.log("[OK] B joined; room is 2/4, no auto-start");
+
+        // A presses Practice. Server should broadcast start + resetvoteskip +
+        // starttrack + practicemode t to BOTH players.
+        a.drain(); b.drain();
+        a.sendData("game", "practice");
+
+        for (const cli of [a, b]) {
+            await cli.waitFor((s) => /^d \d+ game\tstart$/.test(s), `${cli.name} game start (practice)`);
+            await cli.waitFor((s) => /^d \d+ game\tresetvoteskip$/.test(s), `${cli.name} resetvoteskip`);
+            await cli.waitFor((s) => /^d \d+ game\tstarttrack\tff\t/.test(s), `${cli.name} starttrack`);
+            await cli.waitFor((s) => /^d \d+ game\tpracticemode\tt$/.test(s), `${cli.name} practicemode t`);
+        }
+        console.log("[OK] practice started for A & B with random track + practicemode flag");
+
+        // Repeat-press is a no-op on the server.
+        a.drain(); b.drain();
+        a.sendData("game", "practice");
+        await a.assertNotReceived((s) => /^d \d+ game\tstart$/.test(s), "no second start", 200);
+        console.log("[OK] repeat practice press ignored while practice is running");
+
+        // A holes-in (status 't') → server's nextTrack swaps in another random
+        // track and rebroadcasts starttrack with a clean buff.
+        a.drain(); b.drain();
+        const ball = (200 * 1500 + 200 * 4 + 0).toString(36).padStart(4, "0");
+        const mouseA = (300 * 1500 + 250 * 4 + 0).toString(36).padStart(4, "0");
+        a.sendData("game", "beginstroke", ball, mouseA);
+        await a.waitFor((s) => /^d \d+ game\tbeginstroke\t0\t/.test(s), "A own beginstroke");
+        a.sendData("game", "endstroke", 0, "tf");
+        await a.waitFor((s) => /^d \d+ game\tendstroke\t0\t1\tt$/.test(s), "A endstroke t");
+        // B is still 'f', so allDone is false → no advance yet.
+        await a.assertNotReceived((s) => /game\tstarttrack/.test(s), "no advance with B still 'f'", 200);
+
+        b.sendData("game", "beginstroke", ball, mouseA);
+        await b.waitFor((s) => /^d \d+ game\tbeginstroke\t1\t/.test(s), "B own beginstroke");
+        b.sendData("game", "endstroke", 1, "ft");
+        // Now both are 't' → nextTrack picks a fresh random track.
+        await a.waitFor((s) => /^d \d+ game\tstarttrack\tff\t/.test(s), "A practice next track");
+        await b.waitFor((s) => /^d \d+ game\tstarttrack\tff\t/.test(s), "B practice next track");
+        // No `game start` between practice tracks — only on the very first start.
+        // (Existing handler only sends `start` from `startGame`/`startPractice`.)
+        console.log("[OK] practice cycles: both holed → fresh random track");
+
+        // C joins mid-practice — gets a personal start/starttrack/practicemode t.
+        a.drain(); b.drain();
+        c.sendData("lobby", "jmpt", String(gameId));
+        await c.waitFor((s) => /^d \d+ status\tgame/.test(s), "C status game");
+        await c.waitFor((s) => /^d \d+ game\tstart$/.test(s), "C personal start");
+        await c.waitFor((s) => /^d \d+ game\tstarttrack\t/.test(s), "C personal starttrack");
+        await c.waitFor((s) => /^d \d+ game\tpracticemode\tt$/.test(s), "C practicemode t");
+        // A & B don't get a start broadcast (only the join announcement).
+        await a.waitFor((s) => /^d \d+ game\tjoin\t3\t/.test(s), "A sees C join");
+        await a.assertNotReceived((s) => /^d \d+ game\tstart$/.test(s), "no spurious start for A on C-join", 200);
+        console.log("[OK] late joiner C dropped into running practice without disturbing A/B");
+
+        // D joins → room fills (4/4) → real game starts. Practice flag is dropped.
+        a.drain(); b.drain(); c.drain(); d.drain();
+        d.sendData("lobby", "jmpt", String(gameId));
+        await d.waitFor((s) => /^d \d+ status\tgame/.test(s), "D status game");
+        for (const cli of [a, b, c, d]) {
+            await cli.waitFor((s) => /^d \d+ game\tstart$/.test(s), `${cli.name} real game start`);
+            await cli.waitFor((s) => /^d \d+ game\tstarttrack\t/.test(s), `${cli.name} real starttrack`);
+            // No practicemode t on the real-game start.
+            await cli.assertNotReceived((s) => /^d \d+ game\tpracticemode\tt$/.test(s), `${cli.name} no practicemode on real start`, 150);
+        }
+        console.log("[OK] room filled → practice ended, real game started for all four");
+
+        a.close(); b.close(); c.close(); d.close();
+        console.log("\nALL PRACTICE-MODE PHASES PASSED");
+        process.exit(0);
+    } catch (err) {
+        console.error("FAIL:", err);
+        process.exit(1);
+    } finally {
+        if (server) {
+            try { await server.close(); } catch { /* */ }
+        }
+    }
+}
+
+main();

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -276,6 +276,28 @@ export class GamePanel implements Panel {
   private skipButton: HTMLButtonElement | null = null;
   private skipButtonHost: HTMLElement | null = null;
   private playAgainButton: HTMLButtonElement | null = null;
+  /**
+   * Practice-mode button — shown only while a multiplayer room is still
+   * waiting for fillers. Click sends `game practice`; the server answers
+   * with the usual start/starttrack/practicemode trio. Mutually exclusive
+   * with `skipButton` (you only see one or the other depending on whether
+   * a track is currently in play).
+   */
+  private practiceButton: HTMLButtonElement | null = null;
+  /**
+   * True once the server has broadcast `game start` for this room (either
+   * the real game starting because the room filled, or practice mode
+   * starting). Drives the "waiting in lobby" predicate that decides whether
+   * the Practice button is even relevant.
+   */
+  private gameStartedReceived = false;
+  /**
+   * True between `game practicemode t` and the next `game start` (which
+   * either flips this off explicitly or, more commonly, is followed by the
+   * real-game starttrack with no `practicemode t` packet). Suppresses
+   * per-hole columns and shows "Practice" instead of "Track N/M" in the HUD.
+   */
+  private practiceMode = false;
 
   private mouseX = 0;
   private mouseY = 0;
@@ -290,6 +312,16 @@ export class GamePanel implements Panel {
   private rafHandle = 0;
   private gameId: string = "0";
   private numPlayers = 1;
+  /**
+   * Configured room capacity from `gameinfo` — does NOT shrink when a
+   * starttrack arrives with a shorter `playStatus` (which can happen during
+   * practice in a partially-filled room: 1/4 players makes playStatus = "f",
+   * length 1, but the room is still a 4-player room). Drives the
+   * "is this a multiplayer room?" predicate for skip / practice button
+   * visibility, where transient under-population shouldn't flip us into
+   * single-player UI.
+   */
+  private roomCapacity = 1;
   private numTracks = 1;
   private currentTrackIdx = 0;
   private myPlayerId = 0;
@@ -438,6 +470,29 @@ export class GamePanel implements Panel {
     actions.appendChild(skip);
     this.skipButton = skip;
     this.skipButtonHost = actions;
+
+    // Practice — port-original "Harjoittele" button. Occupies the same slot
+    // as the skip button while the multiplayer room is still filling up;
+    // `updateSkipButtonVisibility` keeps the two mutually exclusive (Skip
+    // is meaningless before a track has started; Practice is meaningless
+    // after one has). Larger padding/font give it the "big button" feel
+    // the design calls for.
+    const practice = document.createElement("button");
+    practice.type = "button";
+    practice.className = "btn-green practice-btn";
+    practice.textContent = t("Port_Game_Practice", "Practice");
+    practice.style.padding = "6px 22px";
+    practice.style.minHeight = "auto";
+    practice.style.fontSize = "14px";
+    practice.style.fontWeight = "bold";
+    practice.style.display = "none";
+    practice.title = t(
+      "Port_Game_PracticeHint",
+      "Play random maps while waiting — multiplayer enabled",
+    );
+    practice.addEventListener("click", () => this.startPractice());
+    actions.appendChild(practice);
+    this.practiceButton = practice;
 
     // "Valikko" — opens the ESC popover (settings + quit). Replaces the
     // original "<- Valikkoon" button position.
@@ -603,6 +658,10 @@ export class GamePanel implements Panel {
     this.skipButton = null;
     this.skipButtonHost = null;
     this.playAgainButton = null;
+    this.practiceButton = null;
+    this.gameStartedReceived = false;
+    this.practiceMode = false;
+    this.roomCapacity = 1;
     this.overlay = null;
     this.panelEl = null;
     this.root = null;
@@ -635,8 +694,19 @@ export class GamePanel implements Panel {
     switch (verb) {
       case "gameinfo":
         this.numPlayers = parseInt(f[5] ?? "1", 10) || 1;
+        // Capture the configured room cap before starttrack can shrink
+        // `numPlayers` in a partially-filled room (see `roomCapacity`
+        // declaration).
+        this.roomCapacity = this.numPlayers;
         this.numTracks = parseInt(f[6] ?? "1", 10) || 1;
         this.waterEvent = parseInt(f[10] ?? "0", 10) || 0;
+        // Fresh gameinfo arrives on every join — reset the "started" gate so
+        // the Practice button reappears for any new room (including a
+        // re-join). The trailing `f` flag in the packet always says
+        // "isStarted=false" today; we don't trust it and just track via the
+        // `start` broadcast.
+        this.gameStartedReceived = false;
+        this.practiceMode = false;
         this.ensurePlayerSlots(this.numPlayers);
         this.scoreboardDirty = true;
         this.applyChatVisibility();
@@ -802,6 +872,11 @@ export class GamePanel implements Panel {
           slot.forfeitedThisTrack = false;
         }
         this.currentTrackIdx = 0;
+        this.gameStartedReceived = true;
+        // Default to non-practice. A subsequent `practicemode t` packet will
+        // flip this back on if the start was for practice; otherwise we're
+        // in a real game (full room) and per-hole columns should render.
+        this.practiceMode = false;
         // Tear down any leftover end-of-game overlay before the new round
         // starts; otherwise the play-again button stays on screen even though
         // the new game has begun.
@@ -810,8 +885,37 @@ export class GamePanel implements Panel {
         this.scoreboardDirty = true;
         audio.playNotify();
         break;
+      case "practicemode":
+        // Port-original packet. Sent right after a practice `starttrack` so
+        // the client knows the cycling-random-maps mode is on; absent on
+        // real-game starts. The trailing field is "t"/"f" (default true).
+        this.practiceMode = (f[2] ?? "t") === "t";
+        this.scoreboardDirty = true;
+        this.updateSkipButtonVisibility();
+        this.refreshTrackProgress();
+        break;
       case "starttrack":
+        // A late joiner to a started game gets a personal `starttrack`
+        // (no `start` precedes it on their wire), so flip the
+        // game-started gate here too — otherwise the Practice button
+        // would still be available to a player who's already mid-room.
+        this.gameStartedReceived = true;
         this.handleStartTrack(f);
+        break;
+      case "gametrack":
+        // Late-joiner correction: server tells us which configured track
+        // index this is so the HUD reads "Track N/M" matching the room
+        // rather than the default "Track 1/M" the client would compute
+        // from the single starttrack it just received. No-op for normal
+        // joiners — `handleStartTrack` already incremented to the right
+        // value before this packet arrives, and the server simply doesn't
+        // emit `gametrack` for them.
+        {
+          const idx = parseInt(f[2] ?? "1", 10) || 1;
+          this.currentTrackIdx = idx;
+          this.refreshTrackProgress();
+          this.scoreboardDirty = true;
+        }
         break;
       case "beginstroke":
         // Server broadcasts to ALL (including the shooter) so everyone runs
@@ -1209,13 +1313,15 @@ export class GamePanel implements Panel {
     }
   }
 
-  private setTrackMeta(
-    author: string,
-    name: string,
-    info: TrackInfoLine | null,
-    bestPlayer: string,
-  ): void {
-    if (this.trackProgressEl) {
+  /** Refresh just the track-progress line. Pulled out of `setTrackMeta` so
+   *  `practicemode` packets (which arrive AFTER the starttrack that wrote
+   *  the "Track N/M" text) can re-render it as "Practice" without rebuilding
+   *  the rest of the metadata. */
+  private refreshTrackProgress(): void {
+    if (!this.trackProgressEl) return;
+    if (this.practiceMode) {
+      this.trackProgressEl.textContent = t("Port_Game_PracticeProgress", "Practice");
+    } else {
       this.trackProgressEl.textContent = t(
         "GameTrackInfo_CurrentTrack",
         "Track %1/%2",
@@ -1223,6 +1329,15 @@ export class GamePanel implements Panel {
         this.numTracks,
       );
     }
+  }
+
+  private setTrackMeta(
+    author: string,
+    name: string,
+    info: TrackInfoLine | null,
+    bestPlayer: string,
+  ): void {
+    this.refreshTrackProgress();
     // Stash for the daily-share text; both fields are blank until the first
     // starttrack arrives.
     this.trackName = name;
@@ -1282,26 +1397,50 @@ export class GamePanel implements Panel {
       // span (`.track-cell`) so that 2-digit scores (10+) don't shift the
       // total/note columns out of alignment relative to other rows. Mirrors
       // the column-aligned scoreboard in the original Java client.
+      //
+      // Practice mode: tracks cycle (server picks a new random map every
+      // hole-in), so per-hole columns and a running "total" don't carry
+      // any meaning. Show just the live stroke counter for the current map.
       const tracksCol = document.createElement("span");
       tracksCol.className = "tracks-cells";
       let totalSoFar = 0;
-      for (let t = 0; t < this.numTracks; t++) {
+      if (this.practiceMode) {
         const cell = document.createElement("span");
         cell.className = "track-cell";
-        if (t + 1 < this.currentTrackIdx) {
-          const score = p.holeScores[t] ?? 0;
-          cell.textContent = String(score);
-          totalSoFar += score;
-        } else if (t + 1 === this.currentTrackIdx) {
-          cell.textContent = String(p.strokesThisTrack);
-          totalSoFar += p.strokesThisTrack;
-        } else {
-          cell.textContent = "—";
-        }
+        cell.textContent = String(p.strokesThisTrack);
         tracksCol.appendChild(cell);
+        totalSoFar = p.strokesThisTrack;
+      } else {
+        for (let t = 0; t < this.numTracks; t++) {
+          const cell = document.createElement("span");
+          cell.className = "track-cell";
+          if (t + 1 < this.currentTrackIdx) {
+            // `holeScores[t]` is undefined when this player joined the
+            // room AFTER track `t+1` ended (the server can't replay
+            // historical per-track stroke counts — the client only
+            // accumulates them from live `endstroke` broadcasts during
+            // the run). Render "—" instead of "0" so a late joiner's
+            // scoreboard distinguishes "didn't play" from "scored 0".
+            const score = p.holeScores[t];
+            if (score === undefined) {
+              cell.textContent = "—";
+            } else {
+              cell.textContent = String(score);
+              totalSoFar += score;
+            }
+          } else if (t + 1 === this.currentTrackIdx) {
+            cell.textContent = String(p.strokesThisTrack);
+            totalSoFar += p.strokesThisTrack;
+          } else {
+            cell.textContent = "—";
+          }
+          tracksCol.appendChild(cell);
+        }
       }
       const total = document.createElement("span");
-      total.textContent = "= " + totalSoFar;
+      // In practice mode the "= N" total would just duplicate the single
+      // strokes cell — drop it for a cleaner read.
+      total.textContent = this.practiceMode ? "" : "= " + totalSoFar;
       const note = document.createElement("span");
       // Mirrors Java PlayerInfoPanel's `extraMessage` priority chain:
       // part-reason badges win over voteSkip/wantsNewGame, which win over
@@ -2059,19 +2198,41 @@ export class GamePanel implements Panel {
    * `display: none` once we've voted, so the actions column doesn't collapse
    * and the Menu button doesn't jump positions. Single-player and daily mode
    * collapse the space entirely (no skip is ever shown there).
+   *
+   * Skip is also suppressed while the room is still waiting for fillers
+   * (`!gameStartedReceived`): the Practice button takes that slot. Once
+   * either practice or the real game starts, Skip takes over.
    */
   private updateSkipButtonVisibility(): void {
     const btn = this.skipButton;
-    if (!btn) return;
+    const practiceBtn = this.practiceButton;
     const me = this.players[this.myPlayerId];
-    const isMulti = this.numPlayers > 1 && !this.dailyMode;
-    if (!isMulti) {
+    // Use `roomCapacity` (configured) rather than `numPlayers` (which a
+    // practice starttrack can transiently shrink to 1 in a 1/4 room) so
+    // the multiplayer-only buttons stay shown for the whole room lifetime.
+    const isMulti = this.roomCapacity > 1 && !this.dailyMode;
+
+    if (practiceBtn) {
+      const showPractice = isMulti && !this.gameStartedReceived;
+      practiceBtn.style.display = showPractice ? "" : "none";
+    }
+
+    if (!btn) return;
+    if (!isMulti || !this.gameStartedReceived) {
       btn.style.display = "none";
       btn.style.visibility = "";
       return;
     }
     btn.style.display = "";
     btn.style.visibility = me && !me.votedToSkip ? "visible" : "hidden";
+  }
+
+  /** "Harjoittele" click — kick off (or no-op join) shared practice. The
+   *  server filters out repeat presses while practice is already running
+   *  and after the real game has started. */
+  private startPractice(): void {
+    if (this.gameStartedReceived) return;
+    this.app.connection.sendData("game", "practice");
   }
 
   private applyChatVisibility(): void {

--- a/port/web/src/panels/lobby-multi.ts
+++ b/port/web/src/panels/lobby-multi.ts
@@ -10,6 +10,14 @@ interface GameInfo {
   passworded: boolean;
   perms: number;
   numPlayers: number;
+  /**
+   * True once the game has started (server cleared `isPublic`). Field 5 of
+   * the wire gameString — the original Java client treated this slot as
+   * an unused legacy `-1` value, so emitting `0`/`1` is back-compatible
+   * with anyone still parsing the old format. Drives the "(In progress)"
+   * badge and the Join enable/disable in the games list.
+   */
+  inProgress: boolean;
   numTracks: number;
   trackType: number;
   maxStrokes: number;
@@ -68,7 +76,10 @@ function parseGameFields(fields: string[], offset: number): GameInfo {
     passworded: f(2) === "t",
     perms: parseInt(f(3), 10) || 0,
     numPlayers: parseInt(f(4), 10) || 0,
-    // f(5) is the always-`-1` slot
+    // f(5) was the legacy `-1` slot; we emit "1" once the room has started
+    // so the client can show "(In progress)". Older servers send "-1" — any
+    // non-"1" value parses as "still waiting", which matches the old UX.
+    inProgress: f(5) === "1",
     numTracks: parseInt(f(6), 10) || 0,
     trackType: parseInt(f(7), 10) || 0,
     maxStrokes: parseInt(f(8), 10) || 0,
@@ -629,12 +640,18 @@ export class LobbyMultiPanel implements Panel {
   }
 
   private makeGameRow(g: GameInfo): HTMLElement {
+    // Two-line content with single-line slot/button column: a 4-column grid
+    // (lock | name+meta block | slots | join button) so the slot count and
+    // Join button vertically center against the stacked name+meta cell. The
+    // narrow Games column couldn't fit everything inline once
+    // "(In progress)" was added — splitting the middle cell lets the name
+    // breathe while keeping the action controls anchored to the right.
     const row = document.createElement("div");
     row.style.display = "grid";
-    row.style.gridTemplateColumns = "16px 1fr auto auto auto";
+    row.style.gridTemplateColumns = "16px 1fr auto auto";
     row.style.gap = "6px";
     row.style.alignItems = "center";
-    row.style.padding = "3px 4px";
+    row.style.padding = "4px 4px";
     row.style.borderBottom = "1px solid #ccc";
 
     const lock = document.createElement("span");
@@ -642,19 +659,41 @@ export class LobbyMultiPanel implements Panel {
     lock.style.fontSize = "11px";
     row.appendChild(lock);
 
+    // Stacked middle cell: bold name on top, meta + badge underneath.
+    const block = document.createElement("div");
+    block.style.display = "flex";
+    block.style.flexDirection = "column";
+    block.style.gap = "1px";
+    block.style.minWidth = "0";
+
     const name = document.createElement("span");
     name.textContent = g.name;
     name.style.fontWeight = "bold";
     name.style.overflow = "hidden";
     name.style.textOverflow = "ellipsis";
-    row.appendChild(name);
+    name.style.whiteSpace = "nowrap";
+    name.title = g.name; // Hover reveals long names in full.
+    block.appendChild(name);
+
+    const metaLine = document.createElement("div");
+    metaLine.style.display = "flex";
+    metaLine.style.gap = "8px";
+    metaLine.style.fontSize = "11px";
 
     const meta = document.createElement("span");
     const ttype = trackTypeName(g.trackType);
     meta.textContent = `${ttype} · ${g.numTracks}t`;
-    meta.style.fontSize = "11px";
     meta.style.color = "#406040";
-    row.appendChild(meta);
+    metaLine.appendChild(meta);
+
+    if (g.inProgress) {
+      const badge = document.createElement("span");
+      badge.textContent = t("Port_Lobby_InProgress", "(In progress)");
+      badge.style.color = "#806040";
+      metaLine.appendChild(badge);
+    }
+    block.appendChild(metaLine);
+    row.appendChild(block);
 
     const slots = document.createElement("span");
     slots.textContent = `${g.currentPlayers}/${g.numPlayers}`;
@@ -671,6 +710,13 @@ export class LobbyMultiPanel implements Panel {
       join.disabled = true;
       join.textContent = t("LobbySelect_Full", "(Full)");
     } else {
+      // Slot is free regardless of whether the room is waiting or already
+      // running — the server's `addPlayerWithPassword` catches late joiners
+      // up via `start` / `starttrack` / `gametrack`. Surface the verb
+      // difference so users know what they're walking into.
+      if (g.inProgress) {
+        join.textContent = t("Port_Lobby_JoinInProgress", "Drop in");
+      }
       this.bind(join, "click", () => this.joinGame(g));
     }
     row.appendChild(join);


### PR DESCRIPTION
Adds two features to the multiplayer flow that the original Java client never had:

1. Practice while waiting (Harjoittele button). When a multi-room is still filling up, anyone in it can press a big green Practice button to start a shared run of random tracks. Tracks auto-cycle on each hole-in, late joiners drop into the current track, and the moment the room fills the configured tracks list takes over via the existing startGame() path. Server: new `MultiGame.startPractice()`, override `nextTrack()` to swap in fresh random tracks, override `startGame()` to clear practice residue. New `game practicemode t/f` packet so the client can render "Harjoitus" in the HUD and collapse per-hole columns.

2. Drop-in joining for full / in-progress rooms. Rooms stay in the gamelist after they fill (no more `gamelist remove` on start) so a vacated slot is immediately re-fillable. New `MultiGame.sendCurrentTrackTo()` walks late joiners through `start` / `resetvoteskip` / `starttrack` / `gametrack <idx>` / per-slot `endstroke` replays so their HUD reads "Track N/M" matching the room and finished peers render correctly. Field 5 of the wire gameString (the legacy unused `-1` slot) becomes an inProgress flag; lobby UI shows a "(In progress)" badge and a "Drop in" verb on the join button.

Other touches:
  - `roomCapacity` field on the game panel decouples "configured cap" from "starttrack playStatus length", so a 1/4 practice room doesn't transiently shrink the multi-only UI to single-player.
  - `gameStartedReceived` flips on `starttrack` (not just `start`) so drop-in joiners exit the waiting state.
  - Scoreboard renders `holeScores[t] === undefined` as "—" instead of "0" so a late joiner's missed-track cells don't read as zero scores.
  - Leaver's `playStatus` slot is stamped 'p' on remove (previously practice-only) so a vacated `'f'` can't trap survivors mid-track.
  - Lobby gamelist row is now two-line: bold name on top, track meta
    + badge below, with slots/Join button vertically centered.

Tests: new test-practice.ts covers the start/cycle/late-join/fill flow; new test-late-join.ts covers gamelist-stays-after-fill, slot-reopens-on-leave, and the drop-in catch-up sequence. All existing multiplayer tests still pass.