### PR TITLE
Port: fix daily-mode day rollover dropping shots for sparse-id players

### DIFF
--- a/port/server/src/game.ts
+++ b/port/server/src/game.ts
@@ -1160,12 +1160,36 @@ export class DailyGame extends GolfGame {
         if (this.dateKey === currentDateKey) return;
         this.dateKey = currentDateKey;
         this.tracks = [this.dailyTrackManager.getDailyTrack(currentDateKey)];
-        for (let i = 0; i < this.players.length; i++) {
-            this.playerStrokesThisTrack[i] = 0;
-            this.playerStrokesTotal[i] = 0;
-        }
         this.strokeSeedCounter = 0;
-        this.playStatus = "f".repeat(this.players.length);
+        if (this.players.length === 0) {
+            // Empty room: full reset so any state from yesterday's occupants
+            // (sparse-id leftovers in playStatus / strokes / numberIndex) can't
+            // poison tomorrow's first joiner. Mirrors joinDaily's empty-room
+            // branch — doing it here too means the rotation is self-contained
+            // regardless of whether joinDaily fires immediately after.
+            this.numberIndex = 0;
+            this.playStatus = "";
+            for (let i = 0; i < this.playerStrokesThisTrack.length; i++) {
+                this.playerStrokesThisTrack[i] = 0;
+                this.playerStrokesTotal[i] = 0;
+            }
+        } else {
+            // Non-empty room: ids are sparse (a finisher who left still owned a
+            // slot in playStatus). Size playStatus and the reset loop by
+            // numberIndex (= one past the max id), NOT players.length — a
+            // remaining player whose id is past players.length-1 would have
+            // their slot truncated off the end and the beginstroke gate
+            // (`playStatus.charAt(playerId) === 'f'`) would silently reject
+            // every shot, AND the broadcast starttrack would carry a too-short
+            // playStatus that makes the sparse-id client compute
+            // `numPlayers < myPlayerId+1` so their own ball slot falls off
+            // their players array and the click handler bails.
+            for (let i = 0; i < this.numberIndex; i++) {
+                this.playerStrokesThisTrack[i] = 0;
+                this.playerStrokesTotal[i] = 0;
+            }
+            this.playStatus = "f".repeat(this.numberIndex);
+        }
         // Re-broadcast a fresh starttrack so everyone resets to spawn.
         this.broadcastStartTrack();
     }
@@ -1224,7 +1248,12 @@ export class DailyGame extends GolfGame {
     /** Re-broadcast starttrack to everyone (used after a day rotation). */
     private broadcastStartTrack(): void {
         const stats = this.dailyTrackManager.getStats(this.tracks[0]);
-        const buff = "f".repeat(this.players.length);
+        // Sparse ids: size buff by numberIndex (= max id + 1), not
+        // players.length. A sparse player whose id is past players.length-1
+        // would get a too-short playStatus, set `numPlayers < myPlayerId+1`
+        // on their client, and their own slot would fall off the players
+        // array — their click handler then bails and the ball never moves.
+        const buff = "f".repeat(Math.max(this.numberIndex, this.players.length));
         this.writeAll(tabularize("game", "resetvoteskip"));
         this.markTrackStart();
         this.writeAll(this.formatStartTrack(buff, stats));

--- a/port/server/src/test-daily.ts
+++ b/port/server/src/test-daily.ts
@@ -313,8 +313,88 @@ async function main(): Promise<void> {
         }
         console.log("[OK] daily singleton stays counted after mid-game dropouts and re-entry");
 
-        c.close();
+        // Regression: day rollover with a sparse-id remaining player.
+        // Pre-fix: rotateIfNewDay sized the rebuilt playStatus by
+        // players.length, but a leftover sparse id (>= players.length) was
+        // truncated off the end. The remaining player's beginstroke gate
+        // (`playStatus.charAt(playerId) === 'f'`) silently rejected every
+        // shot, and the broadcast starttrack carried a too-short playStatus
+        // so the sparse client's `numPlayers < myPlayerId+1` made their own
+        // slot fall off the players array (their click handler bailed before
+        // even sending beginstroke). Either way, "the map changes after day
+        // rollover but the ball doesn't move at all" — the user-reported
+        // symptom. F just rejoined above (id=0) — close F and bring in G/H
+        // to set up a sparse remainder, then fake the rollover and verify a
+        // shot from the sparse occupant lands.
         f.close();
+        await new Promise((r) => setTimeout(r, 250));
+
+        const g = new Client("G");
+        const h = new Client("H");
+        await Promise.all([g.open(), h.open()]);
+        await login(g);
+        await login(h);
+        await enterDaily(g);
+        await enterDaily(h);
+        const gOwn = await g.waitFor((s) => /^d \d+ game\towninfo\t/.test(s), "G owninfo");
+        const hOwn = await h.waitFor((s) => /^d \d+ game\towninfo\t/.test(s), "H owninfo");
+        const gid = parseInt(gOwn.split("\t")[2] ?? "-1", 10);
+        const hid = parseInt(hOwn.split("\t")[2] ?? "-1", 10);
+        if (gid !== 0 || hid !== 1) {
+            throw new Error(`G/H entered with ids=${gid}/${hid}; want 0/1`);
+        }
+        // G leaves first: H stays alone with sparse id=1.
+        g.sendData("game", "back");
+        await g.waitFor((s) => /^d \d+ status\tlobbyselect\t/.test(s), "G back");
+
+        // Fake the UTC date rollover by rewinding dailyGame.dateKey. The next
+        // getDailyGame() call (any daily-select) will trip rotateIfNewDay.
+        const dgRef = (server.golfServer as unknown as { dailyGame: { dateKey: string } }).dailyGame;
+        const stashedDate = dgRef.dateKey;
+        dgRef.dateKey = "1999-01-01";
+
+        // I joins → rotation fires with H (id=1) still in the room.
+        const iCli = new Client("I");
+        await iCli.open();
+        await login(iCli);
+        await enterDaily(iCli);
+
+        // H receives the rotation's broadcast starttrack. Post-fix the buff is
+        // length=numberIndex (>= H.id+1) so H's client sees their own slot.
+        const hStartTrack = await h.waitFor((s) => /^d \d+ game\tstarttrack\t/.test(s), "H rollover starttrack");
+        const hStartPlayStatus = hStartTrack.split("\t")[2] ?? "";
+        if (hStartPlayStatus.length <= hid) {
+            throw new Error(
+                `rotation starttrack to sparse-id H carried playStatus="${hStartPlayStatus}" ` +
+                `(length ${hStartPlayStatus.length}) — H's slot id=${hid} falls off the end. ` +
+                `Pre-fix bug: broadcastStartTrack sized buff by players.length not numberIndex.`,
+            );
+        }
+
+        // H tries to shoot. Pre-fix the server's beginstroke gate silently
+        // rejected (playStatus too short for H's id). Reuse the encoded
+        // ball/mouse coords from the earlier A-shoots-B-shoots phase.
+        h.sendData("game", "beginstroke", ball, mouseA);
+        const echo = await Promise.race([
+            h.waitFor((s) => new RegExp(`^d \\d+ game\\tbeginstroke\\t${hid}\\t`).test(s), "H shot echo", 1500)
+                .then((s) => ({ ok: true as const, s })),
+            new Promise<{ ok: false }>((resolve) => setTimeout(() => resolve({ ok: false }), 1500)),
+        ]);
+        if (!echo.ok) {
+            throw new Error(
+                `H (sparse id=${hid}) beginstroke silently dropped after day rollover. ` +
+                `Pre-fix bug: rotateIfNewDay set playStatus = "f".repeat(players.length=1) = "f"; ` +
+                `charAt(${hid}) of "f" = "" so the gate rejected.`,
+            );
+        }
+        console.log("[OK] day rollover with sparse-id occupant: shot lands post-rotation");
+
+        // Restore for any later assertions / clean exit.
+        dgRef.dateKey = stashedDate;
+        g.close();
+        h.close();
+        iCli.close();
+
         a.close();
         b.close();
         console.log("\nALL DAILY-CHALLENGE PHASES PASSED");


### PR DESCRIPTION
DailyGame.rotateIfNewDay sized the rebuilt playStatus by players.length instead of numberIndex. Daily ids are sparse — a previous occupant who left still owns a slot — so a remaining player whose id was past players.length-1 had their slot truncated off the new playStatus. The broadcastStartTrack helper had the same bug.

Two ways this surfaced as "map changes after the day flips but the ball doesn't move":

  - Server: beginstroke gate is playStatus.charAt(playerId) !== "f". For a sparse id past the string's length, charAt returns "" and the shot is silently rejected, never echoed back to the client.

  - Client: the broadcast starttrack carried a too-short playStatus, so numPlayers < myPlayerId+1 made the sparse client's own slot fall off the players array and its click handler bailed before sending.

Empty-room rotation now also resets numberIndex/strokes/playStatus from scratch so stale per-player state ("t" from a previous finisher, non-zero strokes) can't leak forward when no joinDaily fires immediately after the rotation. Added a regression case to test-daily.ts that sets up a sparse-id remainder, fakes the UTC rollover, and asserts the remaining player's beginstroke lands.