### PR TITLE
Port: treat absent S line as "all visible" so magnets render again

### DIFF
--- a/port/docs/KNOWN_ISSUES.md
+++ b/port/docs/KNOWN_ISSUES.md
@@ -99,11 +99,13 @@ A few non-obvious pitfalls when modifying things:
   watch out.
 - **`networkSerialize` has a port-specific addition.** It now includes a
   `C <categories>` line that Java's `FileSystemTrackStats.networkSerialize`
-  doesn't emit, plus an `S <settings>` line that the Java server also
-  omitted (the Java client never honored these flags because of a parser
-  typo on the receiving side - see `parseSettingsFlags` in
+  doesn't emit, plus an optional `S <settings>` line that the Java server
+  also omitted (the Java client never honored these flags because of a
+  parser typo on the receiving side - see `parseSettingsFlags` in
   `shared/src/track.ts`). Clients use C for the in-game tag chips and S
-  for tile-visibility / illusion-shadow rendering. If you ever cross-test
+  for tile-visibility / illusion-shadow rendering. The S line is only
+  shipped when the source track file actually has one; absent S means
+  "all visible" on the client (the editor's view). If you ever cross-test
   against a real Java client, expect it to ignore both lines (it scans
   for known prefixes only).
 - **The shooter waits for the server broadcast.** Don't optimize the

--- a/port/docs/PROTOCOL.md
+++ b/port/docs/PROTOCOL.md
@@ -145,8 +145,12 @@ The `B` line is omitted if `bestPar < 0`. The `C` and `S` lines are OUR port
 extensions - Java doesn't include them. `S` carries the four-flag visibility
 string (`mines/magnets/teleports/illusion-shadows`, plus the legacy 2-digit
 player-range suffix); use `parseSettingsFlags` from `@minigolf/shared` to
-decode the first four chars. Use `extractField(fields, "C ")` /
-`extractField(fields, "S ")` on the client.
+decode the first four chars. The `S` line is only shipped when the track file
+actually has one (~8% of stock tracks); when absent, the client falls back to
+`ALL_VISIBLE_FLAGS` so mines and magnets render the way they look in the
+editor. Use `extractField(fields, "C ")` / `extractField(fields, "S ")` on
+the client and treat a `null` return from the latter as "no settings - default
+visible".
 
 ## Game info packet (15 fields)
 

--- a/port/server/src/test-s-line.ts
+++ b/port/server/src/test-s-line.ts
@@ -1,7 +1,7 @@
-// Smoke check for issue #27 - confirms `S <settings>` rides along in the
-// `game starttrack` payload so the client renderer can apply mine/magnet/
-// teleport visibility + illusion-shadow flags. Reuses the test-fullflow
-// handshake up to starttrack and asserts on the new field.
+// Smoke check for issue #27 - confirms the `game starttrack` payload carries
+// either no S field (track had no S line; client defaults to all visible) or
+// an S field with a parseable body. Reuses the test-fullflow handshake up to
+// starttrack and asserts shape, not presence (since most stock tracks omit S).
 //
 // Usage: WS_URL=ws://localhost:4274/ws node --experimental-strip-types
 //        --no-warnings src/test-s-line.ts
@@ -74,17 +74,22 @@ if (!tField) {
     console.error("FAIL: no T line");
     process.exit(1);
 }
-if (!sField) {
-    console.error("FAIL: no S line in starttrack frame - issue #27 fix incomplete");
-    process.exit(1);
+// S line is optional now: the server only ships it when the track file
+// actually declares one. ~92% of stock tracks have no S line, in which case
+// the client falls back to all-visible flags. When the field IS present, the
+// body is "<flags>" or "<flags><minPlayers><maxPlayers>" (e.g. "tttt14") -
+// `parseTrack` / `parseSettingsFlags` cover the value side in unit tests.
+if (sField) {
+    const sBody = sField.substring(2);
+    if (sBody.length < 4) {
+        console.error(`FAIL: S body too short to carry 4 flags: ${JSON.stringify(sBody)}`);
+        process.exit(1);
+    }
+    console.log("starttrack:", { hasT: true, hasC: !!cField, hasS: true, sBody, sBodyLen: sBody.length });
+    console.log(`OK: S line shipped (body=${JSON.stringify(sBody)}, len=${sBody.length})`);
+} else {
+    console.log("starttrack:", { hasT: true, hasC: !!cField, hasS: false });
+    console.log("OK: no S line (track had none; client defaults to all visible)");
 }
-const sBody = sField.substring(2);
-// The body itself is "ffff" for the ~93% of stock tracks without an explicit
-// S declaration and "<flags><minPlayers><maxPlayers>" (e.g. "tttt14") for the
-// ones that do. We just assert the line IS shipped - `parseTrack` /
-// `parseSettingsFlags` are unit-tested against real track files in
-// shared/src/track.test.ts so the value side is covered there.
-console.log("starttrack:", { hasT: true, hasC: !!cField, hasS: true, sBody, sBodyLen: sBody.length });
-console.log(`OK: S line shipped (body=${JSON.stringify(sBody)}, len=${sBody.length})`);
 ws.close();
 process.exit(0);

--- a/port/server/src/tracks.ts
+++ b/port/server/src/tracks.ts
@@ -94,18 +94,30 @@ export function networkSerialize(stats: TrackStats): string {
     // shadow). Java's networkSerialize omits this - combined with the buggy
     // `length() != 6` skip in VersionedTrackFileParser the original client
     // never honored S at all. The port forwards the raw S body so the renderer
-    // can apply it. Empty string when the track file has no S line; the client
-    // treats that as all-false (Java parser default).
-    const sLine = "S " + (t.settings ?? "");
+    // can apply it. We only emit when the track file actually has an S line:
+    // an absent S means "default to all visible" on the client (matches the
+    // editor preview), while a present "S ffff" means "explicitly hide
+    // everything". Eliding the line for the common no-S case is what restores
+    // mine/magnet visibility on stock tracks.
+    const sLine = t.settings ? "S " + t.settings : null;
+    const lines = [
+        "V 1",
+        "A " + t.author,
+        "N " + t.name,
+        "T " + t.map,
+        cLine,
+        ...(sLine ? [sLine] : []),
+        iLine,
+    ];
 
     if (stats.bestPar < 0) {
-        return tabularize("V 1", "A " + t.author, "N " + t.name, "T " + t.map, cLine, sLine, iLine, rLine);
+        return tabularize(...lines, rLine);
     }
 
     const bestPlayer = stats.bestPlayer ?? "";
     const bestEpoch = stats.bestParEpoch ?? 0;
     const bLine = "B " + commaize(bestPlayer, bestEpoch);
-    return tabularize("V 1", "A " + t.author, "N " + t.name, "T " + t.map, cLine, sLine, iLine, bLine, rLine);
+    return tabularize(...lines, bLine, rLine);
 }
 
 /**

--- a/port/server/src/verify-magnets.ts
+++ b/port/server/src/verify-magnets.ts
@@ -1,0 +1,127 @@
+// One-off verification: spin up a single-player game, force-decode the
+// starttrack frame for each random track until one with magnet shapes
+// (raw 20/21) appears. Print whether the S line was shipped and what the
+// renderer will do with it. Used after the "absent S = all visible" fix to
+// confirm magnet tracks no longer have their magnets clobbered to plain bg.
+//
+// Usage: WS_URL=ws://localhost:4330/ws node --experimental-strip-types
+//        --no-warnings src/verify-magnets.ts
+import { WebSocket } from "ws";
+import { decodeMap, unpackTile, parseSettingsFlags, ALL_VISIBLE_FLAGS, applySettingsToTileCode } from "@minigolf/shared";
+
+const URL = process.env.WS_URL ?? "ws://localhost:4330/ws";
+const MAX_ATTEMPTS = 30;
+
+const ws = new WebSocket(URL);
+const recv: string[] = [];
+let outSeq = 0;
+
+function sendData(...fields: (string | number)[]): void {
+    ws.send(`d ${outSeq++} ${fields.join("\t")}`);
+}
+function sendCommand(verb: string, ...args: string[]): void {
+    ws.send(`c ${[verb, ...args].join(" ")}`);
+}
+function awaitFrame(predicate: (s: string) => boolean, label: string, timeoutMs = 5000): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error(`timeout waiting for ${label}`)), timeoutMs);
+        const tick = (): void => {
+            const idx = recv.findIndex(predicate);
+            if (idx >= 0) {
+                clearTimeout(t);
+                const [s] = recv.splice(idx, 1);
+                resolve(s);
+                return;
+            }
+            setTimeout(tick, 25);
+        };
+        tick();
+    });
+}
+
+ws.on("message", (raw) => recv.push(raw.toString()));
+ws.on("error", (e) => { console.error("ws error:", e); process.exit(2); });
+
+await new Promise<void>((r) => ws.once("open", () => r()));
+
+await awaitFrame((s) => s === "h 1", "h 1");
+await awaitFrame((s) => s.startsWith("c crt"), "c crt");
+await awaitFrame((s) => s === "c ctr", "c ctr");
+sendCommand("new");
+await awaitFrame((s) => s.startsWith("c id "), "c id");
+sendData("version", 35);
+await awaitFrame((s) => /^d \d+ status\tlogin$/.test(s), "status login");
+sendData("language", "en");
+sendData("logintype", "nr");
+await awaitFrame((s) => /^d \d+ status\tlogin$/.test(s), "status login (post-logintype)");
+sendData("login");
+await awaitFrame((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+await awaitFrame((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+sendData("lobbyselect", "select", 1);
+await awaitFrame((s) => /^d \d+ status\tlobby\t1/.test(s), "status lobby 1");
+await awaitFrame((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+
+let attempt = 0;
+let foundMagnet = false;
+while (attempt++ < MAX_ATTEMPTS && !foundMagnet) {
+    if (attempt === 1) {
+        sendData("lobby", "cspt", 1, 0, 0); // category=ALL(1), tracks=1, water=0
+    } else {
+        // Skip current track to get the next random one. The single-track game
+        // ends after a forfeit and we re-create. Simpler: just disconnect and
+        // reconnect would double-loop; let's just request another single-shot.
+        sendData("game", "back"); // back to lobby
+        await awaitFrame((s) => /status\tlobby\t1/.test(s) || /lobby\townjoin/.test(s), "back to lobby", 5000).catch(() => null);
+        sendData("lobby", "cspt", 1, 0, 0);
+    }
+
+    const startFrame = await awaitFrame((s) => /^d \d+ game\tstarttrack\t/.test(s), `starttrack#${attempt}`, 8000);
+    const fields = startFrame.split("\t");
+    const nField = fields.find((f) => f.startsWith("N "));
+    const sField = fields.find((f) => f.startsWith("S "));
+    const tField = fields.find((f) => f.startsWith("T "));
+    if (!tField) continue;
+
+    const name = nField?.slice(2) ?? "(unnamed)";
+    const sBody = sField?.slice(2) ?? null;
+    const flags = sBody === null ? ALL_VISIBLE_FLAGS : parseSettingsFlags(sBody);
+    const map = decodeMap(tField.slice(2));
+
+    let magnetCount = 0;
+    let visibleAfterApply = 0;
+    for (let y = 0; y < map.length; y++) {
+        const row = map[y];
+        for (let x = 0; x < row.length; x++) {
+            const code = row[x];
+            const u = unpackTile(code);
+            // unpackTile.shape is the RAW byte (Java's shape - 24).
+            // Magnets are raw 20/21; matches applySettingsToTileCode's check.
+            if (u.isNoSpecial === 2 && (u.shape === 20 || u.shape === 21)) {
+                magnetCount++;
+                const after = applySettingsToTileCode(code, flags);
+                if (after === code) visibleAfterApply++;
+            }
+        }
+    }
+
+    console.log(`[${attempt}] name=${JSON.stringify(name)} S=${sBody === null ? "(absent)" : JSON.stringify(sBody)} flags=${JSON.stringify(flags)} magnets=${magnetCount} stillVisible=${visibleAfterApply}`);
+    if (magnetCount > 0) {
+        if (visibleAfterApply === magnetCount) {
+            console.log(`OK: ${magnetCount} magnets render visibly on "${name}"`);
+            foundMagnet = true;
+        } else {
+            console.error(`FAIL: ${magnetCount - visibleAfterApply} of ${magnetCount} magnets are hidden on "${name}" (S=${JSON.stringify(sBody)})`);
+            ws.close();
+            process.exit(1);
+        }
+    }
+}
+
+if (!foundMagnet) {
+    console.error(`FAIL: scanned ${MAX_ATTEMPTS} random tracks, none had magnets - inconclusive`);
+    ws.close();
+    process.exit(1);
+}
+
+ws.close();
+process.exit(0);

--- a/port/shared/src/index.ts
+++ b/port/shared/src/index.ts
@@ -28,6 +28,7 @@ export {
     type TrackSetDifficulty,
     type SettingsFlags,
     NO_SETTINGS_FLAGS,
+    ALL_VISIBLE_FLAGS,
     parseTrack,
     parseTrackset,
     parseSettingsFlags,

--- a/port/shared/src/track.test.ts
+++ b/port/shared/src/track.test.ts
@@ -40,7 +40,10 @@ describe("parseTrack - defaults for missing optional lines", () => {
     it("returns defaults when only required lines are present", () => {
         const text = ["V 2", "A x", "N y", "T BAQQ"].join("\n");
         const track = parseTrack(text);
-        assert.equal(track.settings, "ffff");
+        // Empty string is the "no S line was present" sentinel - distinct from
+        // an explicit "S ffff" body and used by `networkSerialize` to decide
+        // whether to ship the S line at all.
+        assert.equal(track.settings, "");
         assert.equal(track.plays, 0);
         assert.equal(track.bestPar, -1);
         assert.deepEqual(track.categories, []);

--- a/port/shared/src/track.ts
+++ b/port/shared/src/track.ts
@@ -9,7 +9,13 @@ export interface Track {
     map: string;
     /** Parsed from C line as integer ids (e.g. [3], [1,2]). Empty if no C line. */
     categories: number[];
-    /** 4-character flag string ("ttff" etc). Default "ffff" if missing. */
+    /**
+     * Raw S-line body when the track file declares one (e.g. "tttt", "fttf14").
+     * Empty string when the track has no S line at all - distinct from an
+     * explicit "ffff" because the renderer treats "absent" as "all visible"
+     * (matches what the editor preview shows the creator) while "ffff" means
+     * "explicitly hide everything".
+     */
     settings: string;
     plays: number;
     strokes: number;
@@ -31,7 +37,9 @@ export interface TrackSet {
     trackNames: string[];
 }
 
-const DEFAULT_SETTINGS = "ffff";
+// Empty - we no longer fabricate "ffff" for tracks that lack an S line. See
+// the comment on `Track.settings` for the absent-vs-explicit-ffff distinction.
+const DEFAULT_SETTINGS = "";
 
 /**
  * Four boolean flags decoded from a track's `S` line. Indexes mirror Java's
@@ -44,6 +52,15 @@ const DEFAULT_SETTINGS = "ffff";
 export type SettingsFlags = readonly [boolean, boolean, boolean, boolean];
 
 export const NO_SETTINGS_FLAGS: SettingsFlags = [false, false, false, false];
+
+/**
+ * Default flags used when a track has no S line at all. We treat "no S line" as
+ * "everything visible" so that mines/magnets/teleports render the way they
+ * appear in the track editor (the creator's intent). This deliberately
+ * diverges from Java's runtime, which - thanks to the `length() != 6` parser
+ * typo - silently rendered most tracks with mines and magnets hidden.
+ */
+export const ALL_VISIBLE_FLAGS: SettingsFlags = [true, true, true, true];
 
 /**
  * Decode the first 4 chars of an S-line body into the boolean flag array.

--- a/port/web/src/game/render.ts
+++ b/port/web/src/game/render.ts
@@ -13,7 +13,7 @@ import {
   PIXEL_PER_TILE,
   MAP_PIXEL_WIDTH,
   MAP_PIXEL_HEIGHT,
-  NO_SETTINGS_FLAGS,
+  ALL_VISIBLE_FLAGS,
   applySettingsToTileCode,
   type SettingsFlags,
   unpackTile,
@@ -177,7 +177,7 @@ export class TrackRenderer {
    * point of the flags as a puzzle-design knob.
    */
   private settingsFlags: SettingsFlags;
-  constructor(parsedMap: ParsedMap, atlases: Atlases, settingsFlags: SettingsFlags = NO_SETTINGS_FLAGS) {
+  constructor(parsedMap: ParsedMap, atlases: Atlases, settingsFlags: SettingsFlags = ALL_VISIBLE_FLAGS) {
     this.parsedMap = parsedMap;
     this.atlases = atlases;
     this.settingsFlags = settingsFlags;

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -1,4 +1,4 @@
-import { PacketType, Seed, parseSettingsFlags, type Packet } from "@minigolf/shared";
+import { ALL_VISIBLE_FLAGS, PacketType, Seed, parseSettingsFlags, type Packet } from "@minigolf/shared";
 import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
 import { loadAtlases, type Atlases } from "../game/sprites.ts";
@@ -1181,11 +1181,14 @@ export class GamePanel implements Panel {
     try {
       const parsed = buildMap(tLine, this.atlases);
       this.parsedMap = parsed;
-      // S line: 4 visibility/shadow flags + legacy 2-digit player range. Server
-      // forwards the raw body; we decode the first four chars. Missing/short
-      // S → all-false, mirroring `new boolean[4]` in Java's track parser.
-      const settingsBody = extractField(f, "S ") ?? "";
-      const settingsFlags = parseSettingsFlags(settingsBody);
+      // S line: 4 visibility/shadow flags + legacy 2-digit player range. The
+      // server only ships S when the track file actually had one, so an
+      // absent field means "no S line in the source" - we default to
+      // all-visible (the editor's view of the track). A present body decodes
+      // per `parseSettingsFlags` (missing chars stay false, matching Java).
+      const settingsBody = extractField(f, "S ");
+      const settingsFlags =
+        settingsBody === null ? ALL_VISIBLE_FLAGS : parseSettingsFlags(settingsBody);
       this.renderer = new TrackRenderer(parsed, this.atlases, settingsFlags);
       // Pick the common (shape-24) start, deterministic from gameId.
       const commonStart: [number, number] | null =

--- a/port/web/src/panels/replay.ts
+++ b/port/web/src/panels/replay.ts
@@ -158,9 +158,10 @@ export class ReplayPanel implements Panel {
       this.atlases = await loadAtlases();
       this.parsedMap = buildMap(this.replay.t, this.atlases);
       // DailyReplay doesn't carry the track's S-line body (yet) so the
-      // renderer defaults to all-false flags - mines/magnets/teleports hide,
-      // illusion walls don't cast shadows. Matches Java's "no S" default and
-      // is acceptable since replay physics doesn't depend on visibility.
+      // renderer falls back to its all-visible default - mines/magnets show,
+      // teleports keep their colours, illusion walls don't cast shadows.
+      // Replay physics doesn't depend on visibility, so this only affects how
+      // the track looks while watching the replay.
       this.renderer = new TrackRenderer(this.parsedMap, this.atlases);
       this.placeAtFirstStrokeOrigin();
       this.updateStrokeLabel();


### PR DESCRIPTION
Commit 54e50ea wired up the track 'S' visibility flags but defaulted `Track.settings` to "ffff" whenever the source file had no S line, then unconditionally shipped "S ffff" over the wire. The client parsed that as "explicitly hide everything," which silently turned magnets, mines and coloured teleports invisible on the ~92% of stock tracks that have no S declaration (1904 of 2062). Java's runtime had the same effect via its `length() != 6` parser typo, but the editor preview shows everything visible - matching the creator's intent - so that's the default we want.

Now `Track.settings` defaults to the empty string (sentinel for "absent"), the server only emits the S line when the track file actually has one, and the client falls back to a new `ALL_VISIBLE_FLAGS` constant when no S field is present in the starttrack frame. An explicit "S ffff" still hides everything as before.

Includes a `verify-magnets.ts` smoke test that exercises the full chain end-to-end against the live server until it lands on a magnet track.