### PR TITLE
Port: add a turn-based lobby option to multiplayer

### DIFF
--- a/client/src/main/resources/l10n/en/AGolf.xml
+++ b/client/src/main/resources/l10n/en/AGolf.xml
@@ -1305,6 +1305,30 @@
 	<str key="Port_Lobby_JoinInProgress">
 		<![CDATA[Drop in]]>
 	</str>
+	<str key="Port_Lobby_TurnMode">
+		<![CDATA[Play mode:]]>
+	</str>
+	<str key="Port_Lobby_TurnsAsync">
+		<![CDATA[Real-time (async)]]>
+	</str>
+	<str key="Port_Lobby_TurnsBased">
+		<![CDATA[Turn-based]]>
+	</str>
+	<str key="Port_Lobby_TurnsBadge">
+		<![CDATA[(Turns)]]>
+	</str>
+	<str key="Port_Game_TurnWaiting">
+		<![CDATA[Waiting for next turn…]]>
+	</str>
+	<str key="Port_Game_TurnYours">
+		<![CDATA[Your turn — click to shoot.]]>
+	</str>
+	<str key="Port_Game_TurnOther">
+		<![CDATA[%1's turn — wait for them to shoot.]]>
+	</str>
+	<str key="Port_Game_TurnTitleAlert">
+		<![CDATA[(Your turn!) ]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Ignore selected user]]>
 	</str>

--- a/client/src/main/resources/l10n/fi/AGolf.xml
+++ b/client/src/main/resources/l10n/fi/AGolf.xml
@@ -1305,6 +1305,30 @@
 	<str key="Port_Lobby_JoinInProgress">
 		<![CDATA[Liity peliin]]>
 	</str>
+	<str key="Port_Lobby_TurnMode">
+		<![CDATA[Pelitapa:]]>
+	</str>
+	<str key="Port_Lobby_TurnsAsync">
+		<![CDATA[Reaaliaikainen]]>
+	</str>
+	<str key="Port_Lobby_TurnsBased">
+		<![CDATA[Vuoropohjainen]]>
+	</str>
+	<str key="Port_Lobby_TurnsBadge">
+		<![CDATA[(Vuoroin)]]>
+	</str>
+	<str key="Port_Game_TurnWaiting">
+		<![CDATA[Odotetaan seuraavaa vuoroa…]]>
+	</str>
+	<str key="Port_Game_TurnYours">
+		<![CDATA[Sinun vuorosi — klikkaa lyödäksesi.]]>
+	</str>
+	<str key="Port_Game_TurnOther">
+		<![CDATA[%1:n vuoro — odota että hän lyö.]]>
+	</str>
+	<str key="Port_Game_TurnTitleAlert">
+		<![CDATA[(Vuorosi!) ]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Mykistä valittu käyttäjä]]>
 	</str>

--- a/client/src/main/resources/l10n/sv/AGolf.xml
+++ b/client/src/main/resources/l10n/sv/AGolf.xml
@@ -1305,6 +1305,30 @@
 	<str key="Port_Lobby_JoinInProgress">
 		<![CDATA[Hoppa in]]>
 	</str>
+	<str key="Port_Lobby_TurnMode">
+		<![CDATA[Spelläge:]]>
+	</str>
+	<str key="Port_Lobby_TurnsAsync">
+		<![CDATA[Realtid]]>
+	</str>
+	<str key="Port_Lobby_TurnsBased">
+		<![CDATA[Turordning]]>
+	</str>
+	<str key="Port_Lobby_TurnsBadge">
+		<![CDATA[(Turer)]]>
+	</str>
+	<str key="Port_Game_TurnWaiting">
+		<![CDATA[Väntar på nästa tur…]]>
+	</str>
+	<str key="Port_Game_TurnYours">
+		<![CDATA[Din tur — klicka för att slå.]]>
+	</str>
+	<str key="Port_Game_TurnOther">
+		<![CDATA[%1:s tur — vänta tills hen slår.]]>
+	</str>
+	<str key="Port_Game_TurnTitleAlert">
+		<![CDATA[(Din tur!) ]]>
+	</str>
 	<str key="UserList_Ignore">
 		<![CDATA[Ignorera vald användare]]>
 	</str>

