### PR TITLE
Port: implement krokkaus (ball-vs-ball collisions) in multiplayer

### DIFF
--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -292,9 +292,14 @@ export class GolfGame extends Game {
                 return true;
             }
             case "endstroke": {
-                // Wire form: game\tendstroke\t<playerId>\t<playStatus>
+                // Wire form: game\tendstroke\t<playerId>\t<playStatus>\t<src?>
+                //   src='s' (default) → real stroke end, server bumps counter.
+                //   src='k'            → krokkaus pushed this player into a
+                //                        hole; mark them done but do NOT bump
+                //                        their stroke counter.
                 const newPlayStatus = fields[3] ?? this.playStatus;
-                this.endStroke(player, newPlayStatus);
+                const src = fields[4] ?? "s";
+                this.endStroke(player, newPlayStatus, src === "k" ? "k" : "s");
                 return true;
             }
             case "voteskip":
@@ -355,16 +360,24 @@ export class GolfGame extends Game {
      * broadcast a fresh per-player update so every client's scoreboard agrees.
      * Once all live players are either holed or skipped, advance the track.
      *
-     *   wire: client → server  : game endstroke <playerId> <playStatus>
+     *   wire: client → server  : game endstroke <playerId> <playStatus> <src?>
      *           (we trust only their OWN char of the playStatus; shooter sees the
      *            board through their own eyes but we authoritatively own the rest)
      *         server → all     : game endstroke <playerId> <strokesThisTrack> <inHole>
+     *
+     *   src = "s" (default, real stroke) → bump stroke counter.
+     *   src = "k" (krokkaus push)        → don't bump; the player was knocked
+     *                                      into a hole by another player's
+     *                                      stroke and didn't shoot themselves.
      */
-    protected endStroke(player: Player, newPlayStatus: string): void {
+    protected endStroke(player: Player, newPlayStatus: string, src: "s" | "k" = "s"): void {
         const id = this.getPlayerId(player);
         const myStatus = newPlayStatus.charAt(id);
-        // Bump stroke count for this player.
-        this.playerStrokesThisTrack[id] = (this.playerStrokesThisTrack[id] ?? 0) + 1;
+        // Bump stroke count for this player - unless this is a krokkaus
+        // outcome, in which case the player didn't take a stroke.
+        if (src === "s") {
+            this.playerStrokesThisTrack[id] = (this.playerStrokesThisTrack[id] ?? 0) + 1;
+        }
 
         // Update authoritative playStatus with this player's char (only).
         const psArr = this.playStatus.split("");

--- a/port/web/src/game/physics.ts
+++ b/port/web/src/game/physics.ts
@@ -45,6 +45,22 @@ export interface BallState {
   spinningStuckCounter: number;
   stopped: boolean;
   inHole: boolean;
+  /**
+   * Did this ball start moving because the player took a stroke (true), or
+   * because another player's krokkaus push gave it velocity (false)?
+   *
+   * Used by the multiplayer panel's tick loop when this ball comes to rest:
+   *   - `true` → our own stroke ended → send `game endstroke … s` so the
+   *     server bumps our stroke counter.
+   *   - `false` → we were just bumped → if we ended in a hole, send
+   *     `game endstroke … k` so the server marks us done WITHOUT counting
+   *     the push as a stroke; if we stopped on solid ground, no packet is
+   *     needed (the server doesn't track ball positions).
+   *
+   * Set by {@link applyStrokeImpulse}; cleared the moment the resulting
+   * stroke ends.
+   */
+  causedByShot: boolean;
 }
 
 export interface PhysicsContext {
@@ -68,6 +84,29 @@ export interface PhysicsContext {
    * clients during async play.
    */
   otherPlayers: Array<{ x: number; y: number } | null>;
+  /**
+   * Krokkaus / ball-vs-ball collisions. Java's `state.collisionMode` from the
+   * lobby's "Krokkaus" setting. 0 = off (balls pass through each other),
+   * 1 = on (balls bounce off each other and exchange velocity in the normal
+   * direction with a 0.75 damping factor).
+   */
+  collisionMode: number;
+  /**
+   * Live `BallState` references for every player slot, indexed by slot id.
+   * Used per-substep for the krokkaus collision check (when `collisionMode`
+   * is 1). `null` for vacant slots or players already done with this hole
+   * (holed / forfeited / parted) - those balls don't participate in
+   * collisions, mirroring Java's `simulatePlayer[k] && !onHoleSync[k]` gate.
+   *
+   * The ARRAY is shared by every slot's ctx so all balls see the same live
+   * peer set. When `step()` mutates `peers[k].vx/vy` during a collision,
+   * the change is visible to peer k's own ctx.peers[k] on the next physics
+   * tick (it's the same `BallState` object).
+   */
+  peers: Array<BallState | null>;
+  /** Slot index of THIS ball within `peers`. The collision loop skips this
+   *  index so a ball never tries to collide with itself. */
+  myIdx: number;
 }
 
 export function newBall(x: number, y: number): BallState {
@@ -92,6 +131,7 @@ export function newBall(x: number, y: number): BallState {
     spinningStuckCounter: 0,
     stopped: false,
     inHole: false,
+    causedByShot: false,
   };
 }
 
@@ -784,6 +824,45 @@ function resetToStart(ball: BallState, ctx: PhysicsContext): void {
   ball.shoreY = ctx.startY;
 }
 
+/**
+ * Krokkaus collision response between two balls - port of
+ * GameCanvas.handlePlayerCollisions (lines 1118-1141).
+ *
+ * Splits each ball's velocity into normal (along the line connecting their
+ * centres) and tangential components, then SWAPS the normal components
+ * (perfectly elastic 1D collision) while keeping the tangentials. Returns
+ * `true` if the collision was processed; the caller scales BOTH balls'
+ * resulting velocities by 0.75 to match Java's damping in GameCanvas.run.
+ *
+ * Touching but not approaching (`a` and `b` separating) is a no-op so
+ * already-resolved overlap can't double-count. Diameter check `<= 13.0` is
+ * Java's exact constant (ball radius 6.5 px each).
+ *
+ * Side effects: ALL state mutation lands on the velocity fields - this
+ * function never re-arms the `stopped` flag or stuck counters. The caller
+ * (panels/game.ts tick loop) is responsible for noticing a previously-
+ * stopped ball gained velocity and clearing its stop state for the next
+ * physics tick.
+ */
+function handlePlayerCollisions(a: BallState, b: BallState): boolean {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+  if (distance === 0 || distance > 13.0) return false;
+  const fx = dx / distance;
+  const fy = dy / distance;
+  const aSpeed = a.vx * fx + a.vy * fy;
+  const bSpeed = b.vx * fx + b.vy * fy;
+  if (aSpeed - bSpeed <= 0) return false;
+  const aPerp = -a.vx * fy + a.vy * fx;
+  const bPerp = -b.vx * fy + b.vy * fx;
+  a.vx = bSpeed * fx - aPerp * fy;
+  a.vy = bSpeed * fy + aPerp * fx;
+  b.vx = aSpeed * fx - bPerp * fy;
+  b.vy = aSpeed * fy + bPerp * fx;
+  return true;
+}
+
 export interface StepResult {
   stopped: boolean;
   inHole: boolean;
@@ -812,6 +891,27 @@ export function step(ball: BallState, ctx: PhysicsContext): StepResult {
       if (ball.x >= 727.9) ball.x = 727.9;
       if (ball.y < 6.6) ball.y = 6.6;
       if (ball.y >= 367.9) ball.y = 367.9;
+
+      // Krokkaus / ball-vs-ball collision (Java GameCanvas.run line 249-267,
+      // HackedShot.run line 198-213). Per-substep check against every other
+      // peer that's still in this hole and not currently on a hole/liquid.
+      // On a successful normal-direction collision both balls' velocities
+      // are scaled by 0.75 (the same damping Java applies in the caller).
+      if (ctx.collisionMode === 1 && !ball.onHole && !ball.onLiquidOrSwamp) {
+        const peers = ctx.peers;
+        for (let pi = 0; pi < peers.length; pi++) {
+          if (pi === ctx.myIdx) continue;
+          const other = peers[pi];
+          if (!other) continue;
+          if (other.inHole || other.onHole || other.onLiquidOrSwamp) continue;
+          if (handlePlayerCollisions(ball, other)) {
+            ball.vx *= 0.75;
+            ball.vy *= 0.75;
+            other.vx *= 0.75;
+            other.vy *= 0.75;
+          }
+        }
+      }
 
       const ix = (ball.x + 0.5) | 0;
       const iy = (ball.y + 0.5) | 0;

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -348,6 +348,14 @@ export class GamePanel implements Panel {
   private currentTrackIdx = 0;
   private myPlayerId = 0;
   private waterEvent = 0;
+  /**
+   * Krokkaus / ball-vs-ball collision toggle from `gameinfo`. Java's
+   * `LobbyReal_Collision` setting; 0 = balls pass through each other,
+   * 1 = balls bounce off each other (the original game's default). Plumbed
+   * straight into every per-stroke {@link PhysicsContext} so the physics
+   * step does (or skips) the player-collision check per substep.
+   */
+  private collisionMode = 1;
   private myNick = "You";
 
   private keyHandler: ((ev: KeyboardEvent) => void) | null = null;
@@ -886,6 +894,10 @@ export class GamePanel implements Panel {
         this.roomCapacity = this.numPlayers;
         this.numTracks = parseInt(f[6] ?? "1", 10) || 1;
         this.waterEvent = parseInt(f[10] ?? "0", 10) || 0;
+        // f[11] is the lobby's "Krokkaus" setting. Default to ON when absent
+        // (matches the original Java client's selectedIndex=1 default).
+        this.collisionMode = parseInt(f[11] ?? "1", 10);
+        if (this.collisionMode !== 0 && this.collisionMode !== 1) this.collisionMode = 1;
         // Fresh gameinfo arrives on every join - reset the "started" gate so
         // the Practice button reappears for any new room (including a
         // re-join). The trailing `f` flag in the packet always says
@@ -1329,6 +1341,23 @@ export class GamePanel implements Panel {
       }
       otherPlayers.push({ x: peer.ball.x, y: peer.ball.y });
     }
+    // Live ball refs for krokkaus collision. Java's `simulatePlayer[k]` gate
+    // is "this player is in this hole at all" - we approximate it by
+    // excluding holed / forfeited / parted slots and vacant nicks. The ARRAY
+    // is shared by every slot's ctx so a collision in slot i's substep
+    // mutates peer k's BallState directly (same object reference).
+    const peers: Array<BallState | null> = [];
+    for (let pi = 0; pi < this.players.length; pi++) {
+      const peer = this.players[pi];
+      if (!peer) { peers.push(null); continue; }
+      const inTrack =
+        peer.nick !== "" &&
+        !peer.holedThisTrack &&
+        !peer.forfeitedThisTrack &&
+        peer.partReason === 0 &&
+        !peer.ball.inHole;
+      peers.push(inTrack ? peer.ball : null);
+    }
     const ctx: PhysicsContext = {
       map: this.parsedMap,
       seed: new Seed(BigInt(seedNum)),
@@ -1340,10 +1369,46 @@ export class GamePanel implements Panel {
       startX: slot.startX,
       startY: slot.startY,
       otherPlayers,
+      collisionMode: this.collisionMode,
+      peers,
+      myIdx: id,
     };
     slot.ctx = ctx;
     applyStrokeImpulse(slot.ball, ctx, mouse.x, mouse.y, mouse.mode);
+    // Track that slot.ball.stopped = false transitions came from a real
+    // stroke vs. a krokkaus push. Used by the tick loop to know whether
+    // to bill the stop as our stroke (`endstroke s`) or as a krokkaus
+    // outcome (`endstroke k`, doesn't bump the counter).
+    slot.ball.causedByShot = true;
     slot.simulating = true;
+
+    // Set up "ready-for-collision" ctxes on every OTHER active idle slot so
+    // their balls can be stepped if A's stroke pushes them. Each slot uses
+    // the SAME beginstroke seed value but its OWN Seed instance - so each
+    // ball's RNG draws are independent across clients but every client
+    // arrives at the same numbers. Skip slots that are currently mid-stroke
+    // (their ctx is in flight; replacing it would corrupt the seed stream).
+    for (let pi = 0; pi < this.players.length; pi++) {
+      if (pi === id) continue;
+      const peer = this.players[pi];
+      if (!peer) continue;
+      if (peer.simulating) continue;
+      if (peer.holedThisTrack || peer.forfeitedThisTrack || peer.partReason !== 0) continue;
+      if (peer.ball.inHole) continue;
+      if (peer.nick === "") continue;
+      peer.ctx = {
+        map: this.parsedMap,
+        seed: new Seed(BigInt(seedNum)),
+        norandom: false,
+        waterEvent: this.waterEvent,
+        startX: peer.startX,
+        startY: peer.startY,
+        otherPlayers,
+        collisionMode: this.collisionMode,
+        peers,
+        myIdx: pi,
+      };
+    }
     // Mirror Java GamePanel.java:388 / :448 - playGameMove() on every stroke,
     // including the local player's (server echoes their own click back).
     audio.playGameMove();
@@ -1449,8 +1514,16 @@ export class GamePanel implements Panel {
       // Step every ball that's currently moving. Each ball has its OWN
       // PhysicsContext (with its OWN Seed), so concurrent strokes can't
       // interfere with one another's randomness.
-      const anySimulating = this.players.some((p) => p.simulating);
-      if (anySimulating) {
+      //
+      // Krokkaus extension: a ball with non-zero velocity but `simulating ===
+      // false` was just bumped by another ball's collision in this same tick
+      // (or an earlier substep within this tick's slot loop). We re-arm its
+      // physics state machine and step it like any active ball, so the
+      // bumped ball naturally rolls until it stops on its own.
+      const anyMoving = this.players.some(
+        (p) => p.simulating || p.ball.vx !== 0 || p.ball.vy !== 0,
+      );
+      if (anyMoving) {
         const now = performance.now();
         if (this.lastTickMs === 0) this.lastTickMs = now;
         const elapsed = now - this.lastTickMs;
@@ -1461,18 +1534,66 @@ export class GamePanel implements Panel {
           this.physicsAccumMs -= PHYSICS_STEP_MS;
           for (let i = 0; i < this.players.length; i++) {
             const slot = this.players[i];
-            if (!slot.simulating || !slot.ctx) continue;
-            const r = step(slot.ball, slot.ctx);
+            if (!slot.ctx) continue;
+            const ball = slot.ball;
+            if (ball.inHole) continue;
+            if (slot.holedThisTrack || slot.forfeitedThisTrack) continue;
+            // Step if we're already simulating, or if a peer's krokkaus
+            // collision just gave us velocity this tick.
+            const moving = slot.simulating || ball.vx !== 0 || ball.vy !== 0;
+            if (!moving) continue;
+            // Re-arm a previously-stopped ball that just got bumped. We do
+            // NOT reset strokeStartX/Y - Java's `tempCoordX/Y` is only set
+            // by a real stroke, so a krokkaus victim that lands in water
+            // (event 0) goes back to where they LAST shot from, not where
+            // they were when bumped. shoreX/Y reset is fine since Java's
+            // `tempCoord2X/Y` is initialized to playerX/Y at run() entry.
+            if (ball.stopped) {
+              ball.stopped = false;
+              ball.iterationsThisStroke = 0;
+              ball.downhillStuckCounter = 0;
+              ball.magnetStuckCounter = 0;
+              ball.spinningStuckCounter = 0;
+              ball.bounciness = 1.0;
+              ball.magnetMul = 1.0;
+              ball.onHole = false;
+              ball.onLiquidOrSwamp = false;
+              ball.liquidTimer = 0;
+              ball.teleported = false;
+              ball.shoreX = ball.x;
+              ball.shoreY = ball.y;
+              // Krokkaus push: not our own stroke. Suppresses the counter
+              // bump on endstroke (see below).
+              ball.causedByShot = false;
+            }
+            slot.simulating = true;
+            const r = step(ball, slot.ctx);
             if (r.stopped) {
               slot.simulating = false;
               if (i === this.myPlayerId) {
-                // Tell the server our ball stopped (and whether we're in hole).
-                this.app.connection.sendData(
-                  "game",
-                  "endstroke",
-                  String(i),
-                  this.myPlayStatus(),
-                );
+                if (ball.causedByShot) {
+                  // Real stroke ending: server bumps our stroke counter.
+                  this.app.connection.sendData(
+                    "game",
+                    "endstroke",
+                    String(i),
+                    this.myPlayStatus(),
+                    "s",
+                  );
+                  ball.causedByShot = false;
+                } else if (ball.inHole) {
+                  // Krokkaus pushed us into the hole - server marks us
+                  // "done" but does NOT bump our stroke counter.
+                  this.app.connection.sendData(
+                    "game",
+                    "endstroke",
+                    String(i),
+                    this.myPlayStatus(),
+                    "k",
+                  );
+                }
+                // If we got bumped onto solid ground, the server doesn't
+                // need to know - it tracks playStatus, not positions.
               }
             }
           }

--- a/port/web/src/panels/lobby-multi.ts
+++ b/port/web/src/panels/lobby-multi.ts
@@ -453,7 +453,11 @@ export class LobbyMultiPanel implements Panel {
       o.textContent = label;
       collisionSel.appendChild(o);
     }
-    collisionSel.disabled = true;
+    // Default to "No". Java's LobbyPanel.addChoicerCollision defaulted to
+    // "Yes" via `c.select(1)`, but we deliberately diverge: krokkaus changes
+    // a stranger's hole significantly and most casual rooms don't expect it,
+    // so opt-in feels safer for the port. Host can toggle it on per-room.
+    collisionSel.value = "0";
     fillCell(collisionSel);
     grid.appendChild(this.label(t("LobbyReal_Collision", "Ball collisions:")));
     grid.appendChild(collisionSel);

--- a/port/web/src/panels/replay.ts
+++ b/port/web/src/panels/replay.ts
@@ -263,6 +263,11 @@ export class ReplayPanel implements Panel {
       // Single-ball replay - no peers to obstruct movable blocks. Pad to
       // length 1 since the obstruction loop is keyed by index.
       otherPlayers: [null],
+      // No krokkaus in single-ball replay - daily share-link replays are
+      // always one player's stroke trace, never multiplayer collision.
+      collisionMode: 0,
+      peers: [this.ball],
+      myIdx: 0,
     };
     applyStrokeImpulse(this.ball, this.ctx, m.x, m.y, m.mode);
     this.simulating = true;


### PR DESCRIPTION
Mirrors the original Java game's `state.collisionMode` behaviour from GameCanvas.run / handlePlayerCollisions: per-substep collision check at 13 px diameter, normal-direction velocity exchange, both balls' speeds scaled by 0.75 on impact. Lobby's "Krokkaus" selector is enabled (was disabled placeholder) and defaults to "No" - we deliberately diverge from Java's "Yes" default since krokkaus changes a stranger's hole significantly.

PhysicsContext gains `collisionMode`, live `peers[]` (BallState refs), and `myIdx`. The tick loop now also steps balls that gained velocity from a peer's collision but aren't yet `simulating` - re-arming `stopped`/stuck-counters/shore but NOT `strokeStartX/Y` (Java parity: water-event=0 sends a krokkaus victim back to where they last shot from, not where they were when bumped).

Wire format: `endstroke` gets an optional 5th field `s` (default, shoot - bumps stroke counter) or `k` (krokkaus push to a hole - marks player done without bumping). Backward-compatible with existing tests.