### PR TITLE
Port: consolidate ai/ docs around HOW_IT_WORKS.md as canonical reference

### DIFF
--- a/port/ai/AUTORESEARCH.md
+++ b/port/ai/AUTORESEARCH.md
@@ -1,204 +1,114 @@
-# Autoresearch — implementation guide
+# Autoresearch — quick reference
 
-The autoresearch system implements the design in
-[`AUTORESEARCH_PLAN.md`](./AUTORESEARCH_PLAN.md). This file documents
-the as-built code so you can run it.
+Focused user manual for the autoresearch loop. For the full system
+overview (browser dashboards, HIO scanner, training, etc.) see
+[`HOW_IT_WORKS.md`](./HOW_IT_WORKS.md).
 
-The plan is the *spec*; this file is the *user manual*.
+## What it does
+
+Drives an LLM (Claude Code by default) to search the 27-knob
+`TrainingConfig` space autonomously. Each iteration: read the log,
+hypothesise one knob change, train + eval a fresh agent, keep if the
+score improved or revert otherwise. Logs everything to JSONL so you
+can see what was tried and why.
 
 ## Quick start
 
-```bash
-# from port/ai/
-npm run ai:sanity       # verify Node can import the RL modules (one-time)
-npm run ai:eval:smoke   # 1-map 5-second smoke test (~10s)
-npm run ai:eval:short   # full 16-map eval, short budget (~10–15 min)
-npm run ai:analyze      # ASCII plots + keep-rate stats
-```
-
-The autonomous loop:
+From `port/ai/`:
 
 ```bash
-npm run ai:loop:dry     # exercise the loop machinery without an LLM
+# Verify Node can import the RL modules (one-time)
+npm run ai:sanity
+
+# Smoke-test the eval harness (~10s)
+npm run ai:eval:smoke
+
+# Run the full eval at default budget (~16 maps × 3 seeds × 60s ≈ 48 min)
+npm run ai:eval
+
+# Print ASCII plots of the log
+npm run ai:analyze
+
+# Start the autonomous loop (CLI)
 npm run ai:loop -- --max-iterations 30 --agent-cmd 'claude --print'
+
+# Or drive it from the browser:
+#   http://localhost:5180/autoresearch.html — loop control + live status
+#   http://localhost:5180/autoresearch-report.html — post-run analysis
 ```
 
-Single-map experiments (own log, won't pollute the main one):
+Single-map experiment (own log, won't pollute the main one):
 
 ```bash
 node --experimental-strip-types research_loop.ts \
   --max-iterations 5 \
   --maps Watertankrun.track \
   --log-path research_log_watertankrun.jsonl \
+  --train-secs 300 \
   --agent-cmd 'claude --print'
 ```
 
-## Two browser views
+## CLI flags
 
-| Page | When to use |
-|---|---|
-| [`/autoresearch.html`](http://localhost:5180/autoresearch.html) | **Live dashboard.** Polls every 2 s while a loop or eval is running. Watch the score chart fill in, see which map/seed/phase is currently running. |
-| [`/autoresearch-report.html`](http://localhost:5180/autoresearch-report.html) | **Post-run report.** Static analysis of a completed loop run: verdict, score chart, per-knob trajectories, per-iteration cards with Claude's reasoning, baseline-vs-best config diff, recommendations. Pass `?log=research_log_NAME.jsonl` to view a specific experiment. |
+`research_loop.ts` and `research_eval.ts` share these flags:
 
-The dashboard has a **"report →"** link in its header that forwards
-the currently-selected log.
+| Flag | Default | What it does |
+|---|---|---|
+| `--max-iterations N` | 30 (loop) | Stop after N iterations even if no stop condition trips |
+| `--budget short\|default\|long` | default | Preset for trainSecs/evalEps/seeds (15/60/120s × 3 seeds) |
+| `--train-secs N` | from budget | Override training seconds per (map, seed) |
+| `--eval-eps N` | from budget | Override eval episodes per (map, seed) |
+| `--seeds 42,123,7` | 3 seeds | Override seed list |
+| `--maps F,G.track` | EVAL_MAPS | Run on a custom subset instead of headless/maps.ts |
+| `--log-path X.jsonl` | research_log.jsonl | Per-experiment log file |
+| `--agent-cmd 'CMD'` | claude --print | The LLM CLI to drive iterations |
+| `--keep-rate-floor 0.1` | 0.1 | Stop when keep-rate over last 30 iters < this |
+| `--plateau-window 50` | 50 | Stop when no new best in this many iters |
+| `--validate-every 20` | 20 | Run a validation-set pass every N kept iters |
+| `--dry-run` | off | Skip the LLM, run eval against current research_program.ts |
 
-## Live dashboard
+## What edits what
 
-While the loop or any eval is running, the live dashboard polls every
-2 s and renders:
+| File | Who edits | When |
+|---|---|---|
+| `program.md` | **You** | When the loop is going off track and you want to redirect it. The loop re-reads it every iteration. |
+| `research_program.ts` | **The loop** | Every iteration. Don't edit manually — the loop will overwrite. |
+| `headless/autoresearch-bounds.ts` | Frozen | Caps "cheap-success" knobs (safetyRetries, numParallel) to close gaming vectors |
+| `headless/maps.ts` | Frozen | The 16 eval maps + 40 validation maps |
+| Everything else under `headless/` and `src/` | Frozen | The evaluator. Editing it would let the loop "improve" by changing the measuring stick. |
 
-- **Score chart**: best-so-far line (green) plus per-iteration dots
-  (filled green = kept, hollow red = reverted).
-- **Live status**: current map / seed / phase / pct, plus loop-level
-  "iteration 3/5, calling_agent | running_eval".
-- **Iteration list**: newest first, with the config diff vs the prior
-  kept iteration, plus the agent's NOTES.
-- **Per-map breakdown**: success rate per map for the latest
-  iteration.
-- **Log dropdown**: switch between the main log, validation log, and
-  any per-experiment `research_log_*.jsonl` (auto-discovered).
+## How a single iteration runs
 
-## Files
+1. Read `research_log.jsonl` (last 30 entries) and `program.md`.
+2. Backup `research_program.ts` to `.research_program.ts.backup`.
+3. Send program.md + log + current research_program.ts to `claude --print`.
+4. Validate the response: must export `TRAINING_CONFIG` with all 27 fields.
+   Anything outside `autoresearch-bounds.ts` is silently clamped.
+5. Write the new research_program.ts.
+6. Spawn `research_eval.ts` — it loads the new program, trains a
+   fresh agent, evaluates, emits one number on stdout.
+7. Compare to prior best (from the log). Strictly better → KEEP.
+   Else → restore from backup.
+8. Append a row to `research_log.jsonl`.
+9. If `iteration % validateEvery == 0` and KEPT → run a validation
+   pass on the held-out 40 maps.
 
-```
-port/ai/
-├── AUTORESEARCH_PLAN.md      # spec (frozen design doc)
-├── AUTORESEARCH.md           # this file (how to run it)
-├── program.md                # ⚙ HUMAN edits this. Steering wheel.
-├── research_program.ts       # ⚙ AGENT edits this. The 27-knob config.
-├── research_eval.ts          # entry: load program → train → eval → emit one number
-├── research_loop.ts          # autonomous-loop driver
-├── research_analyze.ts       # log → ASCII plots
-│
-├── headless/                 # FROZEN. Do not edit during a run.
-│   ├── atlases.ts            #   GIF decoder for collision masks (Node, no canvas)
-│   ├── track-loader.ts       #   fs-based track loader (mirrors browser src/loader.ts)
-│   ├── harness.ts            #   train+eval one config on N maps → one number
-│   ├── maps.ts               #   16 eval maps + 40 validation maps
-│   └── autoresearch-bounds.ts#   tightened bounds that close gaming vectors
-│
-├── scripts/
-│   ├── sanity-check.mjs      # one-time "do imports work in Node?" check
-│   ├── calibration-smoke.mjs # gridSize=5 vs gridSize=11 from AUTORESEARCH_PLAN §10
-│   └── test-headless-load.mjs# end-to-end smoke test
-│
-└── src/                      # FROZEN browser-side trainer (unchanged by autoresearch).
-```
+The loop also writes per-iteration events to
+`research_loop_events.jsonl` for the dashboard's live event feed.
 
-## What's frozen vs mutable
+## Stop conditions
 
-Per `AUTORESEARCH_PLAN.md` §2:
-
-**Frozen** (the loop must not edit these):
-- `port/web/src/game/physics.ts` — physics
-- `port/ai/src/env.ts` — Episode, simulateShot, reward formula
-- `port/ai/src/agent.ts` — actor-critic
-- `port/ai/src/path.ts` — pathfinder
-- `port/ai/src/hio.ts` — HIO brute-force
-- `port/ai/src/nn.ts` — MLP
-- `port/ai/src/config.ts` — TrainingConfig type, DEFAULTS
-- Everything under `port/ai/headless/`
-- `port/ai/research_eval.ts`, `research_loop.ts`, `research_analyze.ts`
-- `port/ai/headless/maps.ts` — eval and validation map sets
-
-**Mutable** (the loop edits between iterations):
-- `port/ai/research_program.ts` — `TRAINING_CONFIG` (27 fields) + `NOTES`
-
-**Human-edited** (you, when redirecting the loop):
-- `port/ai/program.md` — priors, off-limits, what to try next
-
-## The metric
-
-One scalar: **mean success rate (% holed) across 16 eval maps × 3 seeds,
-median-by-seed across maps**. Per `AUTORESEARCH_PLAN.md` §3, this is
-**reward-formula-invariant by design**: changing reward magnitudes
-doesn't move the score directly, only via second-order effects on
-training dynamics.
-
-Per-iteration score lives in `research_log.jsonl` (one JSON line per
-eval), with full per-map breakdown.
-
-## Calibration findings
-
-Two empirical observations from running the harness:
-
-1. **HIO locked off in autoresearch.** The HIO brute-force pre-search
-   (`searchHIOFirst=1`) solves nearly every map in the curated eval set
-   in <3s. With HIO on, the score saturates at 1.0 and the RL policy
-   becomes invisible to the metric. `headless/autoresearch-bounds.ts`
-   locks `searchHIOFirst: { min: 0, max: 0 }` so the loop cannot turn
-   it on. The user-facing browser trainer (`src/config.ts`) still
-   allows 0/1 unchanged.
-
-2. **Short budget gives no signal on hard maps.** The
-   gridSize=5 vs gridSize=11 calibration smoke at 15s × 4 maps × 1 seed
-   showed both variants holing 12/12 on CurveI (with stroke-count
-   delta: 8 vs 13) but 0/12 on hazard/teleport/hard maps. The metric
-   (success rate) doesn't see the stroke-count win. If the standard
-   60s budget shows the same flat-zero behaviour, **switch to the
-   composite metric** (option 4 in `AUTORESEARCH_PLAN.md` §3) which
-   captures stroke efficiency as well as raw success.
-
-3. **Recorded baseline (HIO off, short budget): score = 0.125.**
-   Full 16-map × 3-seed eval at 15s training/map, with the
-   handoff-default config (gridSize=9, useNavigation=1, all reward
-   shaping at default zero). Per-map breakdown:
-   - **CurveI** (100% holed, mean 7.67 strokes per hole)
-   - **1stroke4bounces** (100% holed, mean 4 strokes)
-   - All other 14 maps: 0% holed.
-
-   The loop's first concrete signal will be "did this variant solve
-   any of OvalI / Leobas1 / Wormhole / etc?" — those are the lowest-
-   hanging fruit (trivially HIO-able with HIO=1; they fail at 15s of
-   pure RL because exploration noise is too uniform to find the hole).
-   Bumping to 60s (`--budget default`) is the recommended first step
-   for the next operator. If 60s also leaves >12 maps at 0%, switch
-   to the composite metric.
-
-4. **Loop machinery verified.** One full `claude --print` iteration
-   takes ~30 seconds (25s agent + 5s smoke eval) when --eval-mode is
-   set to smoke. The runner correctly applies the LLM's proposed
-   edit, validates the format, runs the eval, compares against the
-   prior best, and either keeps or restores from backup. JSONL
-   logging works; analyzer ASCII plots render correctly.
-
-## How the loop runs
-
-Every iteration the runner:
-
-1. **Backs up** `research_program.ts` to `.research_program.ts.backup`.
-2. **Calls the agent** (`claude --print` by default) with a prompt that
-   includes `program.md`, the last 30 log entries, and the current
-   `research_program.ts`. The agent emits a complete new
-   `research_program.ts` on stdout.
-3. **Validates** the proposal: must export `TRAINING_CONFIG` with all
-   27 fields. Anything outside `headless/autoresearch-bounds.ts`
-   gets clamped silently.
-4. **Runs `research_eval.ts`**, parses the score from stdout's last
-   line.
-5. **Strict-better-or-revert**: if the score didn't improve, restores
-   from backup.
-6. **Logs**: appends to `research_log.jsonl`.
-7. **Stops** when keep-rate drops below 10% or no new best in 50
-   iterations.
-
-## How to redirect the loop
-
-Edit `program.md`. That's the only knob you should turn while the loop
-is running. Don't edit `research_program.ts` directly — the loop will
-overwrite it next iteration.
-
-If something breaks: stop the loop (Ctrl+C; it finishes the current
-iteration cleanly). Inspect `research_log.jsonl` and
-`research_runner_log.jsonl`. Resume by running `npm run ai:loop`
-again — log + program.ts state are preserved across runs.
+- **Manual** — Ctrl-C (CLI) or click ■ Stop in the dashboard. The
+  Vite plugin runs `taskkill /T /F` (Windows) / `kill -TERM -<pgid>`
+  (POSIX) so the loop process tree dies cleanly (loop + claude
+  --print + research_eval).
+- **Keep-rate floor** — fewer than 10% of last 30 iters were kept.
+- **Score plateau** — no new best in 50 iterations.
 
 ## How to extend the mutable surface
 
-Per `AUTORESEARCH_PLAN.md` §2, this is a **deliberate human
-decision**, not the loop's choice. Wait until the loop's keep-rate
-drops below ~10% on the 27-knob space, then:
+This is a deliberate human decision, not the loop's choice. Wait until
+the keep-rate drops below ~10% on the 27-knob space, then:
 
 1. Decide what to expose: encoder shape, optimizer choice, etc.
 2. Add the field to `TrainingConfig` in `src/config.ts`.
@@ -206,22 +116,19 @@ drops below ~10% on the 27-knob space, then:
    with sensible bounds that close the new gaming vector.
 4. Add to `research_program.ts` with a starting value.
 5. Update `program.md` with priors for the new knob.
-6. Reset the loop log (or keep it for comparison; a fresh start is
-   cleaner) and run again.
+6. Optional: reset `research_log.jsonl` for a clean restart, or keep
+   for comparison.
 
-## Implementation notes (for the next agent)
+## Calibration findings
 
-- **Atlases**: pure-JS GIF decoding via `omggif`. Adds ~30KB to
-  `node_modules` and zero native deps. The masks (12.6KB total) could
-  be pre-extracted to a static binary if the GIF decode ever became
-  load-bearing — currently it's <100ms at startup, cached in-process.
-- **Determinism**: every `(map × seed)` trial installs a fresh
-  Mulberry32 PRNG over `Math.random` and restores the original
-  afterward. Same seed reproduces same rollout for same config.
-- **Storage isolation**: the Node harness never touches localStorage.
-  The user-facing browser trainer's saved policies (`minigolf-ai:
-  policy:v3:*`) are not affected by autoresearch runs.
-- **Wall-clock fairness**: training is wall-clock-budgeted. A variant
-  that simulates faster gets more episodes; a variant that simulates
-  slower gets fewer. This is the design choice — wall-clock is the
-  scarce resource, not episodes.
+- **HIO locked off** in autoresearch (`searchHIOFirst: {min:0,max:0}`).
+  The brute-force pre-search solves nearly every curated eval map in
+  <3s. With it on, score saturates at 1.0 and the RL policy becomes
+  invisible to the metric.
+- **Single-map default-budget runs scored 0.0** on Watertankrun
+  across 5 iterations (progressBonus + initLogStd variants). The map
+  is too hard at 60s × 3 seeds for the metric to discriminate. Bigger
+  budget (`--train-secs 300`) or easier map are the next moves.
+- **Loop machinery verified**: one full `claude --print` iteration
+  takes ~30s in smoke mode. KEEP/REVERT logic, JSONL logging, ASCII
+  plots all working.

--- a/port/ai/AUTORESEARCH_PLAN.md
+++ b/port/ai/AUTORESEARCH_PLAN.md
@@ -1,9 +1,33 @@
 # Autoresearch handoff plan
 
+> **Status (2026-05-10): IMPLEMENTED.** This document is the original
+> design rationale, kept for historical context. The as-built system
+> is documented in [`HOW_IT_WORKS.md`](./HOW_IT_WORKS.md) §10 (the
+> autoresearch loop) and [`AUTORESEARCH.md`](./AUTORESEARCH.md) (CLI
+> quick reference). The numbered sections below trace cleanly to the
+> code:
+>
+> | Plan section | Implementation |
+> |---|---|
+> | §1 Six principles | Encoded in the structure of `research_loop.ts` + `headless/autoresearch-bounds.ts` |
+> | §2 Mutable vs frozen | `research_program.ts` is the only mutable file; everything else under `headless/` and `src/` is frozen |
+> | §3 Scalar metric | `research_eval.ts:medianBySeed` — mean success rate across maps, median across seeds |
+> | §4 Eval harness | `headless/harness.ts`, `headless/maps.ts`, `headless/track-loader.ts`, `headless/atlases.ts` |
+> | §5 program.md | [`program.md`](./program.md) — read by the loop every iteration |
+> | §6 The loop | `research_loop.ts` |
+> | §7 Implementation tasks | All seven tasks delivered (Node sanity-check, headless harness, eval set, program.ts/md, loop runner, analysis script). Plus the four browser pages and the HIO scanner that grew out of it. |
+> | §8 Failure modes | Each "do not do" is enforced: `autoresearch-bounds.ts` clamps gameable knobs, the harness loads research_program.ts via dynamic import only, every iteration trains from scratch. |
+> | §11 Stop conditions | Implemented as `--keep-rate-floor` and `--plateau-window` in `research_loop.ts` |
+>
+> Read the rest of this file when designing extensions to the loop.
+> For day-to-day usage, [`HOW_IT_WORKS.md`](./HOW_IT_WORKS.md) §10 is
+> what you want.
+
+---
+
 A plan for applying the *principles* of Karpathy's
 [autoresearch](https://github.com/karpathy/autoresearch) to this RL trainer
-(`port/ai`). **This is a design doc — no code yet.** The next agent
-implements it.
+(`port/ai`).
 
 The previous context window built a lot of mechanism (HIO search, safety
 filter, pathfinder, navigation channel, ~27 tunable knobs, etc.). What

--- a/port/ai/HOW_IT_WORKS.md
+++ b/port/ai/HOW_IT_WORKS.md
@@ -1,432 +1,948 @@
-# How the minigolf RL trainer works
+# How `port/ai` works — the complete guide
 
-A plain-English guide to everything in `port/ai/`. No prior knowledge of
-machine learning required.
+A plain-English tour of everything in `port/ai/`. Read top to bottom
+to understand the whole system; jump to a section if you know what
+you're after.
+
+> This file is the canonical reference. The other docs in `port/ai/`
+> ([`AUTORESEARCH.md`](./AUTORESEARCH.md), [`AUTORESEARCH_PLAN.md`](./AUTORESEARCH_PLAN.md),
+> [`program.md`](./program.md)) are deliberately narrower — they cover
+> one topic each. When something contradicts, this file wins.
+
+---
+
+## Contents
+
+1. [What is this?](#1-what-is-this)
+2. [Quick start](#2-quick-start)
+3. [The five entry points](#3-the-five-entry-points)
+4. [The agent](#4-the-agent)
+5. [What the agent sees and does](#5-what-the-agent-sees-and-does)
+6. [The training loop](#6-the-training-loop)
+7. [Reward shaping](#7-reward-shaping)
+8. [Helper systems](#8-helper-systems)
+9. [Persistence](#9-persistence)
+10. [The autoresearch loop](#10-the-autoresearch-loop)
+11. [Browser dashboards](#11-browser-dashboards)
+12. [The HIO scanner](#12-the-hio-scanner)
+13. [Physics quirks the port carries](#13-physics-quirks-the-port-carries)
+14. [Files](#14-files)
+15. [Common workflows](#15-common-workflows)
+16. [Glossary](#16-glossary)
+17. [Things that can go wrong](#17-things-that-can-go-wrong)
 
 ---
 
 ## 1. What is this?
 
-It's a small browser app that **teaches a tiny neural network to play
-Aapeli minigolf maps**. You watch a ball get whacked across a course
+A small browser app + Node CLI that **teaches a tiny neural network to
+play Aapeli minigolf**. You watch a ball get whacked across a course
 thousands of times — bad shots at first, gradually better — until the
-network has figured out a reliable way to sink the ball in as few strokes
-as possible.
+network has figured out a reliable way to sink the ball.
 
-Two ways to use it:
+Everything runs locally:
 
-- **Single-map view** (`/`): pick one map, watch four agents train on it
-  in parallel, with charts and stats.
-- **Grid view** (`/grid.html`): train any number of maps side by side.
-  Use it to "solve every map in the catalogue" overnight.
+- The browser side runs the trainer and dashboards (no network calls).
+- The Node side runs the autoresearch loop and the hole-in-one scanner
+  using the *exact same physics* the browser uses (imported directly
+  from `port/web/src/game/`).
 
-Everything runs in the browser. Nothing gets sent to a server. Trained
-policies are saved in your browser's localStorage so they survive
-refreshes.
+Nothing is sent to a server. Trained policies and scan results live in
+your browser's localStorage and as JSON files in this directory.
 
 ---
 
-## 2. The big idea (how the agent learns)
+## 2. Quick start
 
-Imagine teaching a kid minigolf without telling them any rules. You let
-them swing the club, see where the ball goes, and just say "good" if it
-got closer to the hole or "bad" if it got farther. After thousands of
-swings, the kid will have figured out — through pure trial and error —
-how to play that hole.
+From `port/ai/`:
 
-That's exactly what's happening here, just much faster. The "kid" is a
-neural network. Each "swing" is one stroke. The "good/bad" signal is the
-**reward**.
+```bash
+# Install (first time only) and start the dev server
+npm install                  # also installs omggif (Node-side GIF decoder)
+npm run dev                  # serves http://localhost:5180
 
-The big difference from a real kid: the network has no eyes. It doesn't
-*see* the map as pixels. Instead, it gets a small list of numbers
-describing the ball's situation, and it outputs two numbers describing
-where to aim. That's it.
+# Verify the Node side can import the RL modules
+npm run ai:sanity            # ~2s — pure import check
 
----
+# Smoke-test the eval harness
+npm run ai:eval:smoke        # ~10s — 1 map, 5s of training
 
-## 3. What the agent actually sees and does
+# Open the browser dashboards
+#   http://localhost:5180/                         single-map trainer
+#   http://localhost:5180/grid.html                grid trainer (N maps in parallel)
+#   http://localhost:5180/autoresearch.html        live autoresearch dashboard
+#   http://localhost:5180/autoresearch-report.html post-run autoresearch report
+#   http://localhost:5180/hio.html                 hole-in-one tracks list
+```
 
-### State (input to the network) — 111 numbers
+To start an autoresearch loop from the browser, open
+`/autoresearch.html`, fill in the loop-control panel, and click **Start**.
+To run the HIO scan over every track:
 
-- 4 numbers describing position: ball x, ball y, hole x, hole y
-  (normalized to roughly -1 to 1).
-- 75 numbers describing a **5×5 grid of tiles around the ball**, with 3
-  flags per tile: "is this a wall?", "is this the hole?", "is this a
-  hazard (water, mine, acid)?".
-- 32 numbers describing a **ball→hole ray**: 16 evenly-spaced sample
-  points along the straight line between ball and hole, with 2 flags
-  per sample ("is wall here?", "is hazard here?"). Answers the question
-  "is there water in my path if I aim at the hole?" — the 5×5 grid is
-  blind past the ball's immediate neighbourhood.
+```bash
+node --experimental-strip-types scripts/scan-hio.mjs --workers 8
+```
 
-The grid lets the network see its immediate surroundings; the ray gives
-it a long-range path view. Without either, the network would have to
-memorize positions from scratch on each map.
-
-### Action (output of the network) — 4 numbers
-
-- 2 numbers for the *mean* of the shot: how far in x and y to aim from
-  the ball.
-- 2 numbers for the *uncertainty* of the shot: how much random spread
-  to add around the mean.
-
-The actual shot is a random sample from a 2D Gaussian "blob" centered on
-the mean. If the network is uncertain, the blob is wide and shots vary
-a lot. If it's confident, the blob is tight and shots cluster.
-
-### The shot itself
-
-The two action numbers are interpreted as a mouse-cursor offset from the
-ball. Distance from ball = power. Direction = aim. This is exactly how
-the original Aapeli minigolf game worked — you click the mouse somewhere
-near the ball and the ball flies in that direction with that much force.
+Expect ~2-3 hours for the full 2062-track scan. Partial results show
+up live in `/hio.html` as it runs.
 
 ---
 
-## 4. The network's brain
+## 3. The five entry points
 
-It's a small "multi-layer perceptron" (MLP). Three layers of math:
+| Page / CLI | What it does | When to use |
+|---|---|---|
+| **`/index.html`** (single-map view) | Watch four agents train one map in parallel. Live charts, stats, controls. | "Teach me one map fast" / debugging features. |
+| **`/grid.html`** (grid view) | Train any number of maps side by side, one cell per map. | "Solve the catalogue overnight." |
+| **`/autoresearch.html`** (live dashboard) | Drives the autoresearch loop from the browser. Start/Stop button, live event feed, score chart. | Watch the loop search the 27-knob hyperparameter space in real time. |
+| **`/autoresearch-report.html`** (post-run report) | Static analysis of a completed loop run: verdict, score chart, per-knob trajectories, per-iteration cards with Claude's reasoning, baseline-vs-best diff. | "Did the last loop run actually improve anything? What changed?" |
+| **`/hio.html`** (HIO tracks list) | Lists every track that's hole-in-one-able. Filter by name, sort by candidates-tried. Each row deep-links to the single-track viewer. | Find which tracks have a 1-stroke solution; spot maps where humans missed the optimal route. |
 
-1. **111 inputs → 32 hidden neurons** (with a "tanh" squash that keeps
-   numbers between -1 and +1)
-2. **32 hidden → 4 policy outputs** (the means + uncertainties above)
-3. **32 hidden → 1 value output** (the *critic*; explained below)
-
-That's about 3,700 numbers ("weights") that get tuned during training.
-A serious modern AI has billions of weights — this is tiny. The whole
-network fits comfortably in 100 KB of localStorage.
-
-### The actor and the critic
-
-There are *two* heads on the network sharing the same first layer:
-
-- The **actor** (policy head, 4 outputs) decides what action to take.
-- The **critic** (value head, 1 output) predicts how well the agent is
-  going to do from this state.
-
-This is called **actor-critic**. The critic helps the actor learn more
-stably — instead of judging an action only by the final outcome, the
-actor compares the outcome to what the critic *predicted* the outcome
-would be. Surprises (good or bad) are what drives learning.
+`/index.html?map=Foo.track` deep-links to a specific map. The other
+pages keep their state in URL params too, so you can bookmark a
+specific report or HIO experiment.
 
 ---
 
-## 5. The training loop
+## 4. The agent
 
-For one map, the loop looks like this:
+A small **multi-layer perceptron** (MLP) with two output heads (an
+"actor-critic" architecture). The whole network is ~3.7 KB of
+floating-point weights and fits in localStorage easily.
 
-1. Start a fresh ball at the map's start tile.
-2. **Look** at the state (79 numbers).
-3. **Forward pass:** run the state through the network → get the action
-   distribution.
-4. **Sample** a random action from that distribution.
-5. **Apply** the shot. Physics runs the ball until it stops or holes.
-6. If holed → episode done. If not, go to step 2 for the next stroke.
-7. After 30 strokes without holing → episode is a "failure".
-8. Compute the **reward** for the episode.
-9. **Backward pass:** adjust the network's weights so good actions
-   become more likely and bad actions less likely next time.
-10. Start a new episode and repeat.
+```
+state (~424 numbers)
+    │
+    ▼
+[ Linear ]  ← inputSize × hiddenSize  (default: 424×32)
+    │
+    ▼
+[ tanh ]    ← keeps outputs in [-1, 1]
+    │
+    ├──► Actor head  (hiddenSize × 4)  ← μₓ, μᵧ, log σₓ, log σᵧ
+    │                                    "where to aim and how confidently"
+    │
+    └──► Critic head (hiddenSize × 1)  ← V(s)
+                                         "expected return from this state"
+```
 
-Steps 1–7 are "rollout". Step 9 is "learning". The whole thing runs
-hundreds of times per second on a normal computer.
+- **Actor** outputs four numbers: the mean of a 2D Gaussian (where to
+  aim) and its log-standard-deviations (how spread out random samples
+  should be). Each shot is a sample from this Gaussian.
+- **Critic** predicts the expected episode return from the current
+  state. The actor uses the critic's prediction as a baseline for its
+  policy gradient (see §6).
 
-### The reward
+The architecture is hand-coded in `src/nn.ts` and trained via
+hand-coded backprop in `src/agent.ts` — no autograd library, no GPU.
+Every gradient is visible in source.
 
-Per-stroke recipe:
+---
 
-- **−1 for every stroke** (encourages using fewer strokes).
-- **+20 on the holing stroke** (encourages reaching the hole).
-- **−3 extra if a stroke ends in water** (water teleports the ball back
-  to where you shot from, so without this term water-shots and
-  grass-shots produce identical state/reward and the policy has no
-  gradient pulling it off "full speed at water").
-- **−6 extra if a stroke ends in acid** (acid teleports back to the
-  *track* start, undoing prior progress — strictly worse than water).
+## 5. What the agent sees and does
 
-Mines are not penalised (they bump the ball randomly but don't kill it).
+### State features (~424 numbers at default config)
 
-Examples:
-- Holed in 1 stroke → reward = −1 + 20 = **+19** (great)
-- Holed in 5 strokes, no hazards → reward = −5 + 20 = **+15** (good)
-- Holed in 5 strokes, one water bath → reward = −5 + 20 − 3 = **+12**
-- Failed at 30 strokes, four water baths → reward = −30 − 12 = **−42** (bad)
+| Feature | Default size | Toggleable | What it tells the agent |
+|---|---|---|---|
+| Ball + hole positions | 4 | always on | "where am I, where do I want to go" — normalised pixel coords |
+| Ball-centred grid | 9×9 × (3 + 1) = 324 | size adjustable; nav-channel toggleable | A patch of tiles around the ball with 3 boolean channels (wall / hole / hazard) plus an optional 4th channel (pathfinder distance). The 4th channel turns the grid into a *topographic map* the agent can use to navigate around water without ever touching it. |
+| Ball→hole ray | 16 × 2 = 32 | sample count adjustable | 16 evenly-spaced sample points along the straight line ball→hole. 2 channels (wall / hazard). Answers "is there water in my path if I aim at the hole?" |
+| Radial rays | 8 × 4 × 2 = 64 | count and sample count adjustable | 8 rays at fixed compass angles, each with 4 sample points. 2 channels per sample. Answers "which directions are clear?" |
 
-### What "adjust the weights" means
+**Total at defaults: 424 features.** The state encoder is in
+`src/agent.ts:encodeState`.
 
-For each stroke the agent took, the math computes a tiny nudge to every
-single weight in the network — saying "this weight should go up a bit"
-or "this weight should go down a bit" — based on whether the episode
-turned out better or worse than the critic predicted. After running
-many episodes, all those tiny nudges add up to a network that aims
-better.
+The grid covers a ~135×135-pixel patch (the map is 735×375). The grid
+size, ray counts, and navigation channel are all knobs (see §10) — the
+autoresearch loop has tuned these in the past.
 
-This is called **REINFORCE with a value baseline**. It's the same family
-of algorithms used in modern RL papers like PPO and A2C, just stripped
-of refinements.
+### Action
+
+Two numbers: a mouse-cursor offset from the ball. Distance = power,
+direction = aim. This matches how the original Aapeli minigolf game
+worked — click the mouse near the ball, the ball flies.
+
+The actor's four outputs are interpreted as `(μₓ, μᵧ, log σₓ, log σᵧ)`.
+The actual shot is sampled: `(action.dx, action.dy) = (μₓ + ε·σₓ, μᵧ +
+ε·σᵧ)` with ε ∼ N(0, 1). σ shrinks as the agent gets confident.
+
+In **eval mode** the σ is ignored — the agent just plays the mean.
+This is how saved policies replay deterministically.
+
+---
+
+## 6. The training loop
+
+### Single episode
+
+```
+1. Spawn ball at the map's start tile.
+2. Encode state → 424 numbers
+3. Forward pass: state → actor + critic outputs
+4. Pre-roll the action through the safety filter (§8): up to
+   `safetyRetries` times, simulate the shot in a sandbox; if it
+   would land in water/acid, draw a fresh sample.
+5. Apply the chosen shot.
+6. Tick the physics until the ball stops or holes.
+7. If holed → episode done. Else go back to step 2 (or stop at
+   `maxStrokes`, default 30).
+8. Compute discounted per-stroke returns G_t.
+9. For each step in the trace, accumulate the policy + value
+   gradients. After `batchSize` accumulated episodes, apply.
+10. Save trace, repeat.
+```
 
 ### Multi-environment rollouts
 
-Instead of running one episode at a time, the single-map view runs
-**4 episodes in parallel**, all sharing the same network. The four white,
-red, blue, and yellow balls you see on the canvas are the four parallel
-agents. Their gradients get averaged before the weights actually change,
-which makes learning more stable than any single episode would be.
+The single-map view runs **4 episodes in parallel** by default, all
+sharing the same network. Their gradients are averaged before the
+weights actually change. This is "synchronous A2C" — lower variance per
+update for the same wall-clock time. The four white/red/blue/yellow
+balls on the canvas are the four parallel agents.
+
+### Discounted per-step returns
+
+A holing stroke at step N gets the full +20 reward; the strokes
+leading up to it get γⁿ⁻ᵗ × that reward, where γ = 0.99 by default.
+This is "credit assignment" — the actor learns that the last *few*
+shots contributed to the win, weighted by how recent they were. With
+γ = 1, every step in a winning episode gets equal credit.
+
+### Actor-critic update rule
+
+```
+advantage_t = G_t - V(s_t)              # how much better than predicted
+policy_loss = -log π(a_t | s_t) * advantage_t
+value_loss  = (V(s_t) - G_t)²
+total_loss  = policy_loss + valueCoef * value_loss
+```
+
+Standard REINFORCE-with-baseline. The advantage drives the policy
+gradient; the squared error pulls V toward the actual returns.
 
 ---
 
-## 6. Modes (single-map view)
+## 7. Reward shaping
 
-A dropdown in the side panel switches between three modes. Switching is
-non-destructive — weights and stats stay put, only what the agent
-*does* changes.
+Per-stroke recipe:
 
-- **training** — random shots from the policy distribution; weights
-  update after each episode. This is how the agent gets better.
-- **eval** — no randomness; the agent uses the network's mean shot
-  every time. Weights are frozen. Use to see what the policy thinks the
-  "average best" shot is.
-- **best** — replays the exact stroke sequence from the *best-ever*
-  episode you've recorded on this map. This is often shorter than the
-  eval line because best-ever runs are the lucky tail of the random
-  distribution — strokes that the noisy training found by chance.
-
-When the agent reaches PERFECTED (hole-in-1) it auto-switches to "best"
-mode. The recorded sequence becomes the demo.
-
----
-
-## 7. Status badges (what "solved" means)
-
-The little colored pill on each map tells you roughly how done the
-agent is:
-
-| Badge | When you see it | What it means |
+| Term | Default | Fires when |
 |---|---|---|
-| **TRAINING** (gray) | Early, success rate < 50% over recent episodes | The agent is still figuring it out. |
-| **CONVERGING** (amber) | Success rate ≥ 50% | Holes more often than not. Getting there. |
-| **CONVERGED** (green) | Success ≥ 90% over the last 50 episodes, 30+ lifetime, AND best stroke count ≤ the human record (when known) | Reliably solves the map AT a near-optimal stroke count. Auto-saved. |
-| **PERFECTED** (bright green) | Hole-in-1 achieved in eval mode | The optimal possible. Training auto-stops. |
-| **LOADED** (blue) | Loaded a CONVERGED save without enough fresh runs to confirm | "We trust the save but haven't seen 50 fresh runs yet." |
+| `strokePenalty` | −1 | every stroke (encourages fewer strokes) |
+| `holeBonus` | +20 | the holing stroke |
+| `waterPenalty` | −3 | stroke ended in water (ball was teleported back to shot start) |
+| `acidPenalty` | −6 | stroke ended in acid (ball was reset to track start) |
+| `progressBonus` × Δ | 0 | scaled by `pathfinder distance before − after` |
+| `explorationBonus` × Δ | 0 | scaled by `distance from start after − before` |
 
-The "fully solved for our purposes" line is **CONVERGED**. PERFECTED is
-a bonus — only some maps allow hole-in-1.
+`progressBonus` and `explorationBonus` are **optional** dense-shaping
+terms. They're off by default because they're brittle (too high
+swamps the stroke penalty and the policy learns to loiter near the
+hole). When on, `progressBonus` uses the *pathfinder distance* (see
+§8) so detours around water count as progress.
 
-The par-strokes check in CONVERGED is what stops the badge firing on
-maps where the policy settles in a mediocre local minimum (e.g. always
-holes in 3 strokes when 1 or 2 is provably possible). The agent must
-have found at least one trajectory matching the human record before we
-call it done. When the track has no par on file (`bestPar = 0`), we
-fall back to the success-rate-only check.
+Mines are not penalised — they bump the ball randomly but don't kill
+it.
 
----
+Examples (with all shaping at zero):
 
-## 8. The chart
-
-A small line plot below the canvas shows the per-episode reward over
-time:
-
-- **Bright dots** = one episode each
-- **Bold green line** = rolling mean over the last 25 episodes
-
-A successful learning run looks like a line that starts low (around −25
-for failures) and climbs toward positive territory as the agent figures
-out the map.
+| Outcome | Reward |
+|---|---|
+| Holed in 1 | −1 + 20 = **+19** |
+| Holed in 5, no hazards | −5 + 20 = **+15** |
+| Holed in 5, one water bath | −5 + 20 − 3 = **+12** |
+| Failed at 30, four water baths | −30 − 12 = **−42** |
 
 ---
 
-## 9. The speed knob
+## 8. Helper systems
 
-A slider lets you change how many physics ticks happen per rendered
-frame. The browser draws ~60 frames per second; the slider just
-multiplies how much *simulated time* passes between each frame.
+Three pieces of non-RL machinery sit between the network and the
+physics. All three are **off** by configuration alone — flipping their
+knobs lets you compare RL-only against RL-plus-helpers.
 
-- **3** = real game speed (matches the original Aapeli pacing)
-- **30** = ~10× faster, still smooth animation
-- **500–5000** = balls become streaks, fps drops as the per-frame work
-  gets heavy
+### Pathfinder (`src/path.ts`)
 
-For a video recording, anywhere between 30 and 200 looks good. For
-"train as fast as my CPU can go", crank it to 5000.
+A BFS from every hole-tile across the map's collision grid, with:
 
-The slider only affects training cells. Cells in eval/best demo mode
-play at real game speed regardless — that's the deterministic playback,
-no point fast-forwarding.
+- **Ball-radius erosion**: a tile is "passable" only if a 7-pixel
+  circle around its centre is wall-free. Without this, the BFS finds
+  one-pixel-wide gaps the actual ball can't fit through.
+- **Teleporter shortcuts**: teleport-start and teleport-exit pairs
+  share the same BFS distance. The pathfinder's parent pointers
+  correctly walk through teleporters when reconstructing routes.
+- **Multi-hole seeding**: maps with multiple holes seed the BFS from
+  every hole tile, so distance reflects "shortest path to *any* hole."
+
+Result: a `dist` Int16Array (49×25 tile-step distances, normalised) +
+a `parent` array for route reconstruction. Used by:
+
+- The agent's **navigation channel** (4th channel of the ball-centred
+  grid), which tells the policy "which direction is closer to the
+  hole" without it having to figure out walls from scratch.
+- The reward shaping (`progressBonus`).
+- The single-track view's optional **route overlay** (toggle with
+  `#show-route`).
+
+### Safety filter (`src/agent.ts:pickSafeAction`)
+
+The actor samples N candidate actions (`safetyRetries`, default 10).
+For each candidate, the env runs a sandbox simulation in a *cloned*
+map. If the candidate would land the ball in water or acid, it's
+rejected and a fresh one is drawn. After N rejections the filter gives
+up and uses the last sample (so the gradient still gets *some*
+signal).
+
+A second, experimental knob (`learnFromRejectedShots`, default OFF)
+feeds the rejected samples back into the policy as single-sample
+gradient updates with the synthetic water/acid penalty as the reward.
+Was empirically destabilising on heavy-water maps; left as a knob.
+
+### HIO brute-force pre-search (`src/hio.ts`)
+
+For each map, before any training, sweep a polar grid of candidate
+shots (default 1° angle × 2-px power, ~35 000 candidates) and check if
+*any* of them holes. If so, save that exact shot as the PERFECTED
+route — no training needed.
+
+`searchHIOFirst` is the toggle (default ON in the browser trainer,
+LOCKED OFF for autoresearch — see §10). Live visualisation of the
+search overlay paints each candidate's trajectory onto the canvas as
+the search runs.
+
+This is also the engine behind the standalone HIO scanner (§12).
 
 ---
 
-## 10. Persistence (saving across reloads)
+## 9. Persistence
 
 Trained networks save themselves to your browser's **localStorage**.
-One key per map, like `minigolf-ai:policy:v2:CurveI.track`. Each save
-is about 100 KB and contains:
+One key per map, like `minigolf-ai:policy:v3:CurveI.track`. Each save
+is ~100 KB and contains:
 
-- All 2,700+ network weights
-- The current best-strokes record
-- The recorded best-ever action sequence
-- Status (BEST_IMPROVED / CONVERGED / PERFECTED)
-- Lifetime episode count
-- Recent rolling-window stats (so charts and counters resume in place)
+- All network weights + value-head weights
+- Current best-strokes record
+- Recorded best-ever action sequence (replayed in "best" mode)
+- Status (TRAINING / CONVERGING / CONVERGED / PERFECTED / LOADED)
+- Lifetime episode count + recent rolling stats
 
 Saves happen automatically when:
+
 - A new best-strokes record is hit
-- Status crosses into CONVERGED
-- Status reaches PERFECTED
-- Every 50 episodes (so live counters stay current)
+- Status crosses into CONVERGED or PERFECTED
+- Every 50 episodes (so live counters survive reload)
 
-On load, if a save exists for the picked map, it gets restored
-automatically. PERFECTED saves auto-enter "best" mode and start their
-demo loop right away.
+Per-map training **configs** save separately under
+`minigolf-ai:config:v1:<map>`. Storing config per map lets you tune
+high-water maps without affecting easy ones.
 
-**Where to find it on disk**: F12 → Application tab → Local Storage →
-`http://localhost:5180`. Each entry is a JSON blob. The "delete saved
-policies" button in the grid view's header wipes everything.
-
----
-
-## 11. The grid view
-
-`/grid.html` shows N cells, one per map, all training simultaneously.
-
-What's nice about it:
-
-- **Add any map** from the 2,000+ available via the dropdown at the
-  top.
-- **Remove any cell** with the × button on its header.
-- **Selection persists** in localStorage, so your custom set comes back
-  on refresh.
-- **Each cell shows the original Playforia metadata**: map author, par
-  (best human score), record holder, total plays, etc. Compare the
-  agent's `best:` to the human `par:` to see how it's doing.
-- **Solved cells stop training** and play their best route at game
-  speed on a loop. Great for video — once a map flips to green, it
-  becomes a clean visual on permanent loop.
-
-Memory cost is roughly 10 MB per cell. With 6 cells (default) you're
-using ~60 MB. Don't add 200 cells unless you've got memory to spare.
+The Node-side autoresearch harness **never touches localStorage** —
+it trains from scratch every iteration and writes JSONL files instead
+(see §10).
 
 ---
 
-## 12. Common things to do
+## 10. The autoresearch loop
 
-### Train one map fast
-1. Open `/`
-2. Pick a map
-3. Slide speed up to ~500
-4. Wait a few minutes for the badge to turn green
+The 27 knobs across `src/config.ts` are too many to tune by hand
+across 2000+ maps. The autoresearch loop replaces the human tuner
+with an LLM driving local search through hyperparameter space.
 
-### Solve every curated map
-1. Open `/grid.html`
-2. Slide speed up to 1000+
-3. Walk away
-4. Come back, look at the `solved: X / Y` counter
+The full design rationale is in
+[`AUTORESEARCH_PLAN.md`](./AUTORESEARCH_PLAN.md). What's below is
+how the *as-built* system runs.
 
-### Make a video of clean playback
-1. Open `/grid.html`
-2. Add the maps you want
-3. Wait until they all turn green
-4. Record the screen. Each cell is now a deterministic loop at real
-   game speed.
+### The shape
 
-### Compare your policy to humans
-- Look at the metadata under each map. `avg strokes / play` is the
-  human community's average. The agent's `best` and `success` should
-  match or beat this on easy maps.
+```
+                  one iteration
+   ┌──────────────────────────────────────────────────┐
+   │                                                  │
+   │  1. Loop runner reads research_log.jsonl + program.md
+   │  2. Loop runner asks Claude Code:                │
+   │     "given these last 30 iterations,             │
+   │      change ONE knob in research_program.ts"     │
+   │  3. Claude returns a new research_program.ts     │
+   │  4. Runner validates: must export TRAINING_CONFIG│
+   │     with all 27 fields; out-of-bounds get clamped│
+   │  5. Runner spawns research_eval.ts:              │
+   │     - load research_program.ts                   │
+   │     - train fresh agent, N seconds × M maps × K seeds
+   │     - eval (deterministic policy mean), record holed-rate
+   │     - emit one number on stdout (median across seeds)
+   │  6. Runner compares to prior best:               │
+   │     - strictly better → KEEP                     │
+   │     - else            → revert from backup       │
+   │  7. Runner appends a row to research_log.jsonl   │
+   │                                                  │
+   └──────────────────────────────────────────────────┘
+              ↓
+        loop again until stop condition
+```
 
-### Reset everything
-- "delete saved policies" in the grid header wipes all saves.
-- "reset agent" in the single-map side panel resets just the current
-  map's network.
+### What's frozen vs mutable
+
+The loop edits exactly one file. Everything else is the evaluator and
+must not move during a run.
+
+**Mutable** (the loop edits between iterations):
+- `research_program.ts` — exports `TRAINING_CONFIG` (the 27 knobs) and
+  `NOTES` (a freeform paragraph the loop maintains across iterations
+  to remember its own reasoning).
+
+**Human-edited** (you, when redirecting the loop):
+- `program.md` — priors, off-limits, what to try next. The loop
+  re-reads it every iteration. If the loop's going off track, edit
+  this file and it'll see the change immediately.
+
+**Frozen** (the loop must not edit these):
+- `port/web/src/game/physics.ts` — the simulator
+- `src/env.ts` — Episode, simulateShot, reward formula
+- `src/agent.ts`, `src/nn.ts` — the network
+- `src/path.ts`, `src/hio.ts` — pathfinder + HIO search
+- `src/config.ts` — `TrainingConfig` type, `DEFAULTS`
+- Everything under `headless/` — the eval harness, atlas loader,
+  track loader, eval/validation map sets, autoresearch bounds
+- `research_eval.ts`, `research_loop.ts`, `research_analyze.ts` — the
+  loop itself
+
+### The 27 knobs
+
+Defined in `src/config.ts` (`TrainingConfig`). Categories:
+
+| Category | Knobs |
+|---|---|
+| Architecture | `gridSize`, `raySamples`, `radialRays`, `radialSamplesPerRay`, `radialRayMaxDist`, `useNavigation`, `hiddenSize` |
+| Optimizer | `lr`, `gamma`, `batchSize`, `valueCoef`, `gradClip` |
+| Action distribution | `meanScale`, `initLogStd`, `logStdMin`, `logStdMax` |
+| Reward | `strokePenalty`, `holeBonus`, `waterPenalty`, `acidPenalty`, `progressBonus`, `explorationBonus` |
+| Episode/runtime | `maxStrokes`, `numParallel` |
+| Safety/search | `safetyRetries`, `learnFromRejectedShots`, `searchHIOFirst` |
+
+`headless/autoresearch-bounds.ts` defines tighter bounds than the
+user-facing `BOUNDS` in `config.ts`. Specifically, **`searchHIOFirst`
+is locked at `0/0`** for autoresearch — with HIO on, the brute-force
+pre-search solves nearly every curated eval map in <3s and the score
+saturates at 1.0, hiding the RL policy from the metric. Same applies
+to other "cheap-success" knobs like `safetyRetries` (capped at 12) and
+`numParallel` (capped at 8).
+
+### The metric
+
+One scalar: **mean success rate across the eval map set, median by
+seed**. `headless/maps.ts` defines:
+
+- **EVAL_MAPS** (16 maps) — the loop scores against these.
+- **VALIDATION_MAPS** (40 maps) — held-out, checked every 20 iterations
+  to catch overfitting to the eval 16.
+
+Each variant trains for `trainSecsPerMap` seconds × `seeds.length`
+seeds × `EVAL_MAPS.length` maps. Per-seed scores are averaged across
+maps; the median across seeds is the iteration's score.
+
+The metric is **reward-formula-invariant** by design: changing reward
+magnitudes doesn't directly move the score (only via second-order
+effects on training dynamics). Stops the loop "winning" by inflating
+`holeBonus`.
+
+### How to drive it
+
+Three ways:
+
+1. **Browser** (easiest). Open `/autoresearch.html`, fill in the
+   loop-control panel (training secs/seed, maps CSV, log path, max
+   iterations), click **▶ Start**. Watch live. Click **■ Stop** when
+   you want to. Stop kills the loop process tree (`taskkill /T /F` on
+   Windows, `kill -TERM -<pgid>` on POSIX) so the loop AND its
+   `claude --print` child AND any running eval all die together.
+
+2. **`npm run ai:loop`** (CLI):
+   ```bash
+   npm run ai:loop -- --max-iterations 30 --agent-cmd 'claude --print'
+
+   # single-map experiment with own log:
+   node --experimental-strip-types research_loop.ts \
+     --max-iterations 5 \
+     --maps Watertankrun.track \
+     --log-path research_log_watertankrun.jsonl \
+     --agent-cmd 'claude --print'
+   ```
+
+3. **Manual eval** (no LLM): `npm run ai:eval` runs `research_eval.ts`
+   with the current `research_program.ts`. Useful for "what does
+   this hand-tuned config score?"
+
+CLI flags worth knowing:
+
+- `--train-secs N` — override training seconds per (map, seed).
+  Lets you run "5 minutes per training" without editing budget presets.
+- `--eval-eps N` — override eval episodes per (map, seed).
+- `--seeds 42,7,123` — override seed list.
+- `--maps CurveI.track,Watertankrun.track` — restrict to a subset.
+- `--log-path X.jsonl` — write to a custom log so per-experiment runs
+  don't pollute the main `research_log.jsonl`.
+
+### Stop conditions
+
+The loop runner stops on its own when:
+
+- **Keep-rate floor** — fewer than 10% of the last 30 iterations were
+  kept (the search has exhausted the local optimum at this resolution).
+- **Score plateau** — no new best in 50 iterations.
+
+Or, of course, when you click Stop / Ctrl-C / the user signals SIGINT.
+
+### Live status files
+
+The loop and eval write three small JSON files the dashboards poll:
+
+- `.loop_pid.json` — pid + start time. Vite plugin uses this for the
+  Stop button.
+- `.loop_status.json` — current iteration, max, phase
+  (`calling_agent` / `running_eval` / `finished`).
+- `.eval_status.json` — eval-level: current map, seed, training pct.
+
+Plus a JSONL event feed at `research_loop_events.jsonl` (one line per
+key transition: `iteration_start`, `agent_call_start`,
+`agent_call_done`, `eval_start`, `iteration_done`,
+`shutdown_signal`, `loop_finished`, `stopped_by_user`). The live
+dashboard tails this for the "what's happening right now" pane.
+
+All of these are in `.gitignore` — they're regenerated every run.
 
 ---
 
-## 13. Files (where stuff lives)
+## 11. Browser dashboards
+
+The Vite dev server runs at **http://localhost:5180** and serves five
+pages. Production builds (`npm run build`) bundle them all.
+
+### `/index.html` — single-map trainer
+
+The original. Pick a map from the dropdown, watch four agents train,
+see live charts and stats. Every knob in `TrainingConfig` has a UI
+input on the right-hand panel.
+
+URL param: `?map=Foo.track` deep-links to a specific map. Selecting a
+new map updates the URL so a refresh / shared link round-trips.
+
+Mode dropdown:
+
+- **training** — random shots from the policy distribution, weights
+  update.
+- **eval** — deterministic mean shot, weights frozen.
+- **best** — replay the best-ever recorded action sequence (auto-loops).
+
+When the agent reaches PERFECTED (hole-in-1 in eval mode), it
+auto-switches to "best" mode.
+
+Status badge:
+
+| Badge | When you see it |
+|---|---|
+| **TRAINING** (gray) | Recent success rate < 50%. |
+| **CONVERGING** (amber) | Recent success rate ≥ 50%. |
+| **CONVERGED** (green) | Success ≥ 90% over last 50 episodes, 30+ lifetime, AND best ≤ human par when known. |
+| **PERFECTED** (bright green) | Hole-in-one achieved in eval mode. Training auto-stops. |
+| **LOADED** (blue) | Restored a CONVERGED save without enough fresh runs to confirm. |
+
+### `/grid.html` — grid trainer
+
+N maps training side-by-side, one cell per map. Add maps from the
+dropdown; each cell is independent (own network, own config). Solved
+cells stop training and replay their best route on a loop.
+
+Persistence: the cell list is in localStorage so your custom set
+survives refresh. ~10 MB per cell — don't add 200 unless you have RAM.
+
+### `/autoresearch.html` — live dashboard
+
+Read-while-running view of the autoresearch loop. Polls every 2 s.
+Shows:
+
+- **Loop control panel** — Start/Stop buttons, configuration inputs
+  (training secs, maps CSV, log path, max iterations). Talks to the
+  Vite plugin's `/api/loop/{start,stop,status,events}` endpoints.
+- **Score chart** — best-so-far line + per-iteration dots
+  (filled-green = kept, hollow-red = reverted), iteration numbers
+  labelled.
+- **Summary stats** — iterations, best score, total wall, knobs
+  explored, maps tested.
+- **Events feed** — color-coded scrolling log of every key transition
+  (`iteration_start`, `agent_call_start/done`, `eval_start`,
+  `iteration_done` KEPT/REVERTED, `stopped_by_user`).
+- **Live status** — current map / seed / phase / pct progress bar
+  while training/evaluating.
+- **Per-map breakdown** — success rate per map for the latest iteration.
+- **Iteration list** — newest-first, with the config diff vs the prior
+  kept iteration plus the agent's NOTES.
+
+Log dropdown switches between the main eval log, validation log, and
+any per-experiment `research_log_*.jsonl` (auto-discovered).
+
+### `/autoresearch-report.html` — post-run report
+
+Static analysis of a completed loop run. Different from the live
+dashboard: no polling, no live status, just one thorough render of the
+JSONL log. Use after a run to answer "what did this loop actually
+accomplish?"
+
+Sections, top to bottom:
+
+- **Verdict pill** — green ✓ / amber ~ / red ✕ keyed off best vs baseline.
+- **Stat cards** — iterations, best score, wall time, knobs explored, maps.
+- **Score evolution chart** — same as live, larger.
+- **Per-knob trajectories** — only knobs that actually varied get a
+  mini-chart with their distinct values listed. Lets you see "the
+  loop only really tried these two knobs."
+- **Iteration cards** — one per iteration with config diff, an
+  extracted "Hypothesis" line, and the full reasoning blockquote
+  from Claude's NOTES.
+- **Configuration: baseline vs best** — side-by-side table of all 27
+  knobs; differing values highlighted.
+- **Recommendations** — when no improvement, lists knobs not yet
+  tried in this run with one-line explanations of why each might help,
+  plus copy-pasteable bash commands.
+
+URL param: `?log=research_log_NAME.jsonl` selects the experiment.
+
+### `/hio.html` — hole-in-one tracks list
+
+Lists every track in `port/server/tracks/tracks/` with its scan
+status. Filter by name substring; toggle view (HIO-able only / HIO-able
+but humans never got 1 / wall-clip / all / no HIO / errors); sort by
+candidates-tried, scan time, name, file.
+
+Stat cards show:
+
+- Total tracks scanned
+- HIO-able (real, no wall-clips)
+- **Unknown HIO** — HIO-able by physics AND human bestPar > 1. This
+  is the candidate list of "humans missed this 1-stroke route." The
+  amber-highlighted column shows the bestPar with the player name.
+- Wall-clip — scan found a "HIO" but the trajectory phased through
+  walls due to the physics quirk in §13. Hidden from the default list.
+- Grid exhausted, timed out, errors, scan wall.
+
+Each row's `open →` link goes to `/index.html?map=Foo.track`. The
+single-track viewer's URL-param support lets you browse the list and
+jump directly into any map.
+
+The page auto-refreshes every 5 s while a scan is in progress, so the
+list builds live without manual reloads.
+
+---
+
+## 12. The HIO scanner
+
+`scripts/scan-hio.mjs` runs the brute-force HIO search on every track
+and writes the results to `hio-scan.json`. The browser HIO list reads
+from there.
+
+Architecture:
+
+- **8 worker threads** (configurable with `--workers`). Each worker
+  handles one track at a time and posts the result back to the parent.
+- **Per-map time budget** (configurable with `--budget-secs`,
+  default 0 = unbounded). HIO-able maps usually find their answer in
+  <1s; non-HIO-able maps exhaust the full ~35 000-shot grid (~5-15 min
+  CPU each). The budget caps the worst case.
+- **Checkpoints every 10 maps** to `hio-scan.json` so the page can
+  render partial results.
+
+Each scan record includes the track's `bestPar` and `bestPlayer` from
+the .track I-line, so the dashboard can flag "physics says HIO-able
+but no human ever logged 1" — the candidate list of unknown shortcuts.
+
+### Wall-clip detection
+
+The HIO scan ran into a physics quirk: some "HIO" results had the ball
+travelling in a straight line *through walls* (see §13 for the
+explanation). The scanner now **replays each HIO candidate** after the
+search finds it and counts how many wall pixels the trajectory passed
+through. If it's more than 5, the result is tagged `wall_clip: true`
+and excluded from the default HIO list. One-way walls (values 20-23)
+and illusion walls (19) are excluded from the wall-pixel count because
+those are intentionally passable in the right direction.
+
+Real HIOs clip 0 pixels of solid walls. Bogus ones clip 30+ (whole
+wall thicknesses).
+
+### CLI
+
+```bash
+# Full scan, default settings (8 workers, no time budget).
+node --experimental-strip-types scripts/scan-hio.mjs
+
+# Faster but less thorough (2-second budget per map).
+node --experimental-strip-types scripts/scan-hio.mjs --budget-secs 2
+
+# Different parallelism / resolution.
+node --experimental-strip-types scripts/scan-hio.mjs \
+  --workers 4 --angle-step 2 --power-step 5
+```
+
+`hio-scan.json` is gitignored — regenerable any time, takes 2-3 hours
+unbudgeted.
+
+---
+
+## 13. Physics quirks the port carries
+
+The physics engine in `port/web/src/game/physics.ts` is a faithful
+port of the original Aapeli minigolf Java client. Two quirks worth
+documenting:
+
+### Inside-corner suppression (FIXED post-port)
+
+The original `handleWallCollision` had an "inside-corner suppression"
+rule: if `top + tl + left` were all walls (an L-shape), clear `top`
+and `left` to false. The intent was "ball wedged in a corner shouldn't
+double-bounce off both walls in one frame."
+
+In practice, the rule fired purely on geometry — even when the ball
+was just *approaching* the wall from below at vx=0, vy<0. The rule
+cleared `top`, the subsequent reflection was skipped, and the ball
+phased straight through the wall. The HIO scanner found dozens of
+these "HIOs" — straight-line shots that ran through 4+ walls in
+sequence. AdventureIV's `(0, 33)` was the canonical example.
+
+The fix in `port/web/src/game/physics.ts:519-547` adds a velocity
+check: each suppression now requires the ball's velocity to actually
+point *into* the corner. The TL-corner suppression fires only when
+`vx<0 AND vy<0`, etc. Genuine wedge cases (diagonal motion into a
+concave corner) still suppress and the diagonal-reflection block
+handles them. Glancing approaches now reflect normally off the single
+wall they hit.
+
+This intentionally diverges from the Java original. Three-pointer's
+legitimate one-way-wall HIO still works; AdventureIV's bogus straight-
+through-walls "HIO" no longer holes.
+
+### One-way walls vs the wall-clip detector
+
+Tile values 20-23 are "one-way walls" — passable in their nominal
+direction. The wall-clip detector originally treated them as walls and
+flagged shots that *legitimately* passed through them as bogus. Fixed
+by narrowing the detector's wall-set to genuinely-solid values
+(16-18, 27, 40-43, 46).
+
+---
+
+## 14. Files
 
 ```
 port/ai/
-├── index.html        single-map view
-├── grid.html         grid view
-├── HOW_IT_WORKS.md   you are here
-├── public/           (none — assets come from ../web/public)
-└── src/
-    ├── main.ts       entry point for /
-    ├── grid.ts       entry point for /grid.html
-    ├── nn.ts         tiny MLP class (forward pass + Xavier init)
-    ├── agent.ts      MLPAgent (actor-critic, REINFORCE backprop)
-    ├── env.ts        Episode class (wraps physics into a rollout)
-    ├── render.ts     canvas drawing (via the production TrackRenderer)
-    ├── chart.ts      reward sparkline
-    ├── loader.ts     loads .track files into ParsedMap + atlases
-    ├── tracks.ts     enumerates all .track files via Vite glob
-    ├── storage.ts    localStorage helpers (save/load policies)
-    └── track-data.ts (legacy, unused)
+├── HOW_IT_WORKS.md            # this file (canonical reference)
+├── AUTORESEARCH.md            # quick reference for the autoresearch loop
+├── AUTORESEARCH_PLAN.md       # original design doc (status: implemented)
+├── program.md                 # ⚙ HUMAN edits this. Loop steering wheel.
+│
+├── index.html                 # single-map view
+├── grid.html                  # grid view
+├── autoresearch.html          # live autoresearch dashboard
+├── autoresearch-report.html   # post-run autoresearch report
+├── hio.html                   # HIO tracks list
+│
+├── research_program.ts        # ⚙ AGENT edits this. The 27-knob config.
+├── research_eval.ts           # entry: load program → train → eval → emit one number
+├── research_loop.ts           # autonomous-loop driver
+├── research_analyze.ts        # log → ASCII plots
+│
+├── vite-plugin-autoresearch.ts # /api/loop/{start,stop,status,events}
+├── vite.config.ts             # 5 entry points + plugin
+├── package.json               # npm scripts: dev, ai:sanity, ai:eval, ai:loop, ai:analyze, ai:calibrate
+│
+├── headless/                  # FROZEN evaluator components
+│   ├── atlases.ts             #   omggif-based GIF decoder for collision masks
+│   ├── track-loader.ts        #   fs-based track loader (Node, mirrors src/loader.ts)
+│   ├── harness.ts             #   train+eval one config on N maps → one number
+│   ├── maps.ts                #   16 eval maps + 40 validation maps
+│   └── autoresearch-bounds.ts #   tighter bounds that close gaming vectors
+│
+├── scripts/
+│   ├── sanity-check.mjs       # one-time "do imports work in Node?" check
+│   ├── calibration-smoke.mjs  # gridSize=5 vs gridSize=11 sanity check
+│   ├── test-harness.mjs       # smoke: harness on CurveI
+│   ├── test-headless-load.mjs # smoke: load + 1 episode in Node
+│   ├── test-prompt.mjs        # smoke: claude --print prompt format
+│   ├── test-real-iter.mjs     # smoke: one full claude --print iteration
+│   ├── classify-tracks.mjs    # categorise all 2062 tracks by features (used to curate maps)
+│   ├── curate-mapsets.mjs     # buckets classified tracks into eval/validation sets
+│   ├── scan-hio.mjs           # full HIO scan (parallel, with wall-clip detection)
+│   ├── scan-hio-worker.mjs    #   worker thread for the scan
+│   └── summary.mjs            # text alternative to the autoresearch dashboard
+│
+├── src/
+│   ├── main.ts                # entry for /index.html
+│   ├── grid.ts                # entry for /grid.html
+│   ├── autoresearch-dashboard.ts # entry for /autoresearch.html
+│   ├── autoresearch-report.ts # entry for /autoresearch-report.html
+│   ├── hio-page.ts            # entry for /hio.html
+│   ├── nn.ts                  # tiny MLP (forward pass + Xavier init)
+│   ├── agent.ts               # MLPAgent (actor-critic, REINFORCE backprop, state encoder)
+│   ├── env.ts                 # Episode (wraps physics into a rollout, reward formulas)
+│   ├── path.ts                # BFS pathfinder (multi-hole, ball-radius erosion, teleporters)
+│   ├── hio.ts                 # brute-force hole-in-one search
+│   ├── config.ts              # TrainingConfig type, DEFAULTS, BOUNDS, clampConfig, loadConfig/saveConfig
+│   ├── render.ts              # canvas drawing (uses production TrackRenderer)
+│   ├── chart.ts               # reward sparkline
+│   ├── loader.ts              # browser-side track loader (Vite glob)
+│   ├── tracks.ts              # enumerates all .track files via Vite glob
+│   ├── storage.ts             # localStorage helpers (save/load policies)
+│   └── track-data.ts          # (legacy, unused)
 ```
 
 The agent imports physics directly from the main web client at
-`../web/src/game/physics.ts` and `../web/src/game/map.ts`. It uses the
-exact same simulator the live game uses, so anything the agent learns
-to do, a real player could in principle do too.
+`../web/src/game/physics.ts` and `../web/src/game/map.ts`. Same
+simulator the live game uses, so anything the agent learns to do, a
+real player could in principle do too.
 
 ---
 
-## 14. Things that can go wrong (and what they look like)
+## 15. Common workflows
+
+### Train one map fast
+
+```
+1. Open http://localhost:5180/
+2. Pick a map from the dropdown
+3. Slide speed up to ~500
+4. Wait a few minutes for the badge to turn green
+```
+
+### Solve every curated map overnight
+
+```
+1. Open /grid.html
+2. Add maps via the dropdown (or use the curated set)
+3. Slide speed up to 1000+
+4. Walk away
+5. Come back, look at the solved/total counter
+```
+
+### Run autoresearch on a specific map
+
+```
+1. Open /autoresearch.html
+2. Loop control: set
+   - train secs/seed: 300  (5 minutes per training run)
+   - maps:           Watertankrun.track
+   - log file:       research_log_watertankrun.jsonl
+   - max iterations: 1000
+3. Click ▶ Start
+4. Watch the events feed and chart fill in
+5. Click ■ Stop when you've seen enough
+```
+
+### Find tracks where humans missed a 1-stroke solution
+
+```
+1. Run the HIO scan: node --experimental-strip-types scripts/scan-hio.mjs
+2. Open /hio.html
+3. Set "show" dropdown to "HIO-able but humans never got 1 (bestPar > 1)"
+4. Click any row's "open →" to inspect the map in the single-track viewer
+```
+
+### Reset everything
+
+- Browser: "delete saved policies" in the grid view's header wipes
+  all localStorage entries.
+- Autoresearch: `rm research_log*.jsonl` clears the loop history.
+- HIO scan: `rm hio-scan.json` and re-run.
+
+---
+
+## 16. Glossary
+
+- **Agent** — the thing playing the game. Here, a small MLP.
+- **Episode** — one full attempt: from start to either holing or
+  running out of strokes (`maxStrokes`, default 30).
+- **Policy** — the agent's strategy. Maps state → action distribution.
+- **Reward** — the scalar signal the agent uses to learn.
+- **Rollout** — running the policy through one or more episodes to
+  collect training data.
+- **Trace** — recorded (state, action, value) per step, used by the
+  learning pass.
+- **Backprop** — the math that computes per-weight gradients.
+- **Xavier init** — initial random weights that keep activations
+  unit-scale through layers at init (avoids vanishing/exploding
+  gradients).
+- **σ (sigma)** — standard deviation of the action distribution.
+- **γ (gamma)** — discount factor. 0.99 means the agent slightly
+  prefers near-future rewards.
+- **REINFORCE** — the classic policy-gradient algorithm; the
+  grandparent of PPO and A2C.
+- **HIO** — hole-in-one (1-stroke completion).
+- **Wall-clip HIO** — a "HIO" trajectory that phased through walls
+  because of the inside-corner-suppression quirk in physics. Fixed.
+- **Autoresearch** — Karpathy-style autonomous local search through
+  hyperparameter space, driven by an LLM.
+- **PERFECTED** — status badge meaning the agent has found a
+  hole-in-one in eval mode and training is auto-stopped.
+
+---
+
+## 17. Things that can go wrong
 
 ### "It's stuck at TRAINING forever"
-The map is too hard for the simple feature set. Try a different map, or
-let it train for thousands more episodes. Some Aapeli maps require
-trick shots that the 5×5 tile grid can't see far enough to plan.
 
-### "PERFECTED but success shows 0%"
-Old save format from before the perfection criteria were tightened. The
-saved policy was crowned PERFECTED based on a noise-lucky shot that
-doesn't reproduce deterministically. Click "delete saved policies" and
-let it retrain.
+Map is too hard for the current feature set / training budget. Try:
 
-### "The chart is mostly negative"
-Normal during early training. Untrained networks score around −30 (the
-"max strokes, no hole" baseline). Wait — it'll climb.
+- A different map.
+- Higher speed slider for more training episodes.
+- Turn on `progressBonus` (small, e.g. 0.002) for dense gradient
+  signal.
+- Run `/autoresearch.html` on that single map and let the loop search
+  the knob space.
 
 ### "Browser feels sluggish"
+
 You're at slider 5000+ which pegs one CPU core. JavaScript is
 single-threaded so there's no way to use more without Web Workers
-(not implemented). Drop the slider down or close the tab.
+(not implemented). Drop the slider or close the tab.
 
-### "I want to track 200 maps"
-The grid view grows linearly in memory. 200 cells = 2 GB. If you really
-need this scale, the right approach is a Web Worker per cell — same
-agent code, just running in parallel threads. Not built; would be a few
-hundred lines of work.
+### "PERFECTED but success shows 0%"
+
+Old save format from before perfection criteria were tightened. Click
+"delete saved policies" in the grid header and let it retrain.
+
+### "Autoresearch loop never makes progress"
+
+If 5+ iterations all score 0, the metric isn't sensitive enough at
+this budget to differentiate variants. Either:
+
+- Increase `--train-secs` (default 60s preset, try 300s).
+- Switch to a less hard map for calibration (harder maps need more
+  training to surface signal).
+- Add knobs that aren't in the current `TRAINING_CONFIG` — see "How
+  to extend the mutable surface" in [`AUTORESEARCH.md`](./AUTORESEARCH.md).
+
+### "HIO scanner takes forever"
+
+A non-HIO-able map exhausts the full 35 000-shot grid (~5-15 min CPU).
+Use `--budget-secs 2` for a fast first-pass scan, then re-run
+unbudgeted on just the maps that interesting.
+
+### "Loop dashboard says 'running' but nothing changes"
+
+Iteration is in the `calling_agent` phase — Claude Code is generating
+the next proposal (~25-30s per call). The eval phase is when you'll
+see live progress on the chart.
+
+### Stop button doesn't kill claude --print
+
+It should. The Vite plugin's stop endpoint writes a `.loop_stop` flag
+*and* runs `taskkill /T /F` (Windows) or `kill -TERM -<pgid>` (POSIX).
+That tears down the loop, the running `claude --print`, and any
+in-flight `research_eval.ts`. If a stale process survives, find it
+with `tasklist | findstr node` (Windows) or `ps -ef | grep node`
+(POSIX) and kill it manually.
 
 ---
 
-## 15. Glossary
-
-- **Agent** — the thing playing the game. Here, a small neural network.
-- **Episode** — one full attempt: from start to either holing the ball
-  or running out of strokes (max 30).
-- **Policy** — the agent's strategy. In our case, the network that maps
-  state → action distribution.
-- **Reward** — the signal the agent uses to learn. Positive when good
-  things happen, negative when bad things happen.
-- **Rollout** — running the policy through one or more episodes to
-  collect data.
-- **Trace** — the recorded sequence of (state, action, value) for one
-  episode. Used by the learning step.
-- **Backprop** — the math that figures out how to nudge each weight to
-  make good actions more likely. Short for "backpropagation".
-- **Xavier init** — a recipe for initial random weights that keeps the
-  signal flowing through layers without exploding or vanishing.
-- **σ (sigma)** — the standard deviation of the action distribution.
-  Big σ = lots of exploration, small σ = the policy is committed.
-- **γ (gamma)** — the "discount factor". 0.99 means the agent slightly
-  prefers near-future rewards to far-future ones. We use 0.99.
-- **REINFORCE** — the classic policy-gradient algorithm. The grandparent
-  of PPO, A2C, and friends.
-
----
-
-That's the whole thing. The codebase is around 2,000 lines of TypeScript
-+ 300 lines of HTML and CSS. Read `agent.ts` if you want to see the
-actual learning math — it's heavily commented and avoids any deep-learning
-library, so every gradient is visible.
+That's the whole system. The codebase is around 4 000 lines of
+TypeScript + 600 lines of HTML and CSS. Read `src/agent.ts` if you
+want to see the actual learning math — every gradient is visible, no
+deep-learning library used.


### PR DESCRIPTION
The four .md files in port/ai/ had grown apart - HOW_IT_WORKS.md described the original RL trainer with no awareness of pathfinder / HIO / autoresearch / dashboards / wall-clip fix; AUTORESEARCH.md was the de-facto place for everything that came after the trainer. Consolidating:

HOW_IT_WORKS.md is now the canonical reference. Rewritten end-to-end to cover the entire system as it stands today:

  - Five entry points (single-track, grid, autoresearch live, autoresearch report, HIO list) with what each is for
  - The agent (MLP shape, actor-critic heads, 424-feature state encoder at default config, 27-knob TrainingConfig)
  - Helper systems: pathfinder (multi-hole BFS, ball-radius erosion, teleporter handling), safety filter, HIO brute-force pre-search
  - Reward shaping with progressBonus / explorationBonus
  - Persistence (browser localStorage; Node side never touches it)
  - The autoresearch loop end-to-end: shape, frozen vs mutable, 27 knobs, scoring metric, three ways to drive it (browser / npm script / manual eval), CLI flags, stop conditions, live status files
  - All five browser dashboards: what they show, URL params, stat cards, live polling behaviour
  - HIO scanner: 8-worker parallel scan, per-map time budget, wall-clip detection
  - Physics quirks the port carries: the inside-corner suppression fix, one-way wall handling in the wall-clip detector
  - Updated files inventory
  - Common workflows, glossary, troubleshooting

AUTORESEARCH.md is now a focused user manual for the loop only - quick start, CLI flag table, what-edits-what table, single-iteration walkthrough, stop conditions, calibration findings. Everything that duplicated the system overview moved into HOW_IT_WORKS.md.

AUTORESEARCH_PLAN.md gets a status banner at the top mapping each plan section to its as-built implementation. The plan body stays as historical design rationale (read when designing extensions to the loop, not for day-to-day operation).

program.md unchanged - it's a runtime prompt artifact, not really documentation. HOW_IT_WORKS.md points to it as the loop steering wheel.