### PR TITLE
Port: mobile support — landscape-only, drag-to-shoot with magnifier l…

### DIFF
--- a/port/web/index.html
+++ b/port/web/index.html
@@ -2,13 +2,34 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>Playforia Minigolf</title>
     <link rel="icon" href="/picture/agolf/icon.png" />
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
     <div id="app"></div>
+    <!-- Touch-only portrait prompt. Hidden by default; CSS shows it when the
+         viewport is portrait on a coarse-pointer device. Kept in markup so it
+         appears even before main.ts runs. The phone/ball pair is built from
+         CSS shapes so it matches the AWT-era pastel-green theme. -->
+    <div id="rotate-prompt" aria-hidden="true">
+      <div class="rotate-prompt__art" aria-hidden="true">
+        <div class="rotate-prompt__phone">
+          <span class="rotate-prompt__notch"></span>
+          <span class="rotate-prompt__screen">
+            <span class="rotate-prompt__ball"></span>
+          </span>
+          <span class="rotate-prompt__home"></span>
+        </div>
+      </div>
+      <div class="rotate-prompt__text">
+        Käännä puhelin sivuttain
+      </div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/port/web/public/style.css
+++ b/port/web/public/style.css
@@ -1,6 +1,11 @@
 /* Playforia Minigolf — browser port. Visual goal: pixel-faithful match to the
    original Java AWT client (light-green background #99FF99, pastel buttons,
-   serif titles, AWT-style 3D-bevel widgets). */
+   serif titles, AWT-style 3D-bevel widgets).
+
+   Mobile/touch support is appended at the bottom: a portrait-mode "rotate
+   your phone" prompt and a transform-scale fit on the fixed 735×525 #app for
+   landscape touch devices. The game.ts mount handler hooks touch events on
+   the canvas and floats a magnifier loupe above the finger during drag-to-shoot. */
 
 *,
 *::before,