--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -515,6 +515,10 @@ export class GolfGame extends Game {
      * "in-progress" flag: `1` once the game has started (`!isPublic`),
      * `0` while it is still waiting / practicing. Old clients that ignored
      * the field keep working; new clients use it to badge running rooms.
+     *
+     * MultiGame appends a 16th field (turn-based flag, "1"/"0") - see
+     * `MultiGame.getGameString`. Trailing tabs are tolerated by older
+     * parsers so back-compat holds.
      */
     override getGameString(): string {
         return tabularize(
@@ -863,6 +867,20 @@ export class MultiGame extends GolfGame {
     public practiceActive = false;
     /** The map currently in play during practice. Replaced on every hole-in. */
     private practiceTrack: Track | null = null;
+    /**
+     * Lobby option: when true, only the player named by `currentTurn` may
+     * `beginstroke`. The original Java game was strictly turn-based; the port
+     * defaults to the looser real-time model and lets room creators opt back
+     * in via the lobby form. Practice mode ignores this flag - free play
+     * during the warm-up period is part of the practice contract.
+     */
+    public readonly turnBased: boolean;
+    /**
+     * Slot id of the player whose turn it currently is, or -1 if the room
+     * isn't in turn-bound play (waiting/practice/track-over). Always -1 for
+     * `turnBased=false` rooms.
+     */
+    private currentTurn: number = -1;
     constructor(
         creator: Player,
         gameId: number,
@@ -879,6 +897,7 @@ export class MultiGame extends GolfGame {
         trackScoringEnd: number,
         numPlayers: number,
         trackManager: TrackManager,
+        turnBased: boolean = false,
     ) {
         const passworded = !(password === "-" || password === "");
         super(
@@ -899,6 +918,7 @@ export class MultiGame extends GolfGame {
             numPlayers,
             trackManager,
         );
+        this.turnBased = turnBased;
 
         logEvent("game_create", {
             game_id: gameId,
@@ -910,6 +930,7 @@ export class MultiGame extends GolfGame {
             collision,
             passworded,
             creator_id: creator.id,
+            turn_based: turnBased,
         });
 
         // Add creator first.
@@ -1016,6 +1037,92 @@ export class MultiGame extends GolfGame {
                 );
             }
         }
+
+        // Turn-based late-join: tell the newcomer whose turn it currently is.
+        // The joiner's own slot was just stamped 'f' above; if no turn was
+        // active (currentTurn === -1, e.g. everyone present had finished and
+        // we're between hands), seed it with the joiner so the room doesn't
+        // stall waiting for a turn that was never assigned.
+        if (this.turnBased) {
+            if (this.currentTurn < 0) {
+                this.currentTurn = slotId;
+                this.broadcast(tabularize("game", "startturn", slotId));
+            } else {
+                player.connection.sendDataRaw(
+                    tabularize("game", "startturn", this.currentTurn),
+                );
+            }
+        }
+    }
+
+    // ----- turn-based helpers -----------------------------------------------
+
+    /**
+     * Pick the next-eligible slot for turn-based play. Walks `playersNumber`
+     * in ascending order so turn order matches the join order; wraps around
+     * starting just past `from`. Returns -1 if every present player has
+     * finished or skipped this track.
+     */
+    private nextEligibleTurn(from: number): number {
+        if (this.players.length === 0) return -1;
+        const ids = [...this.playersNumber].sort((a, b) => a - b);
+        // Find the lowest id strictly greater than `from`, wrapping if none.
+        let startIdx = 0;
+        for (let i = 0; i < ids.length; i++) {
+            if (ids[i] > from) { startIdx = i; break; }
+            // If `from` is >= every id, startIdx stays 0 (wrap).
+            if (i === ids.length - 1) startIdx = 0;
+        }
+        for (let n = 0; n < ids.length; n++) {
+            const id = ids[(startIdx + n) % ids.length];
+            if (this.playStatus.charAt(id) === "f") return id;
+        }
+        return -1;
+    }
+
+    /**
+     * Re-evaluate whose turn it is and broadcast `game startturn <slot>` if
+     * it changed. Called after every event that can shrink the eligible set:
+     * an endstroke that holed/forfeited the shooter, an explicit forfeit,
+     * a leave, or the start of a new track. No-op for async rooms or when
+     * no eligible player remains (the track-advance path takes over then).
+     */
+    private advanceTurn(after: number): void {
+        if (!this.turnBased) return;
+        const next = this.nextEligibleTurn(after);
+        if (next < 0) {
+            this.currentTurn = -1;
+            return;
+        }
+        if (next !== this.currentTurn) {
+            this.currentTurn = next;
+            this.broadcast(tabularize("game", "startturn", next));
+        }
+    }
+
+    /**
+     * Pick the first turn for a fresh track / fresh game and broadcast it.
+     * Called from `startGame` and `nextTrack` (for turn-based real-game play).
+     * Must be invoked AFTER `playStatus` is reset to all-'f'.
+     */
+    private assignFirstTurn(): void {
+        if (!this.turnBased) return;
+        if (this.players.length === 0) {
+            this.currentTurn = -1;
+            return;
+        }
+        const ids = [...this.playersNumber].sort((a, b) => a - b);
+        // First eligible slot - on a fresh track every present slot is 'f',
+        // so this is just `ids[0]`. Defensive iteration anyway in case a
+        // future code path lands here with a partially-filled playStatus.
+        for (const id of ids) {
+            if (this.playStatus.charAt(id) === "f") {
+                this.currentTurn = id;
+                this.broadcast(tabularize("game", "startturn", id));
+                return;
+            }
+        }
+        this.currentTurn = -1;
     }
 
     /**
@@ -1106,11 +1213,103 @@ export class MultiGame extends GolfGame {
         }
     }
 
+    /**
+     * Append the turn-based flag (16th field) to the game-list row so lobby
+     * clients can render the badge and the joiner's UI knows which gating to
+     * apply. Older clients stop parsing at field 14 and ignore the trailing
+     * tab+digit, so wire compatibility holds.
+     */
+    override getGameString(): string {
+        return tabularize(
+            this.gameId,
+            this.name,
+            this.passworded,
+            this.perms,
+            this.numPlayers,
+            this.isPublic ? 0 : 1,
+            this.tracks.length,
+            this.tracksType,
+            this.maxStrokes,
+            this.strokeTimeout,
+            this.waterEvent,
+            this.collision,
+            this.trackScoring,
+            this.trackScoringEnd,
+            this.players.length,
+            this.turnBased ? 1 : 0,
+        );
+    }
+
+    /**
+     * Append the turn-based flag (15th field, "t"/"f") so the freshly-joined
+     * client knows whether to apply turn gating before any `startturn` packet
+     * arrives. Older clients ignore the extra field.
+     */
+    override sendGameInfo(player: Player): void {
+        player.connection.sendData("status", "game");
+        player.connection.sendData(
+            "game",
+            "gameinfo",
+            this.name,
+            this.passworded,
+            this.gameId,
+            this.numPlayers,
+            this.tracks.length,
+            this.tracksType,
+            this.maxStrokes,
+            this.strokeTimeout,
+            this.waterEvent,
+            this.collision,
+            this.trackScoring,
+            this.trackScoringEnd,
+            "f",
+            this.turnBased ? "t" : "f",
+        );
+    }
+
+    /**
+     * Gate `beginstroke` on the current turn in turn-based rooms. Practice
+     * remains free-play. The base class also enforces `playStatus[id] === 'f'`,
+     * which catches doubled-up strokes; this override only adds the per-room
+     * turn check on top.
+     */
+    protected override beginStroke(p: Player, ballCoords: string, mouseCoords: string): void {
+        if (this.turnBased && !this.practiceActive) {
+            const id = this.getPlayerId(p);
+            if (id !== this.currentTurn) return;
+        }
+        super.beginStroke(p, ballCoords, mouseCoords);
+    }
+
+    /**
+     * After the base class settles the stroke (and possibly advances to the
+     * next track via `nextTrack`), bump the turn pointer if we're still on
+     * the same track. The `advanceTurn` call is a no-op when async or when
+     * `nextTrack` already ran (`assignFirstTurn` will have set the new turn).
+     */
+    protected override endStroke(player: Player, newPlayStatus: string): void {
+        const id = this.getPlayerId(player);
+        const wasTrack = this.currentTrack;
+        super.endStroke(player, newPlayStatus);
+        if (this.currentTrack === wasTrack) this.advanceTurn(id);
+    }
+
+    /** Forfeit advances the turn the same way endstroke does. */
+    protected override forfeit(player: Player): void {
+        const id = this.getPlayerId(player);
+        const wasTrack = this.currentTrack;
+        super.forfeit(player);
+        if (this.currentTrack === wasTrack) this.advanceTurn(id);
+    }
+
     /** During practice each hole-in / forfeit-all advances to a fresh random
      *  track instead of walking through `this.tracks`. */
     protected override nextTrack(): void {
         if (!this.practiceActive) {
             super.nextTrack();
+            // Real-game next-track: assign first turn for the new hole.
+            // Skipped for practice (free-play during warm-up).
+            this.assignFirstTurn();
             return;
         }
         const cat: TrackCategoryId = trackCategoryByTypeId(this.tracksType);
@@ -1147,7 +1346,11 @@ export class MultiGame extends GolfGame {
             }
             this.strokeCounter = 0;
         }
+        // Reset turn pointer before delegating - the base broadcasts `start`
+        // and `starttrack`, after which assignFirstTurn announces who shoots.
+        this.currentTurn = -1;
         super.startGame();
+        this.assignFirstTurn();
     }
 
     /** Inject the `practice` verb before falling through to the standard
@@ -1231,6 +1434,8 @@ export class MultiGame extends GolfGame {
         const wasPublic = this.isPublic;
         const wasPracticing = this.practiceActive;
         const playerNum = this.getPlayerId(player);
+        const trackBeforeLeave = this.currentTrack;
+        const wasTheirTurn = this.turnBased && this.currentTurn === playerNum;
         super.removePlayer(player, reason);
 
         if (this.playStatus.length > playerNum) {
@@ -1264,9 +1469,14 @@ export class MultiGame extends GolfGame {
 
         const lobby = player.lobby;
         if (this.players.length > 0) {
-            if (!wasPublic) {
-                // Game was in progress - pick the first remaining player to shoot.
-                this.broadcast(tabularize("game", "startturn", this.playersNumber[0] ?? 0));
+            if (!wasPublic && this.turnBased && !this.practiceActive) {
+                // Turn-based real game still in progress: if the leaver held
+                // the turn AND `nextTrack` didn't already kick everyone to a
+                // fresh hole (which assigns its own first turn), advance to
+                // the next eligible slot so the survivors aren't blocked.
+                if (wasTheirTurn && this.currentTrack === trackBeforeLeave) {
+                    this.advanceTurn(playerNum);
+                }
             }
             if (lobby) {
                 // Always update the gamelist row so the freed slot is visible

--- a/port/server/src/packet-handlers.ts
+++ b/port/server/src/packet-handlers.ts
@@ -326,11 +326,14 @@ register({
             const collision = parseInt(rest[8] ?? "1", 10) || 1;
             const scoreSystem = parseInt(rest[9] ?? "0", 10) || 0;
             const weightEnd = parseInt(rest[10] ?? "0", 10) || 0;
+            // Port extension: 12th cmpt arg is the turn-based flag. Older
+            // clients omit it - default to async (false) for back-compat.
+            const turnBased = (rest[11] ?? "0") === "1";
 
             console.log(
                 `[lobby] cmpt by ${player.nick}: name="${name}" pwd=${password === "-" ? "no" : "yes"}` +
                     ` players=${playerCount} tracks=${numberOfTracks} trackType=${trackType}` +
-                    ` maxStrokes=${maxStrokes} water=${water} collision=${collision}`,
+                    ` maxStrokes=${maxStrokes} water=${water} collision=${collision} turnBased=${turnBased}`,
             );
             new MultiGame(
                 player,
@@ -348,6 +351,7 @@ register({
                 weightEnd,
                 playerCount,
                 server.trackManager,
+                turnBased,
             );
             return;
         }

--- a/port/server/src/test-late-join.ts
+++ b/port/server/src/test-late-join.ts
@@ -163,9 +163,11 @@ async function main(): Promise<void> {
         b.sendData("game", "back");
 
         // C should see a gamelist change shrinking the room to 1/2,
-        // inProgress still '1' (game still in progress).
+        // inProgress still '1' (game still in progress). The trailing field
+        // is the port-extension `turnBased` flag (0 here); currentPlayers=1
+        // is the second-to-last column.
         await c.waitFor(
-            (s) => /^d \d+ lobby\tgamelist\tchange\t\d+\tDropInTest\tf\t0\t2\t1\t.*\t1$/.test(s),
+            (s) => /^d \d+ lobby\tgamelist\tchange\t\d+\tDropInTest\tf\t0\t2\t1\t.*\t1\t0$/.test(s),
             "C sees 1/2 update with inProgress=1",
         );
         console.log("[OK] B left mid-game → gamelist shrinks back to 1/2 (inProgress=1)");

--- a/port/server/src/test-turn-based.ts
+++ b/port/server/src/test-turn-based.ts
@@ -1,0 +1,237 @@
+// Turn-based multiplayer smoke test.
+//
+// Boots a fresh GolfServer on port 4253, opens three ws clients, walks them
+// through guest-login → multi lobby → create+join 3-player turn-based game,
+// then exercises the contract:
+//
+//   1. Server announces `gameinfo` with the trailing `t` flag.
+//   2. After fill, `startturn 0` is broadcast to all.
+//   3. A non-current-turn shooter is silently rejected.
+//   4. The current-turn shooter's beginstroke is accepted.
+//   5. After endstroke, `startturn` advances to the next slot.
+//   6. When the current-turn player parts mid-track, the turn advances.
+//
+// Usage: node --experimental-strip-types --no-warnings src/test-turn-based.ts
+
+import * as path from "node:path";
+import { WebSocket } from "ws";
+import { startServer, type RunningServer } from "./main.ts";
+
+const PORT = 4253;
+const HOST = "127.0.0.1";
+
+function tracksDir(): string {
+    const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(?=[A-Za-z]:)/, ""));
+    return path.resolve(here, "..", "tracks");
+}
+
+class Client {
+    name: string;
+    ws: WebSocket;
+    outSeq = 0;
+    received: string[] = [];
+
+    constructor(name: string) {
+        this.name = name;
+        this.ws = new WebSocket(`ws://${HOST}:${PORT}/ws`);
+        this.ws.on("message", (m) => this.received.push(m.toString()));
+    }
+    async open(): Promise<void> {
+        await new Promise<void>((r) => this.ws.once("open", () => r()));
+    }
+    send(line: string): void {
+        this.ws.send(line);
+    }
+    sendData(...fields: (string | number)[]): void {
+        this.send(`d ${this.outSeq++} ${fields.join("\t")}`);
+    }
+    sendCommand(verb: string, ...args: string[]): void {
+        this.send(`c ${[verb, ...args].join(" ")}`);
+    }
+    async waitFor(predicate: (s: string) => boolean, label: string, timeoutMs = 4000): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => {
+                console.log(`[${this.name}] timed out waiting for ${label}; queue:`, this.received);
+                reject(new Error(`[${this.name}] timeout: ${label}`));
+            }, timeoutMs);
+            const tick = (): void => {
+                const idx = this.received.findIndex(predicate);
+                if (idx >= 0) {
+                    clearTimeout(t);
+                    const [s] = this.received.splice(idx, 1);
+                    resolve(s);
+                    return;
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+    async assertNotReceived(predicate: (s: string) => boolean, label: string, windowMs: number): Promise<void> {
+        await new Promise<void>((r) => setTimeout(r, windowMs));
+        const idx = this.received.findIndex(predicate);
+        if (idx >= 0) {
+            throw new Error(`[${this.name}] received unexpected (${label}): ${this.received[idx]}`);
+        }
+    }
+    drain(): void {
+        this.received = [];
+    }
+    close(): void {
+        try { this.ws.close(); } catch { /* */ }
+    }
+}
+
+async function login(c: Client): Promise<void> {
+    await c.waitFor((s) => s === "h 1", "h 1");
+    await c.waitFor((s) => s.startsWith("c crt"), "c crt");
+    await c.waitFor((s) => s === "c ctr", "c ctr");
+    c.sendCommand("new");
+    await c.waitFor((s) => s.startsWith("c id "), "c id");
+    c.sendData("version", 35);
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (v)");
+    c.sendData("language", "en");
+    c.sendData("logintype", "nr");
+    await c.waitFor((s) => /^d \d+ status\tlogin$/.test(s), "status login (lt)");
+    c.sendData("login");
+    await c.waitFor((s) => /^d \d+ basicinfo\t/.test(s), "basicinfo");
+    await c.waitFor((s) => /^d \d+ status\tlobbyselect/.test(s), "status lobbyselect");
+}
+
+async function enterMultiLobby(c: Client): Promise<void> {
+    c.sendData("lobbyselect", "select", "x");
+    await c.waitFor((s) => /^d \d+ status\tlobby\tx/.test(s), "status lobby x");
+    await c.waitFor((s) => /^d \d+ lobby\tusers/.test(s), "lobby users");
+    await c.waitFor((s) => /^d \d+ lobby\townjoin/.test(s), "lobby ownjoin");
+    await c.waitFor((s) => /^d \d+ lobby\tgamelist\tfull/.test(s), "gamelist full");
+}
+
+async function main(): Promise<void> {
+    let server: RunningServer | null = null;
+    try {
+        server = await startServer({ host: HOST, port: PORT, tracksDir: tracksDir(), verbose: false });
+        console.log("[server] up");
+
+        const a = new Client("A");
+        const b = new Client("B");
+        const c = new Client("C");
+        await Promise.all([a.open(), b.open(), c.open()]);
+
+        await login(a);
+        await login(b);
+        await login(c);
+        await enterMultiLobby(a);
+        await enterMultiLobby(b);
+        await enterMultiLobby(c);
+        console.log("[OK] three players in multi lobby");
+
+        // A creates a 3-player TURN-BASED game.
+        // Wire: cmpt <name> <pwd> <perms> <numPlayers> <numTracks> <trackType>
+        //       <maxStrokes> <strokeTimeout> <water> <collision> <scoring>
+        //       <weightEnd> <turnBased>
+        a.sendData("lobby", "cmpt", "TurnRoom", "-", 0, 3, 1, 0, 10, 60, 0, 1, 0, 0, 1);
+        const addLine = await b.waitFor(
+            (s) => /^d \d+ lobby\tgamelist\tadd/.test(s),
+            "B sees gamelist add",
+        );
+        // 16-field gameString: last field should be '1' (turnBased).
+        const fields = addLine.split("\t");
+        const turnBasedField = fields[fields.length - 1];
+        if (turnBasedField !== "1") {
+            throw new Error(`expected trailing turnBased=1 in gamelist add: ${addLine}`);
+        }
+        console.log("[OK] gamelist row carries turnBased=1");
+        await a.waitFor((s) => /^d \d+ status\tgame/.test(s), "A status game");
+        const gameId = parseInt(fields[3] ?? "0", 10);
+
+        // Local A also gets gameinfo; check the trailing turn-based flag (last field is `t`).
+        const gi = await a.waitFor((s) => /^d \d+ game\tgameinfo\t/.test(s), "A gameinfo");
+        const giParts = gi.split("\t");
+        if (giParts[giParts.length - 1] !== "t") {
+            throw new Error(`expected gameinfo trailing turnBased="t": ${gi}`);
+        }
+        console.log("[OK] gameinfo carries turnBased=t");
+
+        // B and C join → room fills → startGame → startturn 0.
+        b.sendData("lobby", "jmpt", String(gameId));
+        await b.waitFor((s) => /^d \d+ status\tgame/.test(s), "B status game");
+        c.sendData("lobby", "jmpt", String(gameId));
+        await c.waitFor((s) => /^d \d+ status\tgame/.test(s), "C status game");
+
+        // Wait for startGame → first startturn 0.
+        await a.waitFor((s) => /^d \d+ game\tstart$/.test(s), "A game start");
+        await a.waitFor((s) => /^d \d+ game\tstarttrack/.test(s), "A starttrack");
+        const aTurn0 = await a.waitFor((s) => /^d \d+ game\tstartturn\t0$/.test(s), "A startturn 0");
+        await b.waitFor((s) => /^d \d+ game\tstartturn\t0$/.test(s), "B startturn 0");
+        await c.waitFor((s) => /^d \d+ game\tstartturn\t0$/.test(s), "C startturn 0");
+        if (!aTurn0) throw new Error("expected startturn 0");
+        console.log("[OK] all three saw startturn 0 after fill");
+
+        // B (slot 1) tries to shoot out of turn → should be silently dropped.
+        // Server gates on `playerId === currentTurn`; no beginstroke broadcast back.
+        const ball = (200 * 1500 + 200 * 4 + 0).toString(36).padStart(4, "0");
+        const mouseB = (100 * 1500 + 150 * 4 + 0).toString(36).padStart(4, "0");
+        a.drain();
+        b.sendData("game", "beginstroke", ball, mouseB);
+        await a.assertNotReceived(
+            (s) => /^d \d+ game\tbeginstroke\t1\t/.test(s),
+            "no broadcast for B's out-of-turn stroke",
+            300,
+        );
+        console.log("[OK] B's out-of-turn beginstroke was rejected");
+
+        // A (current turn) shoots → broadcast to all. Then A's endstroke
+        // advances the turn to slot 1.
+        const mouseA = (300 * 1500 + 250 * 4 + 0).toString(36).padStart(4, "0");
+        a.sendData("game", "beginstroke", ball, mouseA);
+        await b.waitFor((s) => /^d \d+ game\tbeginstroke\t0\t/.test(s), "B sees A's stroke");
+        a.sendData("game", "endstroke", 0, "fff");
+        await b.waitFor((s) => /^d \d+ game\tendstroke\t0\t1\tf$/.test(s), "B sees endstroke 0");
+        await a.waitFor((s) => /^d \d+ game\tstartturn\t1$/.test(s), "A startturn 1");
+        await b.waitFor((s) => /^d \d+ game\tstartturn\t1$/.test(s), "B startturn 1");
+        await c.waitFor((s) => /^d \d+ game\tstartturn\t1$/.test(s), "C startturn 1");
+        console.log("[OK] turn advanced to slot 1 after A's endstroke");
+
+        // A (no longer current turn) tries to shoot again → rejected.
+        a.drain();
+        a.sendData("game", "beginstroke", ball, mouseA);
+        await a.assertNotReceived(
+            (s) => /^d \d+ game\tbeginstroke\t0\t/.test(s),
+            "no broadcast for A's now-out-of-turn stroke",
+            300,
+        );
+        console.log("[OK] A's stroke rejected once it was no longer their turn");
+
+        // B (current turn) parts the game mid-track. Server should:
+        //  - mark slot 1 'p',
+        //  - advance the turn to slot 2 (C),
+        //  - keep the game running (A and C still present).
+        b.sendData("game", "back");
+        await a.waitFor((s) => /^d \d+ game\tpart\t1\t4$/.test(s), "A sees B part");
+        await c.waitFor((s) => /^d \d+ game\tpart\t1\t4$/.test(s), "C sees B part");
+        await a.waitFor((s) => /^d \d+ game\tstartturn\t2$/.test(s), "A startturn 2");
+        await c.waitFor((s) => /^d \d+ game\tstartturn\t2$/.test(s), "C startturn 2");
+        console.log("[OK] turn jumped past the leaver to slot 2");
+
+        // C (current turn) can shoot.
+        const mouseC = (250 * 1500 + 100 * 4 + 0).toString(36).padStart(4, "0");
+        c.sendData("game", "beginstroke", ball, mouseC);
+        await c.waitFor((s) => /^d \d+ game\tbeginstroke\t2\t/.test(s), "C sees own stroke");
+        console.log("[OK] new current-turn player's stroke accepted");
+
+        a.close();
+        b.close();
+        c.close();
+        console.log("\nALL TURN-BASED PHASES PASSED");
+        process.exit(0);
+    } catch (err) {
+        console.error("FAIL:", err);
+        process.exit(1);
+    } finally {
+        if (server) {
+            try { await server.close(); } catch { /* */ }
+        }
+    }
+}
+
+main();

--- a/port/web/src/panels/game.ts
+++ b/port/web/src/panels/game.ts
@@ -349,6 +349,25 @@ export class GamePanel implements Panel {
   private myPlayerId = 0;
   private waterEvent = 0;
   private myNick = "You";
+  /**
+   * Turn-based room: -1 means "no turn assigned" (async room, or between
+   * tracks). Anything ≥ 0 is the slot id whose turn it currently is. Set
+   * from `gameinfo` (for the room mode) and `startturn` (for who shoots).
+   */
+  private turnBased = false;
+  private currentTurnSlot = -1;
+  /** Last "is it my turn" we evaluated - used to fire the beep/title flash
+   *  on the rising edge while the tab is unfocused. */
+  private lastMyTurn = false;
+  /** Original `document.title` snapshotted before we started flashing it,
+   *  so `restoreTitle()` can put it back exactly. */
+  private originalTitle = "";
+  /** RAF/timeout handle for the title flash interval, or 0 when idle. */
+  private titleFlashTimer: ReturnType<typeof setInterval> | null = null;
+  /** Detach handlers for window focus/visibility events so the title flash
+   *  resolves the moment the user comes back to the tab. */
+  private focusHandler: (() => void) | null = null;
+  private visibilityHandler: (() => void) | null = null;
 
   private keyHandler: ((ev: KeyboardEvent) => void) | null = null;
   private mouseMoveHandler: ((ev: MouseEvent) => void) | null = null;
@@ -658,12 +677,18 @@ export class GamePanel implements Panel {
       if (!me || me.ball.inHole || me.simulating) return;
       // Java parity: BUTTON1 = shoot; any other button cycles shootingMode
       // through 0..3 (normal → reverse → 90° CW → 90° CCW → …). The cycle
-      // is gated on the same "ball at rest" condition as a shot.
+      // is gated on the same "ball at rest" condition as a shot. Right-click
+      // mode-cycle stays available even on a peer's turn so the local user
+      // can pre-aim while waiting for their slot to come up.
       if (ev.button !== 0) {
         ev.preventDefault();
         this.cycleShootingMode();
         return;
       }
+      // Turn-based room: refuse the click outright if it isn't my turn. The
+      // server enforces this too, but stopping here also suppresses the
+      // shot-feedback flash and unnecessary network traffic.
+      if (this.turnBased && !this.canIShootNow()) return;
       const [mx, my] = localCoords(ev);
       const dx = me.ball.x - mx;
       const dy = me.ball.y - my;
@@ -758,6 +783,8 @@ export class GamePanel implements Panel {
       // Mirror the mousedown shoot path. Same gating: ball must be at rest.
       const me = this.players[this.myPlayerId];
       if (!me || me.ball.inHole || me.simulating) return;
+      // Turn-based: only shoot when it's my turn (mirrors clickHandler).
+      if (this.turnBased && !this.canIShootNow()) return;
       const dx = me.ball.x - mx;
       const dy = me.ball.y - my;
       if (Math.sqrt(dx * dx + dy * dy) < TOUCH_SHOT_DEADZONE) return;
@@ -796,6 +823,7 @@ export class GamePanel implements Panel {
       this.setStatus(t("Port_Game_SpriteLoadFailed", "Sprite load failed: %1", String(err)));
     });
 
+    this.setupTurnFocusListeners();
     this.startLoop();
   }
 
@@ -805,6 +833,18 @@ export class GamePanel implements Panel {
     this.closeSettingsMenu();
     this.menuButtonEl = null;
     if (this.keyHandler) window.removeEventListener("keydown", this.keyHandler);
+    // Always restore the title and tear down focus listeners on panel exit:
+    // a tab still showing "(Your turn!) ..." after navigating to the lobby
+    // would be incorrect, and the focus/visibility handlers leak otherwise.
+    this.stopTitleFlash();
+    if (this.focusHandler) {
+      window.removeEventListener("focus", this.focusHandler);
+      this.focusHandler = null;
+    }
+    if (this.visibilityHandler) {
+      document.removeEventListener("visibilitychange", this.visibilityHandler);
+      this.visibilityHandler = null;
+    }
     if (this.canvas) {
       if (this.mouseMoveHandler) this.canvas.removeEventListener("mousemove", this.mouseMoveHandler);
       if (this.clickHandler) this.canvas.removeEventListener("mousedown", this.clickHandler);
@@ -847,6 +887,9 @@ export class GamePanel implements Panel {
     this.practiceButton = null;
     this.gameStartedReceived = false;
     this.practiceMode = false;
+    this.turnBased = false;
+    this.currentTurnSlot = -1;
+    this.lastMyTurn = false;
     this.roomCapacity = 1;
     this.overlay = null;
     this.panelEl = null;
@@ -886,6 +929,10 @@ export class GamePanel implements Panel {
         this.roomCapacity = this.numPlayers;
         this.numTracks = parseInt(f[6] ?? "1", 10) || 1;
         this.waterEvent = parseInt(f[10] ?? "0", 10) || 0;
+        // Port extension - 15th field carries the turn-based flag. Older
+        // servers omit it and the parsed value will be undefined; treat as
+        // async so the legacy real-time gating applies.
+        this.turnBased = (f[15] ?? "f") === "t";
         // Fresh gameinfo arrives on every join - reset the "started" gate so
         // the Practice button reappears for any new room (including a
         // re-join). The trailing `f` flag in the packet always says
@@ -893,10 +940,13 @@ export class GamePanel implements Panel {
         // `start` broadcast.
         this.gameStartedReceived = false;
         this.practiceMode = false;
+        this.currentTurnSlot = -1;
+        this.lastMyTurn = false;
         this.ensurePlayerSlots(this.numPlayers);
         this.scoreboardDirty = true;
         this.applyChatVisibility();
         this.updateSkipButtonVisibility();
+        this.refreshTurnIndicator();
         break;
       case "owninfo":
         this.myPlayerId = parseInt(f[2] ?? "0", 10) || 0;
@@ -1063,6 +1113,13 @@ export class GamePanel implements Panel {
         // flip this back on if the start was for practice; otherwise we're
         // in a real game (full room) and per-hole columns should render.
         this.practiceMode = false;
+        // Clear any stale turn pointer left over from the previous game so
+        // the late-arriving `startturn` for the fresh game is the one that
+        // wins. Stop any title flash that was still alive from the prior
+        // round; the player is back at the panel by definition here.
+        this.currentTurnSlot = -1;
+        this.lastMyTurn = false;
+        this.stopTitleFlash();
         // Tear down any leftover end-of-game overlay before the new round
         // starts; otherwise the play-again button stays on screen even though
         // the new game has begun.
@@ -1100,6 +1157,23 @@ export class GamePanel implements Panel {
           const idx = parseInt(f[2] ?? "1", 10) || 1;
           this.currentTrackIdx = idx;
           this.refreshTrackProgress();
+          this.scoreboardDirty = true;
+        }
+        break;
+      case "startturn":
+        // Turn-based room: server announces whose turn it is now. Async
+        // rooms ignore this verb - the server only emits it for `turnBased`
+        // games (one historical async-mode emission survives in
+        // MultiGame.removePlayer for back-compat with stale clients but is
+        // a no-op for them today). Slot id is f[2].
+        {
+          const slot = parseInt(f[2] ?? "-1", 10);
+          this.currentTurnSlot = Number.isFinite(slot) ? slot : -1;
+          this.refreshTurnIndicator();
+          this.maybeBeepAndFlash();
+          // The scoreboard's "(turn)" badge follows currentTurnSlot - mark
+          // the next frame dirty so the badge moves to the new player even
+          // though no player-state field changed.
           this.scoreboardDirty = true;
         }
         break;
@@ -1278,6 +1352,15 @@ export class GamePanel implements Panel {
       }
       this.updateSkipButtonVisibility();
       this.scoreboardDirty = true;
+      // Refresh the "your turn / N's turn" hint - on a fresh track the server
+      // resets the turn pointer and immediately broadcasts `startturn` for
+      // the new hole, but until that packet arrives we flip the indicator to
+      // "waiting" so the previous track's status doesn't linger.
+      if (this.turnBased) {
+        this.currentTurnSlot = -1;
+        this.lastMyTurn = false;
+        this.refreshTurnIndicator();
+      }
       // Replay any beginstrokes that arrived too early.
       const queued = this.pendingBeginStrokes;
       this.pendingBeginStrokes = [];
@@ -1417,6 +1500,10 @@ export class GamePanel implements Panel {
   private maybeSendCursor(nowMs: number): void {
     if (!this.app.connection.isOpen) return;
     if (!this.settings.sendCursor) return;
+    // Turn-based rooms keep aim previews local: peers don't want to watch
+    // the active player line up their shot, and a non-current-turn player's
+    // aim is meaningless to peers anyway. Practice keeps the async behaviour.
+    if (this.turnBased && !this.practiceMode) return;
     const me = this.players[this.myPlayerId];
     if (!me) return;
     if (me.simulating || me.ball.inHole || me.holedThisTrack || me.forfeitedThisTrack) return;
@@ -1667,6 +1754,14 @@ export class GamePanel implements Panel {
         note.textContent = t("Port_Game_StatusInHole", "in hole");
       } else if (p.forfeitedThisTrack) {
         note.textContent = t("Port_Game_StatusForfeited", "forfeited");
+      } else if (this.turnBased && i === this.currentTurnSlot) {
+        // Turn-based room: surface the current-turn player consistently,
+        // both while they're aiming and while their ball is in motion.
+        // The "shooting" note becomes redundant once we know whose turn it
+        // is, so this branch wins over `p.simulating`. Reuses the existing
+        // Java translation key for the same concept ("Currently playing"
+        // / "Lyöntivuorossa" / "Har turen").
+        note.textContent = t("GamePlayerInfo_PlayerTurn", "Currently playing");
       } else if (p.simulating) {
         note.textContent = t("Port_Game_StatusShooting", "shooting");
       }
@@ -1800,7 +1895,11 @@ export class GamePanel implements Panel {
     // actively dragging - without this gate, mouseX/Y stays at the last
     // touch point (or the initial 0,0) and we'd render a stale/origin aim.
     const aimSuppressedByTouch = this.isTouchPrimary && !this.aimingByTouch;
-    if (me && !me.ball.inHole && !me.simulating && !aimSuppressedByTouch) {
+    // Turn-based: hide our own aim line until it's actually our turn.
+    // Drawing it on a peer's turn would be misleading - you can't actually
+    // shoot, and the line would still update with the cursor as if you could.
+    // `canIShootNow()` already short-circuits to true for async / practice.
+    if (me && !me.ball.inHole && !me.simulating && !aimSuppressedByTouch && this.canIShootNow()) {
       aim = {
         fromX: me.ball.x,
         fromY: me.ball.y,
@@ -1872,10 +1971,14 @@ export class GamePanel implements Panel {
       // and on each beginstroke so we never show a stale aim. Suppressed in
       // daily mode: the ghost rendering treats other players as non-interactive
       // shadows of past plays; live aim lines would clash with that framing.
+      // Also suppressed in turn-based rooms (outside practice) - the active
+      // player's aim is private and watching them line up adds clutter the
+      // original Java client never had.
       if (
         this.settings.showPeerCursors &&
         !isMine &&
         !ghost &&
+        !(this.turnBased && !this.practiceMode) &&
         !p.ball.inHole &&
         !p.simulating &&
         !p.holedThisTrack &&
@@ -2657,6 +2760,104 @@ export class GamePanel implements Panel {
     // layout switch (chat visible on left, stroke/status/forfeit hidden,
     // `.right` becomes a horizontal row). See style.css for the rules.
     if (this.panelEl) this.panelEl.classList.toggle("is-multi", this.numPlayers > 1);
+  }
+
+  // ----- turn-based helpers ---------------------------------------------
+
+  /**
+   * Whether the local player is allowed to begin a stroke right now. Async
+   * rooms always say yes; turn-based rooms only when our slot matches the
+   * server-broadcast `currentTurnSlot`. Practice mode (which the server
+   * never gates) returns true regardless of `turnBased` so the warm-up
+   * keeps its free-play contract.
+   */
+  private canIShootNow(): boolean {
+    if (!this.turnBased) return true;
+    if (this.practiceMode) return true;
+    return this.currentTurnSlot === this.myPlayerId;
+  }
+
+  /**
+   * Update the HUD status string with whose turn it is in turn-based rooms.
+   * Async rooms return early so the existing "Click to shoot" hint stays
+   * visible. Called on every `gameinfo`, `startturn`, and `starttrack`.
+   */
+  private refreshTurnIndicator(): void {
+    if (!this.turnBased) return;
+    if (this.currentTurnSlot < 0) {
+      this.setStatus(t("Port_Game_TurnWaiting", "Waiting for next turn…"));
+      return;
+    }
+    if (this.currentTurnSlot === this.myPlayerId) {
+      this.setStatus(t("Port_Game_TurnYours", "Your turn — click to shoot."));
+    } else {
+      const slot = this.players[this.currentTurnSlot];
+      const nick = slot?.nick || t("Port_Game_PlayerFmt", "Player %1", this.currentTurnSlot + 1);
+      this.setStatus(t("Port_Game_TurnOther", "%1's turn — wait for them to shoot.", nick));
+    }
+  }
+
+  /**
+   * On the rising-edge of "it just became my turn" while the tab is in the
+   * background, beep and start flashing the document title. Both effects are
+   * suppressed once the user focuses the tab again (see `setupTurnFocusListeners`).
+   * No-op for async rooms, peer turns, or repeated `startturn` packets that
+   * confirm but don't change my turn state.
+   */
+  private maybeBeepAndFlash(): void {
+    const myTurn = this.canIShootNow() && this.turnBased && this.currentTurnSlot === this.myPlayerId;
+    const wasMine = this.lastMyTurn;
+    this.lastMyTurn = myTurn;
+    if (!myTurn || wasMine) return;
+    const tabHidden =
+      document.visibilityState === "hidden" || (typeof document.hasFocus === "function" && !document.hasFocus());
+    if (!tabHidden) return;
+    audio.playNotify();
+    this.startTitleFlash();
+  }
+
+  private startTitleFlash(): void {
+    if (this.titleFlashTimer !== null) return;
+    if (typeof document === "undefined") return;
+    this.originalTitle = document.title;
+    const alertText = t("Port_Game_TurnTitleAlert", "(Your turn!) ");
+    let on = true;
+    document.title = alertText + this.originalTitle;
+    this.titleFlashTimer = setInterval(() => {
+      // Stop flashing the moment the user comes back, even if the focus
+      // listener hasn't fired yet (older browsers fire visibilitychange but
+      // not focus on a programmatic tab activation).
+      const stillHidden =
+        document.visibilityState === "hidden" || (typeof document.hasFocus === "function" && !document.hasFocus());
+      if (!stillHidden) {
+        this.stopTitleFlash();
+        return;
+      }
+      on = !on;
+      document.title = on ? alertText + this.originalTitle : this.originalTitle;
+    }, 1000);
+  }
+
+  private stopTitleFlash(): void {
+    if (this.titleFlashTimer !== null) {
+      clearInterval(this.titleFlashTimer);
+      this.titleFlashTimer = null;
+    }
+    if (this.originalTitle && typeof document !== "undefined") {
+      document.title = this.originalTitle;
+      this.originalTitle = "";
+    }
+  }
+
+  /** Register window focus / document visibility listeners that stop the
+   *  title flash the moment the user comes back to the tab. Called once
+   *  from `mount`. */
+  private setupTurnFocusListeners(): void {
+    const restore = (): void => this.stopTitleFlash();
+    window.addEventListener("focus", restore);
+    document.addEventListener("visibilitychange", restore);
+    this.focusHandler = restore;
+    this.visibilityHandler = restore;
   }
 
   private ensurePlayerSlots(n: number): void {

--- a/port/web/src/panels/lobby-multi.ts
+++ b/port/web/src/panels/lobby-multi.ts
@@ -3,7 +3,7 @@ import type { App } from "../app.ts";
 import type { Panel } from "../panel.ts";
 import { t } from "../i18n.ts";
 
-/** A row from the lobby's game list. Mirrors the 15-field gameString. */
+/** A row from the lobby's game list. Mirrors the 16-field gameString. */
 interface GameInfo {
   id: number;
   name: string;
@@ -27,6 +27,12 @@ interface GameInfo {
   scoring: number;
   scoringEnd: number;
   currentPlayers: number;
+  /**
+   * Port extension - 16th gameString field. True for turn-based rooms, false
+   * (or missing) for the default real-time async play. Drives the "(Turns)"
+   * badge in the lobby's game list.
+   */
+  turnBased: boolean;
 }
 
 interface PlayerInfo {
@@ -67,7 +73,8 @@ function parsePlayerString(s: string): PlayerInfo {
   };
 }
 
-/** Build a GameInfo from 15 consecutive fields. */
+/** Build a GameInfo from 16 consecutive fields. */
+const GAME_FIELD_STRIDE = 16;
 function parseGameFields(fields: string[], offset: number): GameInfo {
   const f = (i: number): string => fields[offset + i] ?? "";
   return {
@@ -89,6 +96,10 @@ function parseGameFields(fields: string[], offset: number): GameInfo {
     scoring: parseInt(f(12), 10) || 0,
     scoringEnd: parseInt(f(13), 10) || 0,
     currentPlayers: parseInt(f(14), 10) || 0,
+    // Port extension. Missing (older server) or "0" → false. Anything truthy
+    // ("1") → true. Older clients still parse the previous 15 fields and
+    // simply ignore this column.
+    turnBased: f(15) === "1",
   };
 }
 
@@ -335,12 +346,12 @@ export class LobbyMultiPanel implements Panel {
   private handleGameList(f: string[]): void {
     const op = f[2];
     if (op === "full") {
-      // lobby gamelist full <count> <g0_f0> ... <gN_f14>
+      // lobby gamelist full <count> <g0_f0> ... <gN_f15>
       const count = parseInt(f[3] ?? "0", 10) || 0;
       this.games.clear();
       for (let i = 0; i < count; i++) {
-        const offset = 4 + i * 15;
-        if (offset + 14 >= f.length) break;
+        const offset = 4 + i * GAME_FIELD_STRIDE;
+        if (offset + GAME_FIELD_STRIDE - 1 >= f.length) break;
         const g = parseGameFields(f, offset);
         this.games.set(g.id, g);
       }
@@ -472,6 +483,23 @@ export class LobbyMultiPanel implements Panel {
     grid.appendChild(this.label(t("LobbyReal_WaterEvent", "When ball goes to water:")));
     grid.appendChild(waterSel);
 
+    // Port extension - lobby option to revert to the original Java client's
+    // strict turn order. Default is async (real-time) play; the create form
+    // exposes the toggle so anyone hosting a "classic" room can opt in.
+    const turnBasedSel = document.createElement("select");
+    for (const [v, label] of [
+      ["0", t("Port_Lobby_TurnsAsync", "Real-time (async)")],
+      ["1", t("Port_Lobby_TurnsBased", "Turn-based")],
+    ] as const) {
+      const o = document.createElement("option");
+      o.value = v;
+      o.textContent = label;
+      turnBasedSel.appendChild(o);
+    }
+    fillCell(turnBasedSel);
+    grid.appendChild(this.label(t("Port_Lobby_TurnMode", "Play mode:")));
+    grid.appendChild(turnBasedSel);
+
     wrap.appendChild(grid);
 
     const createBtn = document.createElement("button");
@@ -488,8 +516,10 @@ export class LobbyMultiPanel implements Panel {
       const maxStrokes = parseInt(maxStrokesSel.value, 10);
       const collision = parseInt(collisionSel.value, 10);
       const water = parseInt(waterSel.value, 10);
+      const turnBased = turnBasedSel.value === "1" ? 1 : 0;
       // lobby cmpt <name> <password> <perms=0> <numPlayers> <numTracks>
-      // <trackType> <maxStrokes> <strokeTimeout> <water> <collision> <scoring> <scoringEnd>
+      // <trackType> <maxStrokes> <strokeTimeout> <water> <collision>
+      // <scoring> <scoringEnd> <turnBased>     (port-extension trailing arg)
       this.app.connection.sendData(
         "lobby",
         "cmpt",
@@ -505,6 +535,7 @@ export class LobbyMultiPanel implements Panel {
         collision,
         0,
         0,
+        turnBased,
       );
     });
     wrap.appendChild(createBtn);
@@ -706,6 +737,12 @@ export class LobbyMultiPanel implements Panel {
       const badge = document.createElement("span");
       badge.textContent = t("Port_Lobby_InProgress", "(In progress)");
       badge.style.color = "#806040";
+      metaLine.appendChild(badge);
+    }
+    if (g.turnBased) {
+      const badge = document.createElement("span");
+      badge.textContent = t("Port_Lobby_TurnsBadge", "(Turns)");
+      badge.style.color = "#205080";
       metaLine.appendChild(badge);
     }
     block.appendChild(metaLine);


### PR DESCRIPTION
Adds a "Play mode" select to the create-game form so a host can pick turn-based instead of the port's default real-time async play. Server gates beginstroke on the current turn, advances turn on every endstroke / forfeit / leave, broadcasts startturn for new tracks and late joiners, and ignores turn gating during practice. Client surfaces whose turn it is in the HUD and scoreboard, hides own + peer aim lines outside the active player's turn, suppresses peer cursor broadcasts in turn-based rooms, and beeps + flashes the document title when the local player's turn comes up while the tab is unfocused.

Wire format extended backward-compatibly: gameString gets a 16th trailing field (turnBased), gameinfo a 15th, and cmpt a 14th positional arg. Older clients/servers ignore the extras.

Reuses the existing GamePlayerInfo_PlayerTurn translation for the scoreboard "currently playing" badge; new keys cover the lobby form labels, HUD hints, and the unfocused-tab title alert.

Includes a new test-turn-based.ts smoke test that exercises out-of-turn rejection, turn advance after endstroke, and turn jump past a leaver.