@@ -712,4 +717,237 @@ input[type="range"].win98-slider::-moz-range-thumb {
   border-bottom: 1px solid #404040;
   box-shadow: inset -1px -1px 0 #808080;
   border-radius: 0;
+}
+
+/* ---------- Mobile / touch support ---------- */
+
+/* Rotate-phone prompt: hidden by default; only shown for coarse-pointer
+   devices in portrait orientation. Lives in HTML so it appears before the
+   TS bundle even runs. */
+#rotate-prompt {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  /* Match the in-game playfield green so the prompt feels like part of the
+     world rather than an OS-style modal. */
+  background: #99ff99;
+  color: #000;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 22px;
+  padding: 24px;
+  text-align: center;
+  font-family: "Times New Roman", "Liberation Serif", serif;
+}
+
+#rotate-prompt .rotate-prompt__art {
+  width: 140px;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* The phone is a small AWT-bezel rectangle drawn entirely with CSS — a
+   3D-bevel border, dark grey body, a screen window in pastel green with a
+   white golf ball inside, and a home indicator pill. The whole assembly
+   rotates from upright to landscape on a loop, mimicking the gesture the
+   user needs to perform. */
+#rotate-prompt .rotate-prompt__phone {
+  position: relative;
+  width: 60px;
+  height: 100px;
+  background: #c0c0c0;
+  border: 2px solid #2a2d33;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
+  border-right-color: #404040;
+  border-bottom-color: #404040;
+  border-radius: 8px;
+  box-shadow:
+    inset 0 0 0 1px #808080,
+    0 4px 0 #2a2d33,
+    0 4px 8px rgba(0, 0, 0, 0.25);
+  animation: rotate-prompt-phone 2.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  transform-origin: 50% 50%;
+}
+
+#rotate-prompt .rotate-prompt__notch {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 18px;
+  height: 3px;
+  background: #2a2d33;
+  border-radius: 2px;
+}
+
+#rotate-prompt .rotate-prompt__screen {
+  position: absolute;
+  inset: 12px 4px 12px 4px;
+  background: #99ff99;
+  border: 1px solid #2a2d33;
+  border-top-color: #4a8040;
+  border-left-color: #4a8040;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+/* Golf ball — white circle with a faint shading dot in the corner so it
+   reads as a ball rather than a flat disc. Rolls left↔right inside the
+   "screen" so there's a hint of motion even mid-rotation. */
+#rotate-prompt .rotate-prompt__ball {
+  width: 14px;
+  height: 14px;
+  background: radial-gradient(circle at 35% 35%, #ffffff 0 60%, #c8e0c8 75%, #88a888 100%);
+  border-radius: 50%;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+  animation: rotate-prompt-ball 2.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+#rotate-prompt .rotate-prompt__home {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 22px;
+  height: 3px;
+  background: #2a2d33;
+  border-radius: 2px;
+}
+
+#rotate-prompt .rotate-prompt__text {
+  font-size: 22px;
+  font-weight: bold;
+  max-width: 320px;
+  /* Subtle 1-px white drop so the text stays legible against the bright
+     green background, matching the original Playforia title styling. */
+  text-shadow: 0 1px 0 #ffffff;
+}
+
+/* Phone tilts from portrait to landscape and holds, then snaps back. */
+@keyframes rotate-prompt-phone {
+  0%   { transform: rotate(0deg); }
+  35%  { transform: rotate(-90deg); }
+  75%  { transform: rotate(-90deg); }
+  100% { transform: rotate(0deg); }
+}
+
+/* Ball nudges sideways on the rotation peak — implies the ball is "ready
+   to roll" once the phone is in the right orientation. */
+@keyframes rotate-prompt-ball {
+  0%   { transform: translateX(0); }
+  35%  { transform: translateX(0); }
+  55%  { transform: translateX(8px); }
+  75%  { transform: translateX(0); }
+  100% { transform: translateX(0); }
+}
+
+/* Magnifier loupe — a fixed-position circular canvas painted from the main
+   game canvas every frame while a touch drag is active. Floats above the
+   finger so the user sees what's hidden under their fingertip. */
+.aim-loupe {
+  display: none;
+  position: fixed;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 3px solid #ffffff;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.6);
+  background: #99ff99;
+  pointer-events: none;
+  z-index: 1500;
+  /* Pixel art look — keep the zoomed-in pixels crisp instead of blurry. */
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+.aim-loupe.is-visible {
+  display: block;
+}
+
+/* Mobile shoot-mode cycle button — desktop right-click parity. The button
+   itself is created in TS and lives inside `.canvas-frame` so it scales with
+   the canvas under the landscape `transform: scale()`. The default rule
+   below hides it on every device; the touch-primary @media block re-enables
+   it. Uses absolute positioning anchored to the canvas-frame's lower-right
+   corner so it doesn't cover the playfield. */
+.panel-game .canvas-frame {
+  position: relative;
+}
+.panel-game .shoot-mode-btn {
+  display: none;
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  font-size: 24px;
+  font-weight: bold;
+  line-height: 1;
+  font-family: "Verdana", Tahoma, sans-serif;
+  background: rgba(255, 255, 255, 0.85);
+  color: #000;
+  border: 2px outset #d9d9d9;
+  border-radius: 6px;
+  cursor: pointer;
+  z-index: 10;
+  /* Each shootingMode picks a tint so the player can recognise the active
+     mode at a glance without reading the glyph. */
+  transition: background 0.15s ease;
+}
+.panel-game .shoot-mode-btn[data-mode="0"] { background: rgba(255, 255, 255, 0.85); }
+.panel-game .shoot-mode-btn[data-mode="1"] { background: rgba(255, 220, 160, 0.95); }
+.panel-game .shoot-mode-btn[data-mode="2"] { background: rgba(180, 220, 255, 0.95); }
+.panel-game .shoot-mode-btn[data-mode="3"] { background: rgba(220, 180, 255, 0.95); }
+.panel-game .shoot-mode-btn:active {
+  border-style: inset;
+}
+
+/* Touch device adjustments. We scope these with both `(hover: none)` and
+   `(pointer: coarse)` so they apply to phones and tablets but not to
+   touch-enabled laptops, where mouse input is still primary. */
+@media (hover: none) and (pointer: coarse) {
+  .panel-game .shoot-mode-btn { display: block; }
+
+  /* Block default scroll/zoom gestures on the play canvas — touch input is
+     consumed by drag-to-shoot. Buttons and chat scrolling outside the
+     canvas remain unaffected. */
+  .panel-game canvas {
+    touch-action: none;
+    cursor: default;
+  }
+
+  /* Portrait — show prompt, hide everything else. */
+  @media (orientation: portrait) {
+    #app { display: none !important; }
+    #rotate-prompt { display: flex; }
+  }
+
+  /* Landscape — fit the fixed-size #app inside the viewport via a uniform
+     transform, preserving the 735×525 internal layout. We can't use
+     `width: 100vw` etc. because every child has hardcoded pixel sizes
+     keyed to that 735×525 design; CSS-scaling the whole thing keeps the
+     pixel art lined up exactly while filling the screen. The scale
+     factor is computed in JS (see `setupMobileScale` in main.ts) and
+     written to `--mobile-scale` because `scale()` requires a unitless
+     number — `min(100vw/735, 100vh/525)` resolves to a length and
+     fails to parse. */
+  @media (orientation: landscape) {
+    body {
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+    #app {
+      transform: scale(var(--mobile-scale, 1));
+      transform-origin: center center;
+      flex: 0 0 auto;
+    }
+  }
 }

--- a/port/web/src/main.ts
+++ b/port/web/src/main.ts
@@ -49,7 +49,27 @@ function mountReplay(replay: DailyReplay): void {
   new ReplayPanel(replay).mount(root);
 }
 
+/**
+ * Update the `--mobile-scale` CSS variable so the landscape-touch media query
+ * can apply `transform: scale(var(--mobile-scale))` to #app. CSS `scale()`
+ * requires a unitless number; `min(100vw/735, 100vh/525)` resolves to a
+ * length and silently fails to parse, so the scale factor has to be computed
+ * in JS. Idempotent and cheap; safe to run on resize/orientation change.
+ */
+function setupMobileScale(): void {
+  const APP_W = 735;
+  const APP_H = 525;
+  const update = () => {
+    const scale = Math.min(window.innerWidth / APP_W, window.innerHeight / APP_H);
+    document.documentElement.style.setProperty("--mobile-scale", String(scale));
+  };
+  update();
+  window.addEventListener("resize", update);
+  window.addEventListener("orientationchange", update);
+}
+
 async function boot(): Promise<void> {
+  setupMobileScale();
   // Load EN first so every panel that mounts can already resolve
   // `t("Key", "default")`. If EN fails to load (e.g. assets weren't prepared),
   // panels still fall back to the inline English defaults — they just don't

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -71,6 +71,14 @@ function normalizeClan(raw: string | undefined): string {
  * cosmetic + bandwidth knobs without leaving the match. Volume lives on the
  * audio singleton (which has its own persistence key); the rest live here.
  */
+/**
+ * Where the magnifier loupe floats while the player drags. The default
+ * `above` puts it directly over the finger; the corner placements pin it to
+ * one side so it never moves with the finger (useful for left-handed users
+ * or anyone whose thumb covers the loupe at the natural offset).
+ */
+type LoupePlacement = "above" | "below" | "top-left" | "top-right";
+
 interface GameSettings {
   /** Render in-game name labels above other players' balls. */
   showNames: boolean;
@@ -78,13 +86,20 @@ interface GameSettings {
   sendCursor: boolean;
   /** Render peers' aim lines from their broadcast cursor positions. */
   showPeerCursors: boolean;
+  /** Mobile-only: where the magnifier loupe is placed during a drag. */
+  loupePlacement: LoupePlacement;
+  /** Mobile-only: magnifier zoom factor. 1.5 / 2 / 3 cover the useful range. */
+  loupeZoom: number;
 }
 
 const SETTINGS_KEY = "minigolf.game.settings";
+const LOUPE_PLACEMENTS: readonly LoupePlacement[] = ["above", "below", "top-left", "top-right"] as const;
 const DEFAULT_SETTINGS: GameSettings = {
   showNames: true,
   sendCursor: true,
   showPeerCursors: true,
+  loupePlacement: "above",
+  loupeZoom: 2,
 };
 
 function loadSettings(): GameSettings {
@@ -92,11 +107,19 @@ function loadSettings(): GameSettings {
     const raw = localStorage.getItem(SETTINGS_KEY);
     if (!raw) return { ...DEFAULT_SETTINGS };
     const parsed = JSON.parse(raw);
+    const place: LoupePlacement = LOUPE_PLACEMENTS.includes(parsed.loupePlacement)
+      ? parsed.loupePlacement
+      : DEFAULT_SETTINGS.loupePlacement;
+    // Clamp the zoom even if a hand-edited localStorage carries a junk value.
+    const zoomRaw = typeof parsed.loupeZoom === "number" ? parsed.loupeZoom : DEFAULT_SETTINGS.loupeZoom;
+    const zoom = Math.max(1.2, Math.min(4, zoomRaw));
     return {
       showNames: typeof parsed.showNames === "boolean" ? parsed.showNames : DEFAULT_SETTINGS.showNames,
       sendCursor: typeof parsed.sendCursor === "boolean" ? parsed.sendCursor : DEFAULT_SETTINGS.sendCursor,
       showPeerCursors:
         typeof parsed.showPeerCursors === "boolean" ? parsed.showPeerCursors : DEFAULT_SETTINGS.showPeerCursors,
+      loupePlacement: place,
+      loupeZoom: zoom,
     };
   } catch {
     return { ...DEFAULT_SETTINGS };
@@ -332,6 +355,44 @@ export class GamePanel implements Panel {
   private mouseMoveHandler: ((ev: MouseEvent) => void) | null = null;
   private clickHandler: ((ev: MouseEvent) => void) | null = null;
   private contextMenuHandler: ((ev: MouseEvent) => void) | null = null;
+  /** Touch-input handlers for mobile drag-to-shoot. Stored so unmount can
+   *  detach them, and grouped with the magnifier-loupe element they update. */
+  private touchStartHandler: ((ev: TouchEvent) => void) | null = null;
+  private touchMoveHandler: ((ev: TouchEvent) => void) | null = null;
+  private touchEndHandler: ((ev: TouchEvent) => void) | null = null;
+  private touchCancelHandler: ((ev: TouchEvent) => void) | null = null;
+  /**
+   * Active touch-aim state. `activeTouchId` is the identifier of the touch we
+   * are tracking (so a second finger doesn't hijack the aim); `null` when no
+   * touch is in progress. `aimingByTouch` gates the aim-line render and the
+   * loupe so we don't draw a stale aim from the last finger position after
+   * release.
+   */
+  private activeTouchId: number | null = null;
+  private aimingByTouch = false;
+  /** Magnifier loupe — circular canvas floating above the finger during a
+   *  drag-to-shoot. Painted from the main canvas inside `draw()` so the
+   *  zoomed-in view always reflects the current aim line. */
+  private loupeEl: HTMLCanvasElement | null = null;
+  /** Mobile-only shoot-mode cycle button. Floats over the canvas (visible
+   *  only on touch-primary devices), shows the current `shootingMode` glyph,
+   *  and cycles 0..3 on tap — replacing the desktop right-click that's
+   *  unavailable on mobile. Created in `mount`, re-synced on every cycle. */
+  private shootModeBtnEl: HTMLButtonElement | null = null;
+  /** Last touch position in viewport coords — used to position the loupe. */
+  private touchClientX = 0;
+  private touchClientY = 0;
+  /**
+   * Cached "is this a phone/tablet" check via the standard touch-primary
+   * media query. On `true`, the aim line and cursor broadcasts are gated on
+   * an active touch — otherwise mouseX/Y starts at (0,0) and the aim line
+   * would point to the top-left corner before the user has even tapped.
+   * Desktop browsers (`hover: hover`) keep the always-visible aim line.
+   */
+  private isTouchPrimary =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(hover: none) and (pointer: coarse)").matches;
   /** Toggleable user prefs (names, cursor send/recv) — persisted via localStorage. */
   private settings: GameSettings = loadSettings();
   private settingsMenuEl: HTMLElement | null = null;
@@ -385,6 +446,25 @@ export class GamePanel implements Panel {
     canvas.width = 735;
     canvas.height = 375;
     frame.appendChild(canvas);
+
+    // Mobile-only shoot-mode cycle button. Lives inside `.canvas-frame` so it
+    // scales with the canvas under the landscape `transform: scale()`. CSS
+    // hides it outside touch-primary devices, so it's invisible on desktop
+    // while still being instantiated unconditionally (keeps the lifecycle
+    // simple and avoids feature-detect branching on mount).
+    const shootModeBtn = document.createElement("button");
+    shootModeBtn.type = "button";
+    shootModeBtn.className = "shoot-mode-btn";
+    shootModeBtn.setAttribute("aria-label", "Shooting mode");
+    shootModeBtn.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.cycleShootingMode();
+    });
+    frame.appendChild(shootModeBtn);
+    this.shootModeBtnEl = shootModeBtn;
+    this.refreshShootModeBtn();
+
     wrap.appendChild(frame);
 
     const bottomBand = document.createElement("div");
@@ -580,11 +660,7 @@ export class GamePanel implements Panel {
       // is gated on the same "ball at rest" condition as a shot.
       if (ev.button !== 0) {
         ev.preventDefault();
-        this.shootingMode = (this.shootingMode + 1) % 4;
-        // Force the next cursor sample through the throttle so peers see the
-        // new orientation immediately, even if the cursor is stationary.
-        this.lastCursorSentX = -9999;
-        this.lastCursorSentY = -9999;
+        this.cycleShootingMode();
         return;
       }
       const [mx, my] = localCoords(ev);
@@ -612,6 +688,100 @@ export class GamePanel implements Panel {
     canvas.addEventListener("contextmenu", contextMenuHandler);
     this.contextMenuHandler = contextMenuHandler;
 
+    // ----- touch input (drag-to-shoot, mobile) ---------------------------
+    // Mirrors the mouse pipeline: touchstart/move set mouseX/Y so the existing
+    // aim-line render and cursor broadcast already work; touchend triggers the
+    // same beginstroke send as a click. preventDefault on touchstart suppresses
+    // iOS's synthesized 300 ms-later mousedown/click that would otherwise fire
+    // a *second* shot.
+    const localCoordsTouch = (t: Touch): [number, number] => {
+      const rect = canvas.getBoundingClientRect();
+      const sx = canvas.width / Math.max(rect.width, 1);
+      const sy = canvas.height / Math.max(rect.height, 1);
+      return [(t.clientX - rect.left) * sx, (t.clientY - rect.top) * sy];
+    };
+
+    // Larger no-shot deadzone for touch than for the 6.5 px mouse threshold:
+    // touch precision is ~10–30 screen px which lands as ~14–42 canvas px
+    // after the landscape-fit downscale. Anything below this counts as a
+    // tap-on-ball cancel rather than a tiny accidental nudge.
+    const TOUCH_SHOT_DEADZONE = 14;
+
+    const touchStartHandler = (ev: TouchEvent) => {
+      // Only track if there is no active touch — multi-finger doesn't aim.
+      if (this.activeTouchId !== null) return;
+      if (ev.changedTouches.length === 0) return;
+      ev.preventDefault();
+      const t = ev.changedTouches[0];
+      this.activeTouchId = t.identifier;
+      const [mx, my] = localCoordsTouch(t);
+      this.mouseX = mx;
+      this.mouseY = my;
+      this.touchClientX = t.clientX;
+      this.touchClientY = t.clientY;
+      this.aimingByTouch = true;
+      this.showLoupe();
+    };
+    canvas.addEventListener("touchstart", touchStartHandler, { passive: false });
+    this.touchStartHandler = touchStartHandler;
+
+    const findActiveTouch = (list: TouchList): Touch | null => {
+      if (this.activeTouchId === null) return null;
+      for (let i = 0; i < list.length; i++) {
+        if (list[i].identifier === this.activeTouchId) return list[i];
+      }
+      return null;
+    };
+
+    const touchMoveHandler = (ev: TouchEvent) => {
+      const t = findActiveTouch(ev.changedTouches);
+      if (!t) return;
+      ev.preventDefault();
+      const [mx, my] = localCoordsTouch(t);
+      this.mouseX = mx;
+      this.mouseY = my;
+      this.touchClientX = t.clientX;
+      this.touchClientY = t.clientY;
+    };
+    canvas.addEventListener("touchmove", touchMoveHandler, { passive: false });
+    this.touchMoveHandler = touchMoveHandler;
+
+    const touchEndHandler = (ev: TouchEvent) => {
+      const t = findActiveTouch(ev.changedTouches);
+      if (!t) return;
+      ev.preventDefault();
+      const [mx, my] = localCoordsTouch(t);
+      this.activeTouchId = null;
+      this.aimingByTouch = false;
+      this.hideLoupe();
+      // Mirror the mousedown shoot path. Same gating: ball must be at rest.
+      const me = this.players[this.myPlayerId];
+      if (!me || me.ball.inHole || me.simulating) return;
+      const dx = me.ball.x - mx;
+      const dy = me.ball.y - my;
+      if (Math.sqrt(dx * dx + dy * dy) < TOUCH_SHOT_DEADZONE) return;
+      const ix = (me.ball.x | 0);
+      const iy = (me.ball.y | 0);
+      this.app.connection.sendData(
+        "game",
+        "beginstroke",
+        encodeCoords(ix, iy, 0) + "\t" + encodeCoords((mx | 0), (my | 0), this.shootingMode),
+      );
+    };
+    canvas.addEventListener("touchend", touchEndHandler, { passive: false });
+    this.touchEndHandler = touchEndHandler;
+
+    const touchCancelHandler = (ev: TouchEvent) => {
+      // OS interruption (notification, system gesture) — abort the aim.
+      const t = findActiveTouch(ev.changedTouches);
+      if (!t) return;
+      this.activeTouchId = null;
+      this.aimingByTouch = false;
+      this.hideLoupe();
+    };
+    canvas.addEventListener("touchcancel", touchCancelHandler);
+    this.touchCancelHandler = touchCancelHandler;
+
     void loadAtlases().then((atl) => {
       this.atlases = atl;
       this.setStatus(t("Port_Game_WaitingForTrack", "Waiting for track…"));
@@ -638,11 +808,26 @@ export class GamePanel implements Panel {
       if (this.mouseMoveHandler) this.canvas.removeEventListener("mousemove", this.mouseMoveHandler);
       if (this.clickHandler) this.canvas.removeEventListener("mousedown", this.clickHandler);
       if (this.contextMenuHandler) this.canvas.removeEventListener("contextmenu", this.contextMenuHandler);
+      if (this.touchStartHandler) this.canvas.removeEventListener("touchstart", this.touchStartHandler);
+      if (this.touchMoveHandler) this.canvas.removeEventListener("touchmove", this.touchMoveHandler);
+      if (this.touchEndHandler) this.canvas.removeEventListener("touchend", this.touchEndHandler);
+      if (this.touchCancelHandler) this.canvas.removeEventListener("touchcancel", this.touchCancelHandler);
     }
     this.keyHandler = null;
     this.mouseMoveHandler = null;
     this.clickHandler = null;
     this.contextMenuHandler = null;
+    this.touchStartHandler = null;
+    this.touchMoveHandler = null;
+    this.touchEndHandler = null;
+    this.touchCancelHandler = null;
+    this.activeTouchId = null;
+    this.aimingByTouch = false;
+    if (this.loupeEl && this.loupeEl.parentNode) {
+      this.loupeEl.parentNode.removeChild(this.loupeEl);
+    }
+    this.loupeEl = null;
+    this.shootModeBtnEl = null;
     this.canvas = null;
     this.scoreboardEl = null;
     this.statusEl = null;
@@ -1039,6 +1224,7 @@ export class GamePanel implements Panel {
       // there's no per-turn boundary, so reset on every track change so a
       // mode picked on the previous hole doesn't leak into the new one.
       this.shootingMode = 0;
+      this.refreshShootModeBtn();
 
       const author = extractField(f, "A ") ?? "";
       const name = extractField(f, "N ") ?? "";
@@ -1156,7 +1342,10 @@ export class GamePanel implements Panel {
     // Java parity: shootingMode resets after the shot is taken. The shooter's
     // server echo is the trigger here so the reset survives any local race
     // with a right-click made between sending the click and the echo.
-    if (id === this.myPlayerId) this.shootingMode = 0;
+    if (id === this.myPlayerId) {
+      this.shootingMode = 0;
+      this.refreshShootModeBtn();
+    }
     // Record OUR strokes when in daily mode for the share-link replay. Stored
     // raw (4-char base36 coords + uint32 seed) so encoding the link is just a
     // straight JSON pack — no further processing needed.
@@ -1216,6 +1405,9 @@ export class GamePanel implements Panel {
     const me = this.players[this.myPlayerId];
     if (!me) return;
     if (me.simulating || me.ball.inHole || me.holedThisTrack || me.forfeitedThisTrack) return;
+    // Touch devices: only broadcast while actively aiming, otherwise peers
+    // would see a frozen aim line at our last finger position.
+    if (this.isTouchPrimary && !this.aimingByTouch) return;
     if (nowMs - this.lastCursorSentMs < 66) return; // 15 Hz cap
     const cx = this.mouseX | 0;
     const cy = this.mouseY | 0;
@@ -1589,7 +1781,11 @@ export class GamePanel implements Panel {
     }
     let aim: AimLine | null = null;
     const me = this.players[this.myPlayerId];
-    if (me && !me.ball.inHole && !me.simulating) {
+    // On touch-primary devices the aim line only shows while a finger is
+    // actively dragging — without this gate, mouseX/Y stays at the last
+    // touch point (or the initial 0,0) and we'd render a stale/origin aim.
+    const aimSuppressedByTouch = this.isTouchPrimary && !this.aimingByTouch;
+    if (me && !me.ball.inHole && !me.simulating && !aimSuppressedByTouch) {
       aim = {
         fromX: me.ball.x,
         fromY: me.ball.y,
@@ -1683,6 +1879,158 @@ export class GamePanel implements Panel {
       }
     }
     this.renderer.drawFrame(ctx, sprites, aim, peerAims);
+    // Update the magnifier loupe AFTER the renderer has painted this frame,
+    // so the zoomed-in copy includes the just-drawn aim line. Sampling in a
+    // touchmove callback would lag the aim line by one frame.
+    if (this.aimingByTouch) this.drawLoupe();
+  }
+
+  // ----- magnifier loupe (mobile) ---------------------------------------
+
+  /**
+   * Mount the loupe canvas on first use and tag it visible. The element lives
+   * directly under <body> (position: fixed) so the landscape transform on
+   * #app doesn't affect its size — we want a constant 120 px circle floating
+   * over the finger regardless of the global scale factor.
+   */
+  private showLoupe(): void {
+    if (!this.loupeEl) {
+      const el = document.createElement("canvas");
+      el.className = "aim-loupe";
+      el.width = 120;
+      el.height = 120;
+      document.body.appendChild(el);
+      this.loupeEl = el;
+    }
+    this.loupeEl.classList.add("is-visible");
+    // Position immediately so the loupe doesn't pop in at (0,0); content gets
+    // painted on the next draw() tick.
+    this.positionLoupe();
+  }
+
+  private hideLoupe(): void {
+    if (this.loupeEl) this.loupeEl.classList.remove("is-visible");
+  }
+
+  /**
+   * Place the loupe according to the user's `loupePlacement` setting:
+   *  - `above` / `below`: track the finger with a 110 px offset; the
+   *    fallback flip happens automatically when the finger is too close to
+   *    the screen edge in that direction.
+   *  - `top-left` / `top-right`: pin to a viewport corner so the loupe never
+   *    moves with the finger (useful when the finger position is fine but
+   *    the user wants the magnified view in a stable spot).
+   *  All variants are clamped to stay fully on screen.
+   */
+  private positionLoupe(): void {
+    if (!this.loupeEl) return;
+    const size = 120;
+    const margin = 8;
+    const fingerGap = 110;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let left = 0;
+    let top = 0;
+    switch (this.settings.loupePlacement) {
+      case "top-left":
+        left = margin;
+        top = margin;
+        break;
+      case "top-right":
+        left = vw - margin - size;
+        top = margin;
+        break;
+      case "below":
+        left = this.touchClientX - size / 2;
+        top = this.touchClientY + fingerGap;
+        // Flip up if there's no room below.
+        if (top + size > vh - margin) top = this.touchClientY - fingerGap - size;
+        break;
+      case "above":
+      default:
+        left = this.touchClientX - size / 2;
+        top = this.touchClientY - fingerGap - size;
+        // Flip down if there's no room above.
+        if (top < margin) top = this.touchClientY + fingerGap;
+        break;
+    }
+    // Viewport clamp common to all placements.
+    if (left < margin) left = margin;
+    if (left + size > vw - margin) left = vw - margin - size;
+    if (top < margin) top = margin;
+    if (top + size > vh - margin) top = vh - margin - size;
+    this.loupeEl.style.left = `${left}px`;
+    this.loupeEl.style.top = `${top}px`;
+  }
+
+  /** Sample around the touch point on the main canvas into the 120×120 loupe
+   *  canvas at the user's chosen zoom factor, with a crosshair overlay
+   *  marking the exact aim point. */
+  private drawLoupe(): void {
+    if (!this.loupeEl || !this.canvas) return;
+    this.positionLoupe();
+    const lctx = this.loupeEl.getContext("2d");
+    if (!lctx) return;
+    // Source region size = loupe size / zoom. Smaller source = stronger zoom.
+    const zoom = this.settings.loupeZoom;
+    const sampleSize = Math.round(120 / zoom);
+    const sx = Math.round(this.mouseX - sampleSize / 2);
+    const sy = Math.round(this.mouseY - sampleSize / 2);
+    lctx.imageSmoothingEnabled = false;
+    lctx.fillStyle = "#99ff99";
+    lctx.fillRect(0, 0, 120, 120);
+    lctx.drawImage(
+      this.canvas,
+      sx, sy, sampleSize, sampleSize,
+      0, 0, 120, 120,
+    );
+    // Crosshair at the loupe centre — marks the exact aim point under the
+    // finger. Two short red strokes with a 6 px gap so the actual pixel of
+    // interest stays visible.
+    lctx.strokeStyle = "rgba(255, 30, 30, 0.95)";
+    lctx.lineWidth = 2;
+    lctx.beginPath();
+    lctx.moveTo(60, 44); lctx.lineTo(60, 56);
+    lctx.moveTo(60, 64); lctx.lineTo(60, 76);
+    lctx.moveTo(44, 60); lctx.lineTo(56, 60);
+    lctx.moveTo(64, 60); lctx.lineTo(76, 60);
+    lctx.stroke();
+  }
+
+  // ----- shoot-mode cycle (mobile parity for desktop right-click) ------
+
+  /**
+   * Cycle shootingMode through 0..3 (normal → reverse → 90° CW → 90° CCW)
+   * and force the next peer-cursor packet through the throttle so watchers
+   * see the new orientation immediately even if the cursor is stationary.
+   * Called from the desktop right-click path AND the mobile in-canvas
+   * shoot-mode button — both go through here so the button glyph and the
+   * cursor broadcast stay in lockstep.
+   */
+  private cycleShootingMode(): void {
+    this.shootingMode = (this.shootingMode + 1) % 4;
+    this.lastCursorSentX = -9999;
+    this.lastCursorSentY = -9999;
+    this.refreshShootModeBtn();
+  }
+
+  /** Update the mobile shoot-mode button glyph + a11y label to match the
+   *  current `shootingMode`. Cheap; safe to call on every cycle/reset. */
+  private refreshShootModeBtn(): void {
+    if (!this.shootModeBtnEl) return;
+    // Glyph picks: a clear-direction-of-aim icon for each mode. The unicode
+    // arrows render reliably at small size and don't need a sprite.
+    const glyphs = ["→", "←", "↻", "↺"];
+    const labels = [
+      "Normal aim",
+      "Reverse aim",
+      "Rotate 90° clockwise",
+      "Rotate 90° counter-clockwise",
+    ];
+    const i = this.shootingMode | 0;
+    this.shootModeBtnEl.textContent = glyphs[i] ?? glyphs[0];
+    this.shootModeBtnEl.setAttribute("aria-label", labels[i] ?? labels[0]);
+    this.shootModeBtnEl.setAttribute("data-mode", String(i));
   }
 
   // ----- game-end overlay -----------------------------------------------
@@ -2077,6 +2425,90 @@ export class GamePanel implements Panel {
         saveSettings(this.settings);
       },
     );
+
+    // Mobile-only loupe controls. Hidden on desktop where there's no
+    // magnifier in play; appended in a divider'd block so the rest of the
+    // menu still reads as the existing AWT-style settings list.
+    if (this.isTouchPrimary) {
+      const sep = document.createElement("div");
+      sep.style.borderTop = "1px solid #ddd";
+      sep.style.margin = "4px 0 2px";
+      menu.appendChild(sep);
+
+      const heading = document.createElement("div");
+      heading.textContent = t("Port_Game_Menu_MobileSection", "Mobile controls");
+      heading.style.fontWeight = "bold";
+      heading.style.padding = "2px 0";
+      menu.appendChild(heading);
+
+      // Loupe placement — radio-style segmented row. Picking a value
+      // immediately persists; the next touch-drag uses the new placement.
+      const placeRow = document.createElement("div");
+      placeRow.style.display = "flex";
+      placeRow.style.alignItems = "center";
+      placeRow.style.gap = "6px";
+      placeRow.style.padding = "2px 0";
+      const placeLabel = document.createElement("span");
+      placeLabel.textContent = t("Port_Game_Menu_LoupePlacement", "Loupe");
+      placeLabel.style.minWidth = "48px";
+      placeRow.appendChild(placeLabel);
+      const placeSelect = document.createElement("select");
+      const placeOpts: Array<[LoupePlacement, string]> = [
+        ["above", t("Port_Game_Menu_LoupeAbove", "Above finger")],
+        ["below", t("Port_Game_Menu_LoupeBelow", "Below finger")],
+        ["top-left", t("Port_Game_Menu_LoupeTopLeft", "Top-left corner")],
+        ["top-right", t("Port_Game_Menu_LoupeTopRight", "Top-right corner")],
+      ];
+      for (const [value, label] of placeOpts) {
+        const opt = document.createElement("option");
+        opt.value = value;
+        opt.textContent = label;
+        if (this.settings.loupePlacement === value) opt.selected = true;
+        placeSelect.appendChild(opt);
+      }
+      placeSelect.style.flex = "1";
+      placeSelect.addEventListener("change", () => {
+        const v = placeSelect.value as LoupePlacement;
+        if (LOUPE_PLACEMENTS.includes(v)) {
+          this.settings.loupePlacement = v;
+          saveSettings(this.settings);
+        }
+      });
+      placeRow.appendChild(placeSelect);
+      menu.appendChild(placeRow);
+
+      // Loupe zoom — range slider. Steps of 0.25 cover 1.5×–3× cleanly.
+      const zoomRow = document.createElement("div");
+      zoomRow.style.display = "flex";
+      zoomRow.style.alignItems = "center";
+      zoomRow.style.gap = "6px";
+      zoomRow.style.padding = "2px 0";
+      const zoomLabel = document.createElement("span");
+      zoomLabel.textContent = t("Port_Game_Menu_LoupeZoom", "Zoom");
+      zoomLabel.style.minWidth = "48px";
+      zoomRow.appendChild(zoomLabel);
+      const zoomSlider = document.createElement("input");
+      zoomSlider.type = "range";
+      zoomSlider.className = "win98-slider";
+      zoomSlider.min = "1.2";
+      zoomSlider.max = "4";
+      zoomSlider.step = "0.1";
+      zoomSlider.value = String(this.settings.loupeZoom);
+      zoomSlider.style.flex = "1";
+      const zoomValue = document.createElement("span");
+      zoomValue.style.minWidth = "30px";
+      zoomValue.style.textAlign = "right";
+      zoomValue.textContent = `${this.settings.loupeZoom.toFixed(1)}×`;
+      zoomSlider.addEventListener("input", () => {
+        const v = zoomSlider.valueAsNumber;
+        this.settings.loupeZoom = v;
+        zoomValue.textContent = `${v.toFixed(1)}×`;
+        saveSettings(this.settings);
+      });
+      zoomRow.appendChild(zoomSlider);
+      zoomRow.appendChild(zoomValue);
+      menu.appendChild(zoomRow);
+    }
 
     // Volume slider — moved here from the bottom strip.
     const volRow = document.createElement("div");


### PR DESCRIPTION
…oupe

Adds touch input alongside the existing mouse pipeline so phones and tablets can play in landscape. Portrait mode shows a Finnish "Käännä puhelin sivuttain" prompt with a CSS-drawn rotating phone + golf ball animation in the game's green theme. Drag-to-shoot mirrors the desktop click-to-shoot semantics: finger position is the aim target, lift triggers the same `beginstroke` send, with `preventDefault` on touchstart to suppress iOS's synthesized mousedown that would otherwise fire a second shot. A 14 px deadzone (vs 6.5 for mouse) absorbs touch imprecision so a tap on the ball doesn't register as a stroke.

A magnifier loupe floats above the finger during a drag, painted from the main canvas inside the existing RAF draw() loop so the zoomed view stays in lockstep with the aim line. New mobile-only Valikko rows let the user pick the loupe placement (above / below / top-left / top-right corner) and zoom level (1.2× – 4×); both persist via the existing settings blob.

A 44×44 in-canvas button replaces the desktop right-click for cycling shootingMode 0..3, with glyph + tint reflecting the current mode. Both input paths share a `cycleShootingMode` helper so reset points keep the button glyph in sync